### PR TITLE
doc: reword 'paved' metaphor in roadmap prose

### DIFF
--- a/TauCetiRoadmap/ReductiveGroups/README.md
+++ b/TauCetiRoadmap/ReductiveGroups/README.md
@@ -1,4 +1,4 @@
-# Roadmap: reductive algebraic groups (paved)
+# Roadmap: reductive algebraic groups
 
 The theory of reductive algebraic groups is the long game: it underpins the Langlands
 programme, automorphic forms, and much of FLT, and it is almost entirely absent from
@@ -30,7 +30,7 @@ Keep **two distinct notions**, and never make smoothness implicit:
 There will be **no** monolithic `LinearAlgebraicGroup`/`Variety` definition. Like
 Mathlib, we state exactly the hypotheses each result needs.
 
-## What "paved" means here
+## Three synchronized models
 
 Maintain **three equivalent views** of an affine algebraic group and the explicit
 equivalences between them, so any proof can work in whichever is most convenient:
@@ -199,7 +199,7 @@ faithfully-flat descent.
   `R(G)` (maximal connected normal solvable, geometric) trivial. Develop the radical,
   the centre `Z(G)`, the derived group `G_der`, **central isogenies**, and the simply
   connected and adjoint forms: these are not optional for the classification.
-- **Alternative paving, linearly reductive:** every f.d. representation is completely
+- **Alternative characterization, linearly reductive:** every f.d. representation is completely
   reducible. ⚠ Reductive groups are **not** linearly reductive in characteristic `p`
   (rational representations are generally not semisimple). State the equivalence precisely:
   for smooth connected affine groups in **characteristic 0**, reductive ⇔ linearly
@@ -246,15 +246,16 @@ the multiplicative-type examples. (Kevin's caution: don't *develop the general t
   to `k̄`.
 - **Don't bundle** typeclasses; **admit** non-smooth/non-reduced groups (`μ_p`) and make
   smoothness an explicit hypothesis where used.
-- **Pave**: keep the Hopf / group-object / functor-of-points views and the
-  representation ⇆ comodule dictionary synchronized via explicit equivalences.
+- **Keep views in sync**: maintain the Hopf / group-object / functor-of-points views and
+  the representation ⇆ comodule dictionary together via explicit equivalences.
 
 ## Downstream consumers (why this matters)
 
 `p`-adic representation theory of `G(K)` (smooth/admissible representations, Hecke
 algebras, Shurui Liu et al.), the Langlands programme, automorphic forms (Kevin
 Buzzard), and FLT. Several of these can start against a **BN-pair** or the dynamic
-parabolic API before the full root-data classification exists: another reason to pave.
+parabolic API before the full root-data classification exists: another reason to keep the
+three views in sync.
 
 ## References
 

--- a/TauCetiRoadmap/ReductiveGroups/Targets.lean
+++ b/TauCetiRoadmap/ReductiveGroups/Targets.lean
@@ -3,7 +3,7 @@ import Mathlib
 /-!
 # Reductive algebraic groups: target signatures
 
-The narrative roadmap (the three "paved" models, the layer-by-layer build plan
+The narrative roadmap (the three synchronized models, the layer-by-layer build plan
 Layers 0–7, the worked examples, and the references) is in `README.md`. We build the
 whole tower here rather than waiting on Mathlib.
 

--- a/TauCetiRoadmap/UniversalCovers/README.md
+++ b/TauCetiRoadmap/UniversalCovers/README.md
@@ -122,7 +122,7 @@ original authors and source PR in each file.
    - *Alternative lens:* phrase the classification of connected covers via transitive
      `π₁(X)`-sets / the monodromy functor (`monodromyFunctor`,
      `Galois/IsFundamentalgroup`), with disconnected covers as functors out of the
-     fundamental groupoid. Worth paving as a second route.
+     fundamental groupoid. Worth building as a second route.
 
 ## Stage 3: higher homotopy
 


### PR DESCRIPTION
This PR replaces the 'paved'/'paving' metaphor in the roadmap prose with plain language that names the actual artifact. In the ReductiveGroups roadmap that is the three synchronized models of an affine algebraic group — commutative Hopf algebras, group objects in schemes, and the functor of points — kept in sync via explicit equivalences; in the UniversalCovers roadmap it is 'building' a second route to the classification of connected covers. No target signature changes, and `Targets.lean` still elaborates.

🤖 Prepared with Claude Code