### PR TITLE
fix: correct stale and fabricated Mathlib paths in roadmap inventories

### DIFF
--- a/TauCetiRoadmap/HeegaardFloer/README.md
+++ b/TauCetiRoadmap/HeegaardFloer/README.md
@@ -167,7 +167,7 @@ Robbin–Salamon spectral flow; Atiyah–Singer never appears.
   **manifolds over arbitrary Banach model spaces by design** (`ModelWithCorners`,
   tangent bundles, smooth vector bundles, manifolds with boundary/corners), with
   integral curves and flows on Banach manifolds; compact operators and the
-  **Fredholm alternative** (`Compact/FredholmAlternative.lean`); Arzelà–Ascoli;
+  **Fredholm alternative** (`Operator/FredholmAlternative.lean`); Arzelà–Ascoli;
   Banach–Alaoglu; Lax–Milgram; strong one-variable complex analysis (Cauchy
   integral, removable singularity, identity theorem, Schwarz lemma); Hofer's lemma
   (`Mathlib/Analysis/Hofer.lean`, whose docstring already names bubbling-off

--- a/TauCetiRoadmap/Multiquadratic/README.md
+++ b/TauCetiRoadmap/Multiquadratic/README.md
@@ -49,7 +49,7 @@ rational and prime-indexed versions (the genus-theory inputs) as corollaries.
 
 ## What Mathlib already has (consume)
 
-- **Adjoining roots / Kummer theory:** `Mathlib/FieldTheory/Adjoin.lean`
+- **Adjoining roots / Kummer theory:** `Mathlib/FieldTheory/IntermediateField/Adjoin/*`
   (`IntermediateField.adjoin`, `adjoin_simple`, `finrank` of `adjoin` of one element),
   `Mathlib/FieldTheory/KummerExtension.lean` (degree of `K(ⁿ√a)`), and the quadratic
   special cases under `Mathlib/Algebra/QuadraticDiscriminant.lean`.

--- a/TauCetiRoadmap/PDE/README.md
+++ b/TauCetiRoadmap/PDE/README.md
@@ -148,7 +148,7 @@ statement time is what keeps the formalized API reusable.
 - **Spectral theory** in `Mathlib/Analysis/InnerProductSpace/Spectrum.lean`: the spectral
   theorem for symmetric operators (finite-dim diagonalization; for **compact** operators,
   `finite_dimensional_eigenspace` and `eq_zero_of_forall_hasEigenvalue_eq_zero`), and
-  `Mathlib/Analysis/Normed/Operator/Compact/FredholmAlternative.lean` (the **Fredholm
+  `Mathlib/Analysis/Normed/Operator/FredholmAlternative.lean` (the **Fredholm
   alternative**). The eigenvalue/eigenfunction-expansion lane builds directly on these.
 - **Functional-analysis backbone:** Hahn–Banach
   (`Mathlib/Analysis/Normed/Module/HahnBanach.lean`), Banach–Steinhaus

--- a/TauCetiRoadmap/UniversalCovers/README.md
+++ b/TauCetiRoadmap/UniversalCovers/README.md
@@ -39,7 +39,7 @@ target isomorphisms below are only correct up to `ᵐᵒᵖ` depending on it.
   covering `FundamentalGroupoid`, `FundamentalGroup`, homotopy-invariance/functoriality
   (`InducedMaps.lean`: `homotopicMapsNatIso`, `equivOfHomotopyEquiv`), `SimplyConnected`.
 - **Homotopy groups:** `Mathlib/Topology/Homotopy/HomotopyGroup.lean` (`Ω^N`,
-  `HomotopyGroup`) and `Mathlib/Topology/Covering/HomotopyGroup.lean`.
+  `HomotopyGroup`).
 - **Galois-category abstraction:** `Mathlib/CategoryTheory/Galois/IsFundamentalgroup.lean`
   (`IsFundamentalGroup`, `toAutMulEquiv : G ≃* Aut F`), an alternative lens on the
   classification, via fibre functors.


### PR DESCRIPTION
This PR corrects three "consume from Mathlib" citations that pointed at files which do not exist at the pinned toolchain. It drops `Mathlib/Topology/Covering/HomotopyGroup.lean` from the universal-covers inventory (the `Topology/Covering/` directory holds only `AddCircle`, `Basic`, and `Quotient`, and the real homotopy-group file `Topology/Homotopy/HomotopyGroup.lean` is already cited beside it); it points the PDE and Heegaard-Floer Fredholm-alternative references at `Mathlib/Analysis/Normed/Operator/FredholmAlternative.lean` rather than a nonexistent `Compact/` subdirectory; and it updates the multiquadratic inventory to the directory `Mathlib/FieldTheory/IntermediateField/Adjoin/`, into which the old `Mathlib/FieldTheory/Adjoin.lean` was refactored. A full sweep confirms every remaining Mathlib file-path and directory-glob citation across the roadmaps resolves against the pin.

🤖 Prepared with Claude Code