### PR TITLE
chore: roadmap content reviewed by the roadmap-reviewers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,11 @@
-# The roadmap is human-governed.
-*                 @FormalFrontier/humans
+# Roadmap content is reviewed by the roadmap-reviewers team: an approving review from a member
+# (plus the `build` check) makes a PR mergeable, and merges it automatically once auto-merge is
+# enabled. Infrastructure stays with the humans team. Last-match-wins.
+
+*                     @FormalFrontier/roadmap-reviewers
+
+# Infrastructure stays human-governed (the more trusted core team):
+/.github/             @FormalFrontier/humans
+/lakefile.toml        @FormalFrontier/humans
+/lake-manifest.json   @FormalFrontier/humans
+/lean-toolchain       @FormalFrontier/humans


### PR DESCRIPTION
This PR points code-ownership of the roadmap content at the new `@FormalFrontier/roadmap-reviewers` team, so an approving review from a team member (plus the `build` check that branch protection already requires) makes a roadmap PR mergeable — and, once auto-merge is enabled, merges it automatically. Infrastructure paths (`.github/`, the lake config) stay with `@FormalFrontier/humans`, the more trusted core, via last-match-wins.

🤖 Prepared with Claude Code