### PR TITLE
ci: auto-enable native auto-merge on roadmap PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,34 @@
+name: auto-merge
+
+# Queue every non-draft PR for GitHub-native auto-merge, using a tauceti-review-bot App token
+# (the org disables write GITHUB_TOKEN). Branch protection requires a roadmap-reviewers code-owner
+# approval plus the `build` check, so GitHub merges the PR automatically once a team member
+# approves and CI passes. Native auto-merge watches PR state directly, so this is unaffected by
+# the pull_request_review event-delivery issue.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  enable:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint App token (pull-requests + contents write)
+        id: token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: FormalFrontier
+          repositories: TauCetiRoadmap
+          permission-pull-requests: write
+          permission-contents: write
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: gh pr merge "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --auto --squash


### PR DESCRIPTION
This PR adds a workflow that turns on GitHub-native auto-merge for every non-draft PR, using a `tauceti-review-bot` App token (the org disables write `GITHUB_TOKEN`). Combined with the existing branch protection — a `roadmap-reviewers` code-owner approval plus the `build` check — a roadmap PR then merges automatically once a team member approves and CI is green. Because it relies on native auto-merge rather than a `pull_request_review`-triggered workflow, it is unaffected by the event-delivery issue we hit on the code repo.

🤖 Prepared with Claude Code