### PR TITLE
fix: restore the Compact/ Fredholm path and the Projection directory in the PDE and Heegaard Floer roadmaps

### DIFF
--- a/TauCetiRoadmap/HeegaardFloer/README.md
+++ b/TauCetiRoadmap/HeegaardFloer/README.md
@@ -167,7 +167,7 @@ Robbin–Salamon spectral flow; Atiyah–Singer never appears.
   **manifolds over arbitrary Banach model spaces by design** (`ModelWithCorners`,
   tangent bundles, smooth vector bundles, manifolds with boundary/corners), with
   integral curves and flows on Banach manifolds; compact operators and the
-  **Fredholm alternative** (`Operator/FredholmAlternative.lean`); Arzelà–Ascoli;
+  **Fredholm alternative** (`Operator/Compact/FredholmAlternative.lean`); Arzelà–Ascoli;
   Banach–Alaoglu; Lax–Milgram; strong one-variable complex analysis (Cauchy
   integral, removable singularity, identity theorem, Schwarz lemma); Hofer's lemma
   (`Mathlib/Analysis/Hofer.lean`, whose docstring already names bubbling-off

--- a/TauCetiRoadmap/PDE/README.md
+++ b/TauCetiRoadmap/PDE/README.md
@@ -144,11 +144,11 @@ statement time is what keeps the formalized API reusable.
   `Mathlib/Analysis/InnerProductSpace/LaxMilgram.lean` (`IsCoercive`,
   `continuousLinearEquivOfBilin`, i.e. **Lax–Milgram itself**),
   `…/InnerProductSpace/Dual.lean` (**Fréchet–Riesz** `toDual`),
-  `…/InnerProductSpace/Adjoint.lean`, `…/InnerProductSpace/Projection.lean`.
+  `…/InnerProductSpace/Adjoint.lean`, `…/InnerProductSpace/Projection/`.
 - **Spectral theory** in `Mathlib/Analysis/InnerProductSpace/Spectrum.lean`: the spectral
   theorem for symmetric operators (finite-dim diagonalization; for **compact** operators,
   `finite_dimensional_eigenspace` and `eq_zero_of_forall_hasEigenvalue_eq_zero`), and
-  `Mathlib/Analysis/Normed/Operator/FredholmAlternative.lean` (the **Fredholm
+  `Mathlib/Analysis/Normed/Operator/Compact/FredholmAlternative.lean` (the **Fredholm
   alternative**). The eigenvalue/eigenfunction-expansion lane builds directly on these.
 - **Functional-analysis backbone:** Hahn–Banach
   (`Mathlib/Analysis/Normed/Module/HahnBanach.lean`), Banach–Steinhaus


### PR DESCRIPTION
This PR restores the `Compact/` segment in the `FredholmAlternative.lean` Mathlib citations and corrects the stale `InnerProductSpace/Projection.lean` reference in the PDE and Heegaard Floer roadmap inventories. PR #14 mistakenly changed a correct path into a stale one: at the pinned Mathlib commit (`9caeba1000ef8f302920981f4a08651d325abc81`), `FredholmAlternative.lean` lives under `Mathlib/Analysis/Normed/Operator/Compact/`, so this reverts that incorrect path change. Separately, `Projection.lean` was refactored into the directory `Mathlib/Analysis/InnerProductSpace/Projection/` (Basic, FiniteDimensional, Minimal, Reflection, Submodule) at the pin, so the single-file citation becomes the directory form to match how other roadmaps cite refactored directories. Both facts were confirmed against the pinned commit in a local Mathlib checkout. The arXiv:2604.05984 citation is left untouched.

🤖 Prepared with Claude Code