### PR TITLE
Add roadmap: one-parameter semigroups, completely monotone functions, and BCR Bochner

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ industry groups.
 7. [Multiquadratic fields and genus theory](TauCetiRoadmap/Multiquadratic/README.md)
 8. [Effective arithmetic bounds and geometry of numbers](TauCetiRoadmap/EffectiveBounds/README.md)
 9. [Geometric topology and the Kirby-list problems](TauCetiRoadmap/GeometricTopology/README.md)
+10. [One-parameter semigroups, completely monotone functions, and BCR Bochner](TauCetiRoadmap/OneParameterSemigroups/README.md)
 
 ## How changes are made
 

--- a/TauCetiRoadmap/OneParameterSemigroups/README.md
+++ b/TauCetiRoadmap/OneParameterSemigroups/README.md
@@ -1,106 +1,170 @@
 # Roadmap: one-parameter semigroups, completely monotone functions, and BCR Bochner
 
 Operator semigroups are the analytic backbone of evolution equations (heat, Fokker–Planck,
-Schrödinger) and of Markov-process theory. Mathlib has the static functional-analysis stack
-(Banach/Hilbert spaces, bounded operators, spectrum, the Bochner integral, Fourier theory)
-but **not** the dynamical layer: strongly continuous (C₀) semigroups, their generators and
-resolvents, the Hille–Yosida generation theorem, Bernstein's theorem on completely monotone
-functions, or the Berg–Christensen–Ressel (BCR) Bochner theorem for positive-definite
-functions on involutive semigroups.
+Schrödinger) and of Markov-process theory. Mathlib has the *static* functional-analysis
+stack — Banach/Hilbert spaces, bounded operators, spectrum, the holomorphic functional
+calculus, the Bochner integral, Fourier theory, unbounded operators via `LinearPMap` — but
+**not the dynamical layer**: strongly continuous (C₀) semigroups, their generators and
+resolvents, the **Hille–Yosida** generation theorem, **Bernstein's theorem** on completely
+monotone functions, or the **Berg–Christensen–Ressel (BCR)** Bochner theorem for
+positive-definite functions on involutive semigroups.
 
 The bar for "done": a researcher in evolution equations or Markov semigroups looks at this
 material and says *"the C₀-semigroup / generator / resolvent API is here, in reusable form,
 and the Hille–Yosida and Bochner-type representation theorems are available."*
 
-> **Provenance note.** A substantial AI-authored development of this material already exists
-> (`mrdouglasny/hille-yosida`, sorry-free, 0 project axioms), covering the Hille–Yosida
-> resolvent identities, Bernstein's theorem, and the BCR semigroup-Bochner theorem. It is a
-> natural source for "make existing material ready to Tau Ceti" PRs. Two adaptation tasks:
-> it targets Lean v4.29.0 (Tau Ceti is on v4.31.0 — a Mathlib bump is needed), and its BCR
-> *existence* half depends on a separate Bochner–Minlos package, so the **resolvent and
-> Bernstein items below are the cleanly Mathlib-only first targets**; the BCR existence item
-> needs a Mathlib-only route to the spatial Bochner theorem first.
+Suggested home: `TauCeti/Analysis/Semigroups/` (the C₀ API, resolvent, generation),
+`TauCeti/Analysis/CompletelyMonotone/` (Bernstein), `TauCeti/Analysis/BCR/` (the
+Bochner-type representations).
 
 ## The end goal (v1)
 
-The three pillars, each a standalone, reusable theorem about contraction C₀-semigroups on a
-Banach space and the representation of the functions that arise from them.
+The three pillars, each a standalone, reusable theorem (stated in `Targets.lean` with
+`sorry`/`def_wanted` as the supporting types land).
 
 ```lean
--- the shapes we are building toward (state in Targets.lean as the supporting types land):
 variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
 
--- A strongly continuous semigroup and its (unbounded) generator.
--- structure C0Semigroup (X) : ...                 -- S 0 = id, S (s+t) = S s ∘ S t, strong continuity
--- def C0Semigroup.generator (S : C0Semigroup X) : X →ₗ.[ℝ] X        -- A u = lim (S t u - u)/t
+-- 1. Hille–Yosida resolvent: for a contraction C₀-semigroup, R λ = ∫₀^∞ e^{-λt} S t dt
+--    inverts (λ − A) on the domain, with the contraction-scale bound.
+-- theorem resolvent_right_inverse (S : ContractionC0Semigroup X) {l : ℝ} (hl : 0 < l) :
+--     (l • 1 − S.generator) ∘L S.resolvent l = 1
+-- theorem resolvent_norm_le (S : ContractionC0Semigroup X) {l : ℝ} (hl : 0 < l) :
+--     ‖S.resolvent l‖ ≤ 1 / l
 
--- 1. Hille–Yosida resolvent: for a contraction semigroup, R λ = ∫₀^∞ e^{-λt} S t dt
---    inverts (λ - A) and is a contraction-scale bound.
--- theorem resolvent_right_inverse (S : ContractionC0Semigroup X) {λ : ℝ} (hλ : 0 < λ) :
---     (λ • 1 - S.generator) ∘L S.resolvent λ = 1
--- theorem resolvent_norm_le (S : ContractionC0Semigroup X) {λ : ℝ} (hλ : 0 < λ) :
---     ‖S.resolvent λ‖ ≤ 1 / λ
-
--- 2. Hille–Yosida generation theorem (converse / Lumer–Phillips): a densely-defined
---    dissipative operator whose range condition holds generates a contraction semigroup.
+-- 2. Hille–Yosida generation (converse / Lumer–Phillips): densely-defined dissipative +
+--    a range condition ⇒ generates a contraction C₀-semigroup.
 -- theorem generates_of_dissipative (A : DenseLinearOperator X)
---     (hdiss : A.IsDissipative) (hrange : ∀ λ > 0, Surjective (λ • 1 - A)) :
+--     (hd : A.IsDissipative) (hr : ∀ l > 0, Surjective (l • 1 − A)) :
 --     ∃ S : ContractionC0Semigroup X, S.generator = A
 
--- 3a. Bernstein's theorem: a completely monotone function on [0,∞) is the Laplace transform
---     of a unique finite positive measure.
+-- 3a. Bernstein: a completely monotone function on [0,∞) is the Laplace transform of a
+--     unique finite positive measure.
 -- theorem bernstein (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) :
 --     ∃! μ : Measure ℝ, IsFiniteMeasure μ ∧ μ.support ⊆ Ici 0 ∧
 --       ∀ t ≥ 0, f t = ∫ x, Real.exp (-t * x) ∂μ
 
 -- 3b. BCR Bochner (Berg–Christensen–Ressel 4.1.13): a bounded continuous positive-definite
 --     function on [0,∞) × ℝᵈ is the Laplace–Fourier transform of a unique finite measure.
--- theorem bcr_semigroup_bochner (d : ℕ) (F : (ℝ × EuclideanSpace ℝ (Fin d)) → ℂ)
+-- theorem bcr_semigroup_bochner (d : ℕ) (F : ℝ × EuclideanSpace ℝ (Fin d) → ℂ)
 --     (hpd : IsSemigroupGroupPD d F) :
---     ∃! μ : Measure (ℝ × EuclideanSpace ℝ (Fin d)), IsFiniteMeasure μ ∧ ... ∧
+--     ∃! μ : Measure (ℝ × EuclideanSpace ℝ (Fin d)), IsFiniteMeasure μ ∧ … ∧
 --       ∀ t ≥ 0, ∀ a, F (t, a) = ∫ (p, q), Real.exp (-t * p) * Complex.exp (I * ⟪a, q⟫) ∂μ
 ```
 
 ## Standing hypotheses (spell them out; never bundle)
 
 - **Contraction vs general C₀.** State the resolvent identities for **contraction**
-  semigroups (`‖S t‖ ≤ 1`); the general bounded case (`‖S t‖ ≤ M e^{ωt}`) is a separate,
-  later generalization via rescaling — carry `M, ω` explicitly, do not assume contraction
-  silently.
-- **Generator domain.** The generator is **unbounded**: track its dense domain as a genuine
-  `LinearPMap` / submodule, never as a total operator.
-- **Completely monotone** means `(-1)ⁿ f⁽ⁿ⁾ ≥ 0` for all `n` on `(0,∞)`; keep the endpoint
-  and finiteness hypotheses explicit (the measure is finite, supported on `[0,∞)`).
-- **Positive-definite** on a semigroup-with-involution: state the BCR hypothesis as a named
-  predicate (`IsSemigroupGroupPD`), not bundled into the conclusion.
+  semigroups (`‖S t‖ ≤ 1`); the general bounded case (`‖S t‖ ≤ M e^{ωt}`) is a later
+  generalization via rescaling — carry `M, ω` explicitly, never assume contraction silently.
+- **Unbounded generator.** The generator has a **dense domain**; track it as a genuine
+  `LinearPMap` / submodule, never a total operator. ⚠ Do not conflate the operator with its
+  closure's domain.
+- **Completely monotone** means `(−1)ⁿ f⁽ⁿ⁾ ≥ 0` for all `n` on `(0,∞)`; keep the endpoint
+  and finiteness hypotheses explicit (the representing measure is finite, supported on
+  `[0,∞)`).
+- **Positive-definite on a semigroup-with-involution.** State the BCR hypothesis as a named
+  predicate (`IsSemigroupGroupPD`), not bundled into the conclusion; fix the involution
+  (`(t,a) ↦ (t,−a)`) and the `[0,∞) × ℝᵈ` structure up front.
 
-## Inventory: what Mathlib master gives us (consume)
+## What Mathlib already has (consume)
 
-- Banach/Hilbert spaces, `ContinuousLinearMap`, operator norm, `spectrum`, the holomorphic
-  functional calculus; **unbounded operators** via `LinearPMap` (closure, adjoint, cores).
-- The **Bochner integral**, `MeasureTheory.integral`, dominated convergence, Fubini — the
-  resolvent `∫₀^∞ e^{-λt} S t dt` is a Bochner integral of an operator-valued map.
-- **Fourier theory**: `Real.fourierIntegral`, inversion, Plancherel; characteristic-function
-  uniqueness for finite measures — the spatial half of BCR.
-- **Laplace transforms** and `Real.exp`; Stieltjes/`Measure` API; Prokhorov tightness for the
-  measure-extraction in Bernstein.
+- **Operators & spectrum:** `ContinuousLinearMap`, operator norm, `spectrum`, the
+  holomorphic functional calculus; **unbounded operators** via `LinearPMap` (closure,
+  adjoint, cores) — the generator and its domain live here.
+- **The Bochner integral** (`Mathlib/MeasureTheory/Integral/Bochner/*`): the resolvent
+  `∫₀^∞ e^{−λt} S t dt` is a Bochner integral of an operator-valued map; dominated
+  convergence, Fubini, the `integral_comp_add_right`/`Ioi` lemmas.
+- **Fourier analysis** (`Mathlib/Analysis/Fourier/*`): `FourierTransform`, inversion,
+  Plancherel, and characteristic-function uniqueness of finite measures — the spatial half
+  of BCR uniqueness.
+- **Laplace transforms / `Real.exp`**, the `Measure`/`IsFiniteMeasure` API, and **Prokhorov
+  tightness** for the measure-extraction in Bernstein.
+- **Completely monotone scaffolding:** Taylor's theorem with integral remainder, monotone
+  convergence, `deriv`/iterated derivatives.
 
-## Roadmap items
+## What is missing (build here)
 
-1. **C₀-semigroup API** — `C0Semigroup`, generator, domain, strong continuity, basic laws.
-   *(Ready: `hille-yosida` `StronglyContinuousSemigroup.lean`.)*
-2. **Hille–Yosida resolvent** — `resolvent`, `resolvent_right_inverse`, `resolvent_norm_le`.
-   *(Ready: `hilleYosidaResolventBound`, `ContractingSemigroup.resolventRightInv`.)* **← suggested first PR.**
-3. **Generation theorem / Lumer–Phillips converse** — dissipative + range ⇒ generates.
-   *(Partial: `Future/GenerationTheorem.lean`; the `IsDissipative` scaffold exists.)*
-4. **Bernstein's theorem** — completely monotone ⇒ Laplace transform of a unique finite
-   measure. *(Ready: `bernstein_theorem`.)*
-5. **BCR Bochner (d = 0, then general)** — semigroup/Laplace positive-definite representation.
-   *(Existence depends on a Bochner-theorem prerequisite — needs a Mathlib-only route to the
-   spatial Bochner step before porting; uniqueness `laplaceFourier_unique` is Mathlib-only.)*
+C₀-semigroups, their generators/resolvents, the Hille–Yosida resolvent identities and the
+generation theorem, Bernstein's theorem, and the BCR semigroup-Bochner theorem. **None of
+this is upstream** (Mathlib has the static stack but no operator-semigroup theory).
 
-## Suggested home
+## Migration source (existing AI-authored material)
 
-`TauCeti/Analysis/Semigroups/` (C₀ API, resolvent, generation) with
-`TauCeti/Analysis/CompletelyMonotone/` (Bernstein) and `TauCeti/Analysis/BCR/` (the
-Bochner-type representations).
+Most of this exists, **sorry-free and with 0 project axioms**, in
+[`mrdouglasny/hille-yosida`](https://github.com/mrdouglasny/hille-yosida), pinned at commit
+`8fda1863eea60068e32f7ea6c0c27da5dd650957`. A v4.29→v4.31 toolchain bump is prepared on its
+`bump/v4.31` branch (the resolvent module compiles clean on Mathlib v4.31 with no code
+changes). Credit that source (and the BCR theorem to Berg–Christensen–Ressel) in each ported
+file.
+
+⚠ **Bochner-dependency split.** Two files of the source — `BCR_Common.lean`,
+`BCR_Existence.lean` — depend on a separate Bochner–Minlos package, so **Layers 0–3 below
+are cleanly Mathlib-only**, and the BCR *existence* half (Layer 4) needs a Mathlib-only route
+to the spatial Bochner theorem before it can be ported. Port in layer order.
+
+Per-file decls to migrate (in order within each file):
+- `StronglyContinuousSemigroup.lean` → `StronglyContinuousSemigroup`, `ContractingSemigroup`,
+  `.generator`, `.domain`, `.resolvent`, `resolventMapsToDomain`, `resolventRightInv`,
+  `hilleYosidaResolventBound`, `HasGrowthBound`, `existsGrowthBound`.
+- `BernsteinBasic.lean` → `IsCompletelyMonotone`, `taylor_integral_remainder`; then
+  `BernsteinMeasures.lean`, `BernsteinChafai.lean`, then `Bernstein.lean` → `bernstein_theorem`.
+- `FourierPD.lean` → `pd_quadratic_form_of_measure`; `BCR_d0.lean` → `semigroup_pd_laplace`;
+  `SemigroupGroupDefs.lean` → `IsSemigroupGroupPD`; `BCR_General.lean` →
+  `laplaceFourier_unique` (Mathlib-only) and `semigroupGroupBochner_proof` (needs Bochner);
+  `SemigroupGroupExtension.lean` → `semigroupGroupBochner`, `semigroupGroupBochnerExtension`.
+
+## The build, in layers
+
+The ordering is the dependency order, not a strict schedule.
+
+### Layer 0: C₀-semigroup API
+`StronglyContinuousSemigroup`, `ContractingSemigroup`, the generator and its dense domain,
+strong continuity, the semigroup laws. *(Migrate `StronglyContinuousSemigroup.lean`.)*
+
+### Layer 1: Hille–Yosida resolvent — **suggested first PR**
+`resolvent`, `resolventRightInv` ((λ−A)R(λ) = 1 on the domain), `hilleYosidaResolventBound`
+(`‖R(λ)‖ ≤ 1/λ`). Cleanly Mathlib-only; the migrated module already compiles on v4.31.
+
+### Layer 2: generation theorem / Lumer–Phillips converse
+Densely-defined dissipative + range condition ⇒ generates a contraction semigroup. ⚠ Mostly
+**build-here**: the source has the `IsDissipative` scaffold (`Future/GenerationTheorem.lean`)
+but not the full converse; this is the genuinely open item.
+
+### Layer 3: Bernstein's theorem
+Completely monotone ⇒ Laplace transform of a unique finite measure. *(Migrate the Bernstein
+chain.)* Mathlib-only; the measure extraction uses Prokhorov tightness.
+
+### Layer 4: BCR Bochner (d = 0, then general)
+Semigroup/Laplace positive-definite representation. **Uniqueness** (`laplaceFourier_unique`)
+is Mathlib-only and portable now; **existence** (`semigroupGroupBochner`) ⚠ depends on the
+spatial Bochner theorem — defer until there is a Mathlib-only route to it (or until a Bochner
+theorem for positive-definite functions on `ℝᵈ` is itself a TauCeti target).
+
+## Worked examples (acceptance criteria, keeping the statements honest)
+
+- **Concrete C₀-semigroup:** the multiplication semigroup `S t f = e^{−t·m} f` on a function
+  space (or `e^{tA}` for a bounded `A`) is a `ContractingSemigroup` with generator `−m` (resp.
+  `A`); its resolvent is the expected Neumann/integral form.
+- **Resolvent bound is non-vacuous:** for the bounded generator `A`, `‖R(λ)‖ ≤ 1/λ` matches
+  the Neumann series `R(λ) = (λ − A)⁻¹`.
+- **Bernstein on `e^{−t}`:** `f t = e^{−t}` is completely monotone with representing measure
+  the Dirac mass `δ₁`; `f t = 1/(1+t)` gives `μ = e^{−x} dx`.
+- **BCR d = 0** recovers exactly Bernstein.
+
+## Ordering
+
+Layers 0–1 first: the C₀ API and the Hille–Yosida resolvent are direct migrations that
+compile on v4.31 and validate the pipeline (Layer 1 is the suggested first PR). Layer 3
+(Bernstein) is an independent Mathlib-only migration that can proceed in parallel. Layer 2
+(generation theorem) is the open mathematical item. Layer 4 (BCR) is last: its uniqueness is
+portable now, its existence waits on a Mathlib-only spatial Bochner theorem.
+
+## References
+
+- K.-J. Engel, R. Nagel, *One-Parameter Semigroups for Linear Evolution Equations* (GTM 194,
+  2000) — C₀-semigroups, generators, Hille–Yosida, Lumer–Phillips.
+- R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications* (de
+  Gruyter, 2nd ed. 2012) — completely monotone / Bernstein functions.
+- C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984)
+  — Theorem 4.1.13, positive-definite functions on involutive semigroups.

--- a/TauCetiRoadmap/OneParameterSemigroups/README.md
+++ b/TauCetiRoadmap/OneParameterSemigroups/README.md
@@ -1,193 +1,208 @@
-# Roadmap: one-parameter semigroups, completely monotone functions, and BCR Bochner
+# Roadmap: one-parameter semigroups, completely monotone and positive-definite functions, and Bochner-type representations
 
 Operator semigroups are the analytic backbone of evolution equations (heat, Fokker–Planck,
 Schrödinger) and of Markov-process theory. Mathlib has the *static* functional-analysis
-stack — Banach/Hilbert spaces, bounded operators, spectrum, the holomorphic functional
-calculus, the Bochner integral, Fourier theory, unbounded operators via `LinearPMap` — but
-**not the dynamical layer**: strongly continuous (C₀) semigroups, their generators and
-resolvents, the **Hille–Yosida** generation theorem, **Bernstein's theorem** on completely
-monotone functions, or the **Berg–Christensen–Ressel (BCR)** Bochner theorem for
-positive-definite functions on involutive semigroups.
+stack — Banach/Hilbert spaces, bounded operators, `spectrum` and `resolvent`, the
+holomorphic functional calculus, the Bochner integral, Fourier theory, unbounded operators
+via `LinearPMap` — but **not the dynamical layer**: strongly continuous (C₀) semigroups,
+their generators and resolvents, the **Hille–Yosida** generation theorem, the theory of
+**completely monotone** functions and **Bernstein's** representation theorem, **continuous
+positive-definite functions** and **Bochner's** theorem, or the **Berg–Christensen–Ressel
+(BCR)** representation for positive-definite functions on involutive semigroups.
 
-The bar for "done": a researcher in evolution equations or Markov semigroups looks at this
-material and says *"the C₀-semigroup / generator / resolvent API is here, in reusable form,
-and the Hille–Yosida and Bochner-type representation theorems are available."*
+The goal is to **build the reusable theory of these objects**, not to race to a handful of
+named theorems. The bar for "done": a researcher in evolution equations, Markov semigroups,
+or harmonic analysis finds the objects defined at their natural generality, equipped with
+the basic API (closure properties, the standard identities, the connections to existing
+Mathlib structures), so that the headline theorems are *consequences of a developed theory*
+rather than isolated endpoints. A PR that proves a headline theorem but leaves the
+surrounding object without its basic API is not yet what we want.
 
-Suggested home: `TauCeti/Analysis/Semigroups/` (the C₀ API, resolvent, generation),
-`TauCeti/Analysis/CompletelyMonotone/` (Bernstein), `TauCeti/Analysis/BCR/` (the
-Bochner-type representations).
+Suggested home: `TauCeti/Analysis/Semigroups/`, `TauCeti/Analysis/CompletelyMonotone/`,
+`TauCeti/Analysis/PositiveDefinite/`, `TauCeti/Analysis/Bochner/`.
 
-## The end goal (v1)
+## Generality bar (decide these up front; do not silently specialize)
 
-The three pillars, each a standalone, reusable theorem (stated in `Targets.lean` with
-`sorry`/`def_wanted` as the supporting types land).
+- **Semigroups: general C₀ first, contraction as a subclass.** Define general strongly
+  continuous semigroups with a growth bound `‖S t‖ ≤ M e^{ω t}`; contraction semigroups
+  (`M = 1, ω = 0`) are a subclass. State the Hille–Yosida bounds at the general `(M, ω)`
+  level (`‖R(λ,A)ⁿ‖ ≤ M / (λ−ω)ⁿ`); the contraction case is the corollary, never the
+  silent default.
+- **Generators are unbounded.** The generator carries a **dense domain**; model it as a
+  `LinearPMap` / submodule, never a total operator, and **relate its resolvent to Mathlib's
+  existing `resolvent`/`spectrum`** (and to the bounded-operator resolvent when the
+  generator is bounded), rather than introducing a parallel notion.
+- **Bochner at its natural generality.** A continuous positive-definite function lives on a
+  **general finite-dimensional real inner-product space** `V` (so `ℝ²` as `ℝ × ℝ`, or any
+  finite-dim space, is covered) — *not* on hard-coded `Fin d` coordinates. State Bochner for
+  such `V`. **Stretch goal:** a locally compact abelian group via Pontryagin duality (gated
+  on Mathlib's LCA/Pontryagin support). The BCR involutive-semigroup representation is then
+  stated over `[0,∞) × V`.
+- **Spell hypotheses out; never bundle.** Positive-definiteness, complete monotonicity, the
+  involution, growth bounds — each is a named predicate, stated explicitly, not folded into
+  a conclusion.
+
+## What Mathlib already has (consume, and connect to)
+
+- **Operators & spectrum:** `ContinuousLinearMap`, operator norm, `spectrum`, **`resolvent`**,
+  the holomorphic functional calculus; **unbounded operators** via `LinearPMap` (closure,
+  adjoint, cores). The generator, its domain, and its resolvent should be *tied to* these,
+  not duplicated.
+- **The Bochner integral** (`MeasureTheory/Integral/Bochner/*`): the resolvent
+  `∫₀^∞ e^{−λt} S t dt` is a Bochner integral of an operator-valued map; dominated
+  convergence, Fubini, the `Ioi`/`integral_comp_add_right` lemmas.
+- **Fourier analysis** (`Analysis/Fourier/*`): `FourierTransform`, inversion, Plancherel,
+  and characteristic-function uniqueness of finite measures — the spatial half of Bochner.
+  ⚠ Mind Mathlib's `2π` convention (`e^{-2πi⟨·,·⟩}`, unitary, no prefactors).
+- **Measure theory:** `Measure`/`IsFiniteMeasure`, `charFun`
+  (`Measure/CharacteristicFunction`), **Lévy continuity** (`Probability/CentralLimitTheorem`),
+  **Prokhorov** (`Measure/Prokhorov`), **Riesz–Markov–Kakutani**
+  (`Integral/RieszMarkovKakutani`) — the measure-extraction toolkit.
+- **Real analysis:** `Real.exp`, Taylor's theorem with integral remainder, monotone/dominated
+  convergence, `deriv`/iterated derivatives — for the completely-monotone theory.
+
+## What is missing (build here)
+
+The whole dynamical / representation-theoretic layer below is **absent upstream**. Build it
+as developed theories, in dependency order (this is not a strict schedule). Each part lists
+the **API to develop**, then the **representation theorem** as a milestone, then **acceptance
+examples**.
+
+---
+
+## Part A — Strongly continuous semigroups
+
+**Objects.** `StronglyContinuousSemigroup` (general C₀, with a growth bound), its subclass
+`ContractionSemigroup`; the **generator** `A` with its dense domain `D(A)` (a `LinearPMap`);
+the **resolvent** `R(λ,A)`.
+
+**API to develop.**
+- The semigroup laws, strong continuity, and the growth bound `‖S t‖ ≤ M e^{ω t}`
+  (`existsGrowthBound`); the generator as the strong derivative at `0` on `D(A)`.
+- **The generator determines the semigroup uniquely** (a generator-uniqueness theorem).
+- **Resolvent theory**, tied to Mathlib's `resolvent`/`spectrum`:
+  - `R(λ,A) = ∫₀^∞ e^{−λt} S t dt` as a Bochner integral, defined for `Re λ > ω`;
+  - the **resolvent identity** `R(λ,A) − R(μ,A) = (μ − λ) R(λ,A) R(μ,A)`;
+  - **analyticity** of `λ ↦ R(λ,A)` on the resolvent set;
+  - the **derivative / power formulas** `R(λ,A)ⁿ = ∫₀^∞ tⁿ⁻¹/(n−1)! · e^{−λt} S t dt`;
+  - the **iterated-resolvent bounds** `‖R(λ,A)ⁿ‖ ≤ M / (λ − ω)ⁿ` (Hille–Yosida bound, general
+    `(M, ω)`; contraction `‖R(λ,A)‖ ≤ 1/λ` is the corollary).
+
+**Milestone — Hille–Yosida generation theorem.** A densely-defined operator with the
+resolvent bounds above generates a C₀ semigroup; the contraction case via **Lumer–Phillips**:
+densely-defined dissipative `A` with a **range condition** (`∃ λ₀ > 0` with `λ₀ − A`
+surjective) generates a contraction semigroup. ⚠ **Genuinely open / build-here.** Discharge
+via **Yosida approximation**: `Aλ = λ² R(λ,A) − λI` (bounded, by the resolvent API); show each
+`Aλ` generates `e^{tAλ}` and that `e^{tAλ} x` converges uniformly on compacts to `S(t)x` with
+generator `A`. Sub-lemmas: generator-domain density; the approximation estimates +
+convergence of the exponentials. Refs: Engel–Nagel II.3.5–3.8; Pazy Ch. 1.
 
 ```lean
 variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
 
--- 1. Hille–Yosida resolvent: for a contraction C₀-semigroup, R λ = ∫₀^∞ e^{-λt} S t dt
---    inverts (λ − A) on the domain, with the contraction-scale bound.
--- theorem resolvent_right_inverse (S : ContractionC0Semigroup X) {l : ℝ} (hl : 0 < l) :
---     (l • 1 − S.generator) ∘L S.resolvent l = 1
--- theorem resolvent_norm_le (S : ContractionC0Semigroup X) {l : ℝ} (hl : 0 < l) :
---     ‖S.resolvent l‖ ≤ 1 / l
---   (possible further extension: characterize R λ as the *two-sided* inverse (λ − A)⁻¹
---    on D(A) — the v1 target above is the right-inverse + bound that `resolventRightInv` proves.)
+-- resolvent identity, analyticity, power bounds (the developed API), then:
+-- theorem hilleYosida_generation (A : DenseLinearOperator X)
+--     (hbound : ∀ n (l : ℝ), ω < l → ‖resolvent A l ^ n‖ ≤ M / (l - ω) ^ n) :
+--     ∃ S : StronglyContinuousSemigroup X, S.generator = A ∧ S.HasGrowthBound M ω
+-- theorem lumerPhillips (A : DenseLinearOperator X)
+--     (hd : A.IsDissipative) (hr : ∃ l₀ > 0, Surjective (l₀ • 1 - A)) :
+--     ∃ S : ContractionSemigroup X, S.generator = A
+```
 
--- 2. Hille–Yosida generation (converse / Lumer–Phillips): densely-defined dissipative +
---    a range condition ⇒ generates a contraction C₀-semigroup.
--- theorem generates_of_dissipative (A : DenseLinearOperator X)
---     (hd : A.IsDissipative) (hr : ∃ l₀ > 0, Surjective (l₀ • 1 − A)) :   -- one λ₀ suffices (Lumer–Phillips)
---     ∃ S : ContractionC0Semigroup X, S.generator = A
+**Acceptance examples.** The multiplication semigroup `S t f = e^{−t·m} f` (generator `−m`)
+and `e^{tA}` for bounded `A`; the resolvent matches the Neumann series `R(λ) = (λ−A)⁻¹`; the
+resolvent identity and `‖R(λ)‖ ≤ 1/λ` hold on these concretely.
 
--- 3a. Bernstein: a completely monotone function on [0,∞) is the Laplace transform of a
---     unique finite positive measure.
--- theorem bernstein (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) :
---     ∃! μ : Measure ℝ, IsFiniteMeasure μ ∧ μ.support ⊆ Ici 0 ∧
---       ∀ t ≥ 0, f t = ∫ x, Real.exp (-t * x) ∂μ
+## Part B — Completely monotone (and Bernstein) functions
 
--- 3b. BCR Bochner (Berg–Christensen–Ressel 4.1.13): a bounded continuous positive-definite
---     function on [0,∞) × ℝᵈ is the Laplace–Fourier transform of a unique finite measure.
--- theorem bcr_semigroup_bochner (d : ℕ) (F : ℝ × EuclideanSpace ℝ (Fin d) → ℂ)
---     (hpd : IsSemigroupGroupPD d F) :
---     ∃! μ : Measure (ℝ × EuclideanSpace ℝ (Fin d)), IsFiniteMeasure μ ∧ … ∧
+**Objects.** `IsCompletelyMonotone` (`(−1)ⁿ f⁽ⁿ⁾ ≥ 0` on `(0,∞)`); the related
+**Bernstein functions** (nonnegative with completely monotone derivative).
+
+**API to develop.**
+- Closure: completely monotone functions are closed under **sums, nonnegative scalar
+  multiples, products, and pointwise limits**; **composition** `g ∘ f` of completely monotone
+  `g` with a Bernstein function `f` is completely monotone; derivative/integral closure.
+- The **extreme rays**: the functions `t ↦ e^{−tx}` (`x ≥ 0`) are the building blocks, and the
+  representation below realizes a general completely monotone function as a mixture of them.
+- The **Stieltjes / Bernstein-function relationships** (completely monotone ↔ Bernstein via
+  the standard correspondences).
+
+**Milestone — Bernstein's theorem.** `f` is completely monotone **iff** it is the Laplace
+transform of a (unique) finite positive measure on `[0,∞)`. Develop both directions and the
+uniqueness (Laplace-transform injectivity); measure extraction via Prokhorov tightness.
+
+```lean
+-- theorem bernstein (f : ℝ → ℝ) :
+--     IsCompletelyMonotone f ↔
+--       ∃! μ : Measure ℝ, IsFiniteMeasure μ ∧ μ.support ⊆ Set.Ici 0 ∧
+--         ∀ t ≥ 0, f t = ∫ x, Real.exp (-t * x) ∂μ
+```
+
+**Acceptance examples.** `e^{−t} → δ₁`; `1/(1+t) → e^{−x}dx`; closure used to build new
+completely monotone functions from these.
+
+## Part C — Positive-definite functions and Bochner's theorem
+
+**Objects.** Continuous **positive-definite** functions on a finite-dimensional real
+inner-product space `V` (stretch: an LCA group); the **semigroup–group** positive-definite
+predicate `IsSemigroupGroupPD` on `[0,∞) × V`, with its involution `(t, a) ↦ (t, −a)` stated
+explicitly.
+
+**API to develop.**
+- Basic properties of positive-definite functions: **closure under sums, products, Schur
+  (pointwise) products, and pointwise limits**; `F(0) ≥ |F(a)|`; **continuity at `0` ⇒ uniform
+  continuity**; conjugate symmetry.
+- The bridge lemma: a finite measure's Fourier transform is continuous positive-definite
+  (`pd_quadratic_form_of_measure`).
+
+**Milestone 1 — Bochner's theorem on `V`.** A continuous positive-definite function on a
+finite-dimensional real inner-product space `V` **iff** the Fourier transform of a finite
+positive measure on `V`. ⚠ **Verified absent from Mathlib (v4.31)** — Mathlib's "Bochner" is
+the *integral*, and positive-definiteness is only for *matrices*/quadratic forms; there is no
+continuous-PD-*function* notion or Bochner representation. Build it: define continuous PD
+functions on `V`, then either (i) the positive linear functional `f ↦ ∫ f̂ · φ` + Riesz–Markov,
+or (ii) `charFun` + Lévy/Prokhorov tightness. State for general `V`; specialize to `ℝᵈ` as a
+corollary. **Stretch:** LCA group via Pontryagin.
+
+**Milestone 2 — BCR semigroup–Bochner (Berg–Christensen–Ressel 4.1.13).** A bounded
+continuous positive-definite function on the involutive semigroup `[0,∞) × V` is the
+Laplace–Fourier transform of a unique finite measure; develop existence (consuming Milestone
+1) and uniqueness (`laplaceFourier_unique`, Fourier/Laplace injectivity, Mathlib-only).
+
+```lean
+variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
+
+-- theorem bochner (F : V → ℂ) (hcont : Continuous F) (hpd : IsPositiveDefinite F) :
+--     ∃! μ : Measure V, IsFiniteMeasure μ ∧ ∀ a, F a = ∫ q, Complex.exp (I * ⟪a, q⟫) ∂μ
+-- theorem bcr_semigroup_bochner (F : ℝ × V → ℂ) (hpd : IsSemigroupGroupPD F) … :
+--     ∃! μ : Measure (ℝ × V), IsFiniteMeasure μ ∧ … ∧
 --       ∀ t ≥ 0, ∀ a, F (t, a) = ∫ (p, q), Real.exp (-t * p) * Complex.exp (I * ⟪a, q⟫) ∂μ
 ```
 
-## Standing hypotheses (spell them out; never bundle)
+**Acceptance examples.** Bochner on `V = ℝ` recovers the classical statement; **BCR at
+`V = 0`** recovers exactly Bernstein; a Gaussian `e^{−‖a‖²}` is positive-definite with the
+expected Gaussian representing measure.
 
-- **Contraction vs general C₀.** State the resolvent identities for **contraction**
-  semigroups (`‖S t‖ ≤ 1`); the general bounded case (`‖S t‖ ≤ M e^{ωt}`) is a later
-  generalization via rescaling — carry `M, ω` explicitly, never assume contraction silently.
-- **Unbounded generator.** The generator has a **dense domain**; track it as a genuine
-  `LinearPMap` / submodule, never a total operator. ⚠ Do not conflate the operator with its
-  closure's domain.
-- **Completely monotone** means `(−1)ⁿ f⁽ⁿ⁾ ≥ 0` for all `n` on `(0,∞)`; keep the endpoint
-  and finiteness hypotheses explicit (the representing measure is finite, supported on
-  `[0,∞)`).
-- **Positive-definite on a semigroup-with-involution.** State the BCR hypothesis as a named
-  predicate (`IsSemigroupGroupPD`), not bundled into the conclusion; fix the involution
-  (`(t,a) ↦ (t,−a)`) and the `[0,∞) × ℝᵈ` structure up front.
+---
 
-## What Mathlib already has (consume)
+## Dependency ordering
 
-- **Operators & spectrum:** `ContinuousLinearMap`, operator norm, `spectrum`, the
-  holomorphic functional calculus; **unbounded operators** via `LinearPMap` (closure,
-  adjoint, cores) — the generator and its domain live here.
-- **The Bochner integral** (`Mathlib/MeasureTheory/Integral/Bochner/*`): the resolvent
-  `∫₀^∞ e^{−λt} S t dt` is a Bochner integral of an operator-valued map; dominated
-  convergence, Fubini, the `integral_comp_add_right`/`Ioi` lemmas.
-- **Fourier analysis** (`Mathlib/Analysis/Fourier/*`): `FourierTransform`, inversion,
-  Plancherel, and characteristic-function uniqueness of finite measures — the spatial half
-  of BCR uniqueness.
-- **Laplace transforms / `Real.exp`**, the `Measure`/`IsFiniteMeasure` API, and **Prokhorov
-  tightness** for the measure-extraction in Bernstein.
-- **Completely monotone scaffolding:** Taylor's theorem with integral remainder, monotone
-  convergence, `deriv`/iterated derivatives.
-
-## What is missing (build here)
-
-C₀-semigroups, their generators/resolvents, the Hille–Yosida resolvent identities and the
-generation theorem, Bernstein's theorem, and the BCR semigroup-Bochner theorem. **None of
-this is upstream** (Mathlib has the static stack but no operator-semigroup theory).
-
-## Migration source (existing AI-authored material)
-
-Most of this exists, **sorry-free and with 0 project axioms**, in
-[`mrdouglasny/hille-yosida`](https://github.com/mrdouglasny/hille-yosida), pinned at commit
-`8fda1863eea60068e32f7ea6c0c27da5dd650957`. A v4.29→v4.31 toolchain bump is prepared on its
-`bump/v4.31` branch (the resolvent module compiles clean on Mathlib v4.31 with no code
-changes). Credit that source (and the BCR theorem to Berg–Christensen–Ressel) in each ported
-file.
-
-⚠ **Bochner-dependency split.** Two files of the source — `BCR_Common.lean`,
-`BCR_Existence.lean` — depend on a separate Bochner–Minlos package, so **Layers 0–3 below
-are cleanly Mathlib-only**, and the BCR *existence* half (Layer 4) needs a Mathlib-only route
-to the spatial Bochner theorem before it can be ported. Port in layer order.
-
-Per-file decls to migrate (in order within each file):
-- `StronglyContinuousSemigroup.lean` → `StronglyContinuousSemigroup`, `ContractingSemigroup`,
-  `.generator`, `.domain`, `.resolvent`, `resolventMapsToDomain`, `resolventRightInv`,
-  `hilleYosidaResolventBound`, `HasGrowthBound`, `existsGrowthBound`.
-- `BernsteinBasic.lean` → `IsCompletelyMonotone`, `taylor_integral_remainder`; then
-  `BernsteinMeasures.lean`, `BernsteinChafai.lean`, then `Bernstein.lean` → `bernstein_theorem`.
-- `FourierPD.lean` → `pd_quadratic_form_of_measure`; `BCR_d0.lean` → `semigroup_pd_laplace`;
-  `SemigroupGroupDefs.lean` → `IsSemigroupGroupPD`; `BCR_General.lean` →
-  `laplaceFourier_unique` (Mathlib-only) and `semigroupGroupBochner_proof` (needs Bochner);
-  `SemigroupGroupExtension.lean` → `semigroupGroupBochner`, `semigroupGroupBochnerExtension`.
-
-## The build, in layers
-
-The ordering is the dependency order, not a strict schedule.
-
-### Layer 0: C₀-semigroup API
-`StronglyContinuousSemigroup`, `ContractingSemigroup`, the generator and its dense domain,
-strong continuity, the semigroup laws. *(Migrate `StronglyContinuousSemigroup.lean`.)*
-
-### Layer 1: Hille–Yosida resolvent — **suggested first PR**
-`resolvent`, `resolventRightInv` ((λ−A)R(λ) = 1 on the domain), `hilleYosidaResolventBound`
-(`‖R(λ)‖ ≤ 1/λ`). Cleanly Mathlib-only; the migrated module already compiles on v4.31.
-
-### Layer 2: generation theorem / Lumer–Phillips converse
-Densely-defined dissipative + a range condition (`∃ λ₀ > 0` with `λ₀ − A` surjective) ⇒
-generates a contraction semigroup. ⚠ **Build-here** (the genuinely open item).
-**Discharge plan — Yosida approximation.** Set `Aλ = λ² R(λ,A) − λI` (bounded, by Layer 1);
-show each `Aλ` generates a contraction semigroup `e^{tAλ}` and that `e^{tAλ} x` converges
-(uniformly on compacts) to a limit `S(t)x`, with generator `A`. Sub-lemmas: (a) generator-domain
-**density** (`domain_isDense`); (b) the **approximation estimates** + convergence of the
-exponentials. `Future/GenerationTheorem.lean` already carries `DenseLinearOperator`,
-`IsDissipative`, and the target statement (as a commented spec, with `∃ λ₀`); only the proof is
-missing. Refs: Engel–Nagel II.3.5–3.8; Pazy Ch. 1.
-
-### Layer 3: Bernstein's theorem
-Completely monotone ⇒ Laplace transform of a unique finite measure. *(Migrate the Bernstein
-chain.)* Mathlib-only; the measure extraction uses Prokhorov tightness.
-
-### Layer 4: BCR Bochner (d = 0, then general)
-Semigroup/Laplace positive-definite representation. **Uniqueness** (`laplaceFourier_unique`)
-is Mathlib-only and portable now. **Existence** (`semigroupGroupBochner`) ⚠ consumes the
-*spatial* Bochner theorem on `ℝᵈ` (continuous positive-definite ⇒ Fourier transform of a finite
-measure), so it is gated on **Layer 4a** below.
-
-### Layer 4a (prerequisite): Bochner's theorem on ℝᵈ — its own target
-**Verified absent from Mathlib (v4.31):** "Bochner" in Mathlib is the Bochner *integral*, and
-the positive-definite theory is only for *matrices*/quadratic forms — there is **no**
-continuous-positive-definite-*function* notion or Bochner representation. So formalize it as a
-standalone target (which Layer 4 then consumes). The ingredients **are** present:
-`charFun` (`MeasureTheory/Measure/CharacteristicFunction`), **Lévy continuity**
-(`Probability/CentralLimitTheorem`), **Prokhorov** (`MeasureTheory/Measure/Prokhorov`),
-**Riesz–Markov–Kakutani** (`MeasureTheory/Integral/RieszMarkovKakutani`), and Fourier
-inversion/Plancherel (`Analysis/Fourier/*`). Route: define continuous PD functions, then either
-(i) the positive linear functional `f ↦ ∫ f̂ · φ` + Riesz–Markov, or (ii) `charFun` + tightness
-via Lévy/Prokhorov. ⚠ pitfalls: Mathlib's `2π` Fourier convention (`e^{-2πi⟨·,·⟩}`, unitary
-without prefactors); and the PD-function notion itself is new. *(Researched + cross-checked
-against the Mathlib source, 2026-06-18.)*
-
-## Worked examples (acceptance criteria, keeping the statements honest)
-
-- **Concrete C₀-semigroup:** the multiplication semigroup `S t f = e^{−t·m} f` on a function
-  space (or `e^{tA}` for a bounded `A`) is a `ContractingSemigroup` with generator `−m` (resp.
-  `A`); its resolvent is the expected Neumann/integral form.
-- **Resolvent bound is non-vacuous:** for the bounded generator `A`, `‖R(λ)‖ ≤ 1/λ` matches
-  the Neumann series `R(λ) = (λ − A)⁻¹`.
-- **Bernstein on `e^{−t}`:** `f t = e^{−t}` is completely monotone with representing measure
-  the Dirac mass `δ₁`; `f t = 1/(1+t)` gives `μ = e^{−x} dx`.
-- **BCR d = 0** recovers exactly Bernstein.
-
-## Ordering
-
-Layers 0–1 first: the C₀ API and the Hille–Yosida resolvent are direct migrations that
-compile on v4.31 and validate the pipeline (Layer 1 is the suggested first PR). Layer 3
-(Bernstein) is an independent Mathlib-only migration that can proceed in parallel. Layer 2
-(generation theorem) is the open mathematical item (discharge via Yosida approximation). Layer 4
-(BCR) is last: uniqueness is portable now; existence waits on **Layer 4a**, the spatial Bochner
-theorem on ℝᵈ — absent from Mathlib, so a standalone prerequisite target.
+Part A (semigroups) and Part B (completely monotone) are independent and can proceed in
+parallel; the Hille–Yosida resolvent API and the Bernstein representation are good early
+targets. Part A's **generation theorem** (Yosida approximation) is build-here and can follow
+the resolvent API. Part C builds on B for the `V = 0` consistency check; its **Bochner
+theorem on `V`** (Milestone 1) is build-here and **gates** the BCR existence half, while BCR
+uniqueness is independent and portable early.
 
 ## References
 
 - K.-J. Engel, R. Nagel, *One-Parameter Semigroups for Linear Evolution Equations* (GTM 194,
-  2000) — C₀-semigroups, generators, Hille–Yosida, Lumer–Phillips.
+  2000); A. Pazy, *Semigroups of Linear Operators and Applications to PDE* (1983) —
+  C₀-semigroups, generators, resolvent theory, Hille–Yosida, Lumer–Phillips.
 - R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications* (de
-  Gruyter, 2nd ed. 2012) — completely monotone / Bernstein functions.
+  Gruyter, 2nd ed. 2012) — completely monotone / Bernstein functions and their structure.
+- W. Rudin, *Fourier Analysis on Groups* (1962); G. Folland, *A Course in Abstract Harmonic
+  Analysis* (2nd ed. 2016) — Bochner's theorem, positive-definite functions, Pontryagin
+  duality (the stretch generality).
 - C. Berg, J. P. R. Christensen, P. Ressel, *Harmonic Analysis on Semigroups* (GTM 100, 1984)
   — Theorem 4.1.13, positive-definite functions on involutive semigroups.

--- a/TauCetiRoadmap/OneParameterSemigroups/README.md
+++ b/TauCetiRoadmap/OneParameterSemigroups/README.md
@@ -31,11 +31,13 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X
 --     (l • 1 − S.generator) ∘L S.resolvent l = 1
 -- theorem resolvent_norm_le (S : ContractionC0Semigroup X) {l : ℝ} (hl : 0 < l) :
 --     ‖S.resolvent l‖ ≤ 1 / l
+--   (possible further extension: characterize R λ as the *two-sided* inverse (λ − A)⁻¹
+--    on D(A) — the v1 target above is the right-inverse + bound that `resolventRightInv` proves.)
 
 -- 2. Hille–Yosida generation (converse / Lumer–Phillips): densely-defined dissipative +
 --    a range condition ⇒ generates a contraction C₀-semigroup.
 -- theorem generates_of_dissipative (A : DenseLinearOperator X)
---     (hd : A.IsDissipative) (hr : ∀ l > 0, Surjective (l • 1 − A)) :
+--     (hd : A.IsDissipative) (hr : ∃ l₀ > 0, Surjective (l₀ • 1 − A)) :   -- one λ₀ suffices (Lumer–Phillips)
 --     ∃ S : ContractionC0Semigroup X, S.generator = A
 
 -- 3a. Bernstein: a completely monotone function on [0,∞) is the Laplace transform of a
@@ -127,9 +129,15 @@ strong continuity, the semigroup laws. *(Migrate `StronglyContinuousSemigroup.le
 (`‖R(λ)‖ ≤ 1/λ`). Cleanly Mathlib-only; the migrated module already compiles on v4.31.
 
 ### Layer 2: generation theorem / Lumer–Phillips converse
-Densely-defined dissipative + range condition ⇒ generates a contraction semigroup. ⚠ Mostly
-**build-here**: the source has the `IsDissipative` scaffold (`Future/GenerationTheorem.lean`)
-but not the full converse; this is the genuinely open item.
+Densely-defined dissipative + a range condition (`∃ λ₀ > 0` with `λ₀ − A` surjective) ⇒
+generates a contraction semigroup. ⚠ **Build-here** (the genuinely open item).
+**Discharge plan — Yosida approximation.** Set `Aλ = λ² R(λ,A) − λI` (bounded, by Layer 1);
+show each `Aλ` generates a contraction semigroup `e^{tAλ}` and that `e^{tAλ} x` converges
+(uniformly on compacts) to a limit `S(t)x`, with generator `A`. Sub-lemmas: (a) generator-domain
+**density** (`domain_isDense`); (b) the **approximation estimates** + convergence of the
+exponentials. `Future/GenerationTheorem.lean` already carries `DenseLinearOperator`,
+`IsDissipative`, and the target statement (as a commented spec, with `∃ λ₀`); only the proof is
+missing. Refs: Engel–Nagel II.3.5–3.8; Pazy Ch. 1.
 
 ### Layer 3: Bernstein's theorem
 Completely monotone ⇒ Laplace transform of a unique finite measure. *(Migrate the Bernstein
@@ -137,9 +145,23 @@ chain.)* Mathlib-only; the measure extraction uses Prokhorov tightness.
 
 ### Layer 4: BCR Bochner (d = 0, then general)
 Semigroup/Laplace positive-definite representation. **Uniqueness** (`laplaceFourier_unique`)
-is Mathlib-only and portable now; **existence** (`semigroupGroupBochner`) ⚠ depends on the
-spatial Bochner theorem — defer until there is a Mathlib-only route to it (or until a Bochner
-theorem for positive-definite functions on `ℝᵈ` is itself a TauCeti target).
+is Mathlib-only and portable now. **Existence** (`semigroupGroupBochner`) ⚠ consumes the
+*spatial* Bochner theorem on `ℝᵈ` (continuous positive-definite ⇒ Fourier transform of a finite
+measure), so it is gated on **Layer 4a** below.
+
+### Layer 4a (prerequisite): Bochner's theorem on ℝᵈ — its own target
+**Verified absent from Mathlib (v4.31):** "Bochner" in Mathlib is the Bochner *integral*, and
+the positive-definite theory is only for *matrices*/quadratic forms — there is **no**
+continuous-positive-definite-*function* notion or Bochner representation. So formalize it as a
+standalone target (which Layer 4 then consumes). The ingredients **are** present:
+`charFun` (`MeasureTheory/Measure/CharacteristicFunction`), **Lévy continuity**
+(`Probability/CentralLimitTheorem`), **Prokhorov** (`MeasureTheory/Measure/Prokhorov`),
+**Riesz–Markov–Kakutani** (`MeasureTheory/Integral/RieszMarkovKakutani`), and Fourier
+inversion/Plancherel (`Analysis/Fourier/*`). Route: define continuous PD functions, then either
+(i) the positive linear functional `f ↦ ∫ f̂ · φ` + Riesz–Markov, or (ii) `charFun` + tightness
+via Lévy/Prokhorov. ⚠ pitfalls: Mathlib's `2π` Fourier convention (`e^{-2πi⟨·,·⟩}`, unitary
+without prefactors); and the PD-function notion itself is new. *(Researched + cross-checked
+against the Mathlib source, 2026-06-18.)*
 
 ## Worked examples (acceptance criteria, keeping the statements honest)
 
@@ -157,8 +179,9 @@ theorem for positive-definite functions on `ℝᵈ` is itself a TauCeti target).
 Layers 0–1 first: the C₀ API and the Hille–Yosida resolvent are direct migrations that
 compile on v4.31 and validate the pipeline (Layer 1 is the suggested first PR). Layer 3
 (Bernstein) is an independent Mathlib-only migration that can proceed in parallel. Layer 2
-(generation theorem) is the open mathematical item. Layer 4 (BCR) is last: its uniqueness is
-portable now, its existence waits on a Mathlib-only spatial Bochner theorem.
+(generation theorem) is the open mathematical item (discharge via Yosida approximation). Layer 4
+(BCR) is last: uniqueness is portable now; existence waits on **Layer 4a**, the spatial Bochner
+theorem on ℝᵈ — absent from Mathlib, so a standalone prerequisite target.
 
 ## References
 

--- a/TauCetiRoadmap/OneParameterSemigroups/README.md
+++ b/TauCetiRoadmap/OneParameterSemigroups/README.md
@@ -29,9 +29,11 @@ Suggested home: `TauCeti/Analysis/Semigroups/`, `TauCeti/Analysis/CompletelyMono
   level (`‖R(λ,A)ⁿ‖ ≤ M / (λ−ω)ⁿ`); the contraction case is the corollary, never the
   silent default.
 - **Generators are unbounded.** The generator carries a **dense domain**; model it as a
-  `LinearPMap` / submodule, never a total operator, and **relate its resolvent to Mathlib's
-  existing `resolvent`/`spectrum`** (and to the bounded-operator resolvent when the
-  generator is bounded), rather than introducing a parallel notion.
+  `LinearPMap` / submodule, never a total operator. Mathlib's `resolvent`/`spectrum` are
+  **Banach-algebra-only**, so an unbounded generator needs its **own** resolvent notion
+  (`λ ∈ ρ(A)` iff `λ·I − A : D(A) → X` is a bijection with bounded inverse); add a **bridge
+  lemma** identifying it with Mathlib's `resolvent` in the bounded (`domain = ⊤`) case, rather
+  than duplicating effort.
 - **Bochner at its natural generality.** A continuous positive-definite function lives on a
   **general finite-dimensional real inner-product space** `V` (so `ℝ²` as `ℝ × ℝ`, or any
   finite-dim space, is covered) — *not* on hard-coded `Fin d` coordinates. State Bochner for
@@ -46,18 +48,23 @@ Suggested home: `TauCeti/Analysis/Semigroups/`, `TauCeti/Analysis/CompletelyMono
 
 - **Operators & spectrum:** `ContinuousLinearMap`, operator norm, `spectrum`, **`resolvent`**,
   the holomorphic functional calculus; **unbounded operators** via `LinearPMap` (closure,
-  adjoint, cores). The generator, its domain, and its resolvent should be *tied to* these,
-  not duplicated.
-- **The Bochner integral** (`MeasureTheory/Integral/Bochner/*`): the resolvent
-  `∫₀^∞ e^{−λt} S t dt` is a Bochner integral of an operator-valued map; dominated
-  convergence, Fubini, the `Ioi`/`integral_comp_add_right` lemmas.
+  adjoint, cores). Tie the generator and its domain to these; the generator's resolvent needs
+  its own notion (it is not a Banach-algebra element — see the generality bar), bridged to
+  Mathlib's `resolvent` in the bounded case rather than duplicated.
+- **The Bochner integral** (`MeasureTheory/Integral/Bochner/*`): the resolvent is a
+  **pointwise** `X`-valued Bochner integral `R(λ)x = ∫₀^∞ e^{−λt} S(t)x dt`. ⚠ A general C₀
+  semigroup is only *strongly* continuous, so `t ↦ S(t)` need not be norm-measurable as a
+  `ContinuousLinearMap` (`B(X)` is generally non-separable) — integrate **pointwise** in `x`,
+  then bundle the result into a `ContinuousLinearMap`. Plus dominated convergence, Fubini,
+  the `Ioi`/`integral_comp_add_right` lemmas.
 - **Fourier analysis** (`Analysis/Fourier/*`): `FourierTransform`, inversion, Plancherel,
   and characteristic-function uniqueness of finite measures — the spatial half of Bochner.
   ⚠ Mind Mathlib's `2π` convention (`e^{-2πi⟨·,·⟩}`, unitary, no prefactors).
 - **Measure theory:** `Measure`/`IsFiniteMeasure`, `charFun`
-  (`Measure/CharacteristicFunction`), **Lévy continuity** (`Probability/CentralLimitTheorem`),
-  **Prokhorov** (`Measure/Prokhorov`), **Riesz–Markov–Kakutani**
-  (`Integral/RieszMarkovKakutani`) — the measure-extraction toolkit.
+  (`MeasureTheory/Measure/CharacteristicFunction`), **Lévy continuity**, **Prokhorov**
+  (`MeasureTheory/Measure/Prokhorov`), **Riesz–Markov–Kakutani**
+  (`MeasureTheory/Integral/RieszMarkovKakutani`) — the measure-extraction toolkit. *(Confirm
+  the exact module paths against the pinned Mathlib commit before relying on them.)*
 - **Real analysis:** `Real.exp`, Taylor's theorem with integral remainder, monotone/dominated
   convergence, `deriv`/iterated derivatives — for the completely-monotone theory.
 
@@ -79,34 +86,45 @@ the **resolvent** `R(λ,A)`.
 **API to develop.**
 - The semigroup laws, strong continuity, and the growth bound `‖S t‖ ≤ M e^{ω t}`
   (`existsGrowthBound`); the generator as the strong derivative at `0` on `D(A)`.
-- **The generator determines the semigroup uniquely** (a generator-uniqueness theorem).
-- **Resolvent theory**, tied to Mathlib's `resolvent`/`spectrum`:
-  - `R(λ,A) = ∫₀^∞ e^{−λt} S t dt` as a Bochner integral, defined for `Re λ > ω`;
+- **The generator determines the semigroup uniquely**; the generator is **closed**, with
+  `S(t)·D(A) ⊆ D(A)` and `A S(t)x = S(t) A x`, and `t ↦ S(t)x` differentiable for `x ∈ D(A)`.
+- **Bounded ↔ uniformly continuous:** `A` is bounded (`domain = ⊤`) iff the semigroup is
+  uniformly (norm-) continuous; plus the bounded-perturbation theorem.
+- **Resolvent theory** (its own unbounded-resolvent notion + the bridge lemma above):
+  - `R(λ,A)x = ∫₀^∞ e^{−λt} S(t)x dt` (pointwise Bochner integral) for **real** `λ > ω` (use
+    a complexification for the complex resolvent set and the analyticity below);
   - the **resolvent identity** `R(λ,A) − R(μ,A) = (μ − λ) R(λ,A) R(μ,A)`;
   - **analyticity** of `λ ↦ R(λ,A)` on the resolvent set;
-  - the **derivative / power formulas** `R(λ,A)ⁿ = ∫₀^∞ tⁿ⁻¹/(n−1)! · e^{−λt} S t dt`;
-  - the **iterated-resolvent bounds** `‖R(λ,A)ⁿ‖ ≤ M / (λ − ω)ⁿ` (Hille–Yosida bound, general
-    `(M, ω)`; contraction `‖R(λ,A)‖ ≤ 1/λ` is the corollary).
+  - the **derivative / power formulas** (for `n ≥ 1`) `R(λ,A)ⁿ x = ∫₀^∞ tⁿ⁻¹/(n−1)! · e^{−λt}
+    S(t)x dt`, with `dᵏR(λ,A)/dλᵏ = (−1)ᵏ k! · R(λ,A)^{k+1}`;
+  - the **iterated-resolvent bounds** (for `λ > ω`, `n ≥ 1`) `‖R(λ,A)ⁿ‖ ≤ M / (λ − ω)ⁿ`
+    (Hille–Yosida bound, general `(M, ω)`; contraction `‖R(λ,A)‖ ≤ 1/λ` is the corollary).
 
 **Milestone — Hille–Yosida generation theorem.** A densely-defined operator with the
 resolvent bounds above generates a C₀ semigroup; the contraction case via **Lumer–Phillips**:
 densely-defined dissipative `A` with a **range condition** (`∃ λ₀ > 0` with `λ₀ − A`
 surjective) generates a contraction semigroup. ⚠ **Genuinely open / build-here.** Discharge
-via **Yosida approximation**: `Aλ = λ² R(λ,A) − λI` (bounded, by the resolvent API); show each
-`Aλ` generates `e^{tAλ}` and that `e^{tAλ} x` converges uniformly on compacts to `S(t)x` with
-generator `A`. Sub-lemmas: generator-domain density; the approximation estimates +
-convergence of the exponentials. Refs: Engel–Nagel II.3.5–3.8; Pazy Ch. 1.
+via **Yosida approximation**: `Aλ = λ² R(λ,A) − λI` (bounded, by the resolvent API), each
+generating a uniformly continuous contraction semigroup `e^{tAλ}`. ⚠ `S` does not exist yet,
+so do not phrase this as convergence "to `S(t)x`": instead prove the `e^{tAλ}x` are **Cauchy
+uniformly on compact `t`-intervals**, *define* `S(t)x` as the limit, and then identify its
+generator as `A`. Sub-lemmas: generator-domain density; the stability/approximation estimates
++ the Cauchy property of the exponentials.
+Refs: Engel–Nagel II.3.5–3.8; Pazy Ch. 1.
 
 ```lean
 variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
 
 -- resolvent identity, analyticity, power bounds (the developed API), then:
+-- variable (M ω : ℝ)   -- growth constants; 1 ≤ M
 -- theorem hilleYosida_generation (A : DenseLinearOperator X)
---     (hbound : ∀ n (l : ℝ), ω < l → ‖resolvent A l ^ n‖ ≤ M / (l - ω) ^ n) :
+--     (hρ : ∀ l : ℝ, ω < l → l ∈ resolventSet A)          -- (ω,∞) ⊆ ρ(A)
+--     (hbound : ∀ n, 1 ≤ n → ∀ l : ℝ, ω < l → ‖resolvent A l ^ n‖ ≤ M / (l - ω) ^ n) :
 --     ∃ S : StronglyContinuousSemigroup X, S.generator = A ∧ S.HasGrowthBound M ω
 -- theorem lumerPhillips (A : DenseLinearOperator X)
---     (hd : A.IsDissipative) (hr : ∃ l₀ > 0, Surjective (l₀ • 1 - A)) :
---     ∃ S : ContractionSemigroup X, S.generator = A
+--     (hd : A.IsDissipative)
+--     (hr : ∃ l₀ > 0, Surjective (l₀ • 1 - A))    -- surjectivity of (λ₀·I − A) : D(A) → X
+--     : ∃ S : ContractionSemigroup X, S.generator = A
 ```
 
 **Acceptance examples.** The multiplication semigroup `S t f = e^{−t·m} f` (generator `−m`)
@@ -115,8 +133,11 @@ resolvent identity and `‖R(λ)‖ ≤ 1/λ` hold on these concretely.
 
 ## Part B — Completely monotone (and Bernstein) functions
 
-**Objects.** `IsCompletelyMonotone` (`(−1)ⁿ f⁽ⁿ⁾ ≥ 0` on `(0,∞)`); the related
-**Bernstein functions** (nonnegative with completely monotone derivative).
+**Objects.** `IsCompletelyMonotone` — **bundle smoothness** with the sign condition:
+`ContDiffOn ℝ ⊤ f (Set.Ici 0) ∧ ∀ n, ∀ t ≥ 0, 0 ≤ (−1)ⁿ · iteratedDeriv n f t`. ⚠ The
+smoothness clause is essential: `iteratedDeriv` is total and defaults to `0` where `f` is not
+differentiable, so `0 ≤ 0` would let a non-smooth `f` pass *vacuously*. The related
+**Bernstein functions** (nonnegative, with completely monotone derivative).
 
 **API to develop.**
 - Closure: completely monotone functions are closed under **sums, nonnegative scalar
@@ -125,11 +146,16 @@ resolvent identity and `‖R(λ)‖ ≤ 1/λ` hold on these concretely.
 - The **extreme rays**: the functions `t ↦ e^{−tx}` (`x ≥ 0`) are the building blocks, and the
   representation below realizes a general completely monotone function as a mixture of them.
 - The **Stieltjes / Bernstein-function relationships** (completely monotone ↔ Bernstein via
-  the standard correspondences).
+  the standard correspondences); the **Lévy–Khinchine representation** of Bernstein functions.
 
-**Milestone — Bernstein's theorem.** `f` is completely monotone **iff** it is the Laplace
-transform of a (unique) finite positive measure on `[0,∞)`. Develop both directions and the
-uniqueness (Laplace-transform injectivity); measure extraction via Prokhorov tightness.
+**Milestone — Bernstein's theorem.** `f` completely monotone **on the closed `[0,∞)`** (so
+`f(0⁺) < ∞`) **iff** it is the Laplace transform of a unique **finite** positive measure on
+`[0,∞)`. ⚠ Complete monotonicity on the *open* `(0,∞)` alone yields only a general (possibly
+infinite) positive measure — e.g. `1/t = ∫₀^∞ e^{−tx} dx` is completely monotone with the
+infinite Lebesgue representing measure (Hausdorff–Bernstein–Widder). Finiteness is exactly the
+`f(0⁺) < ∞` criterion, which our `Set.Ici 0` definition above builds in. Develop both
+directions and uniqueness (Laplace-transform injectivity); measure extraction via Prokhorov
+tightness.
 
 ```lean
 -- theorem bernstein (f : ℝ → ℝ) :
@@ -143,15 +169,21 @@ completely monotone functions from these.
 
 ## Part C — Positive-definite functions and Bochner's theorem
 
-**Objects.** Continuous **positive-definite** functions on a finite-dimensional real
-inner-product space `V` (stretch: an LCA group); the **semigroup–group** positive-definite
-predicate `IsSemigroupGroupPD` on `[0,∞) × V`, with its involution `(t, a) ↦ (t, −a)` stated
-explicitly.
+**Objects.** Continuous **positive-definite** functions. Define `IsPositiveDefinite`
+**generically on `[AddCommMonoid M] [StarAddMonoid M]`**, then instantiate: on a
+finite-dimensional real inner-product space `V` (involution `a⋆ = −a`), and on `ℝ≥0 × V`,
+where the **product `StarAddMonoid` automatically supplies the BCR involution** `(t,a)⋆ = (t,−a)`
+(`ℝ≥0` carries the trivial involution, `V` the negation) — no hand-coding. `IsSemigroupGroupPD`
+is then this predicate on `ℝ≥0 × V`. (Stretch: an LCA group.)
 
 **API to develop.**
-- Basic properties of positive-definite functions: **closure under sums, products, Schur
-  (pointwise) products, and pointwise limits**; `F(0) ≥ |F(a)|`; **continuity at `0` ⇒ uniform
-  continuity**; conjugate symmetry.
+- Basic properties: **closure under sums, products, Schur (pointwise) products**; for
+  `F : M → ℂ`, conjugate symmetry, `(F 0).im = 0`, `0 ≤ (F 0).re`, and `‖F a‖ ≤ (F 0).re`
+  (the Lean-typed form of `F(0) ≥ |F(a)|`); **continuity at `0` ⇒ uniform continuity**.
+  ⚠ Pointwise limits preserve positive-definiteness but **not** continuity — that needs an
+  extra hypothesis (e.g. locally uniform convergence).
+- The **PD-function ↔ PD-kernel** equivalence (`K(a,b) = F(a − b)`), pullbacks, and the
+  GNS/Kolmogorov decomposition; normalization `F(0) = 1`.
 - The bridge lemma: a finite measure's Fourier transform is continuous positive-definite
   (`pd_quadratic_form_of_measure`).
 
@@ -160,7 +192,8 @@ inner-product space `V` is continuous and positive-definite **iff** it is the Fo
 transform of a finite positive measure on `V`. State it for general `V`, with `ℝᵈ` as a
 corollary.
 
-⚠ **Verified absent from Mathlib (v4.31):** Mathlib's "Bochner" is the *integral*, and its
+⚠ **Checked against the Mathlib source (v4.31, 2026-06-18; re-confirm against the pinned
+commit before relying on it):** Mathlib's "Bochner" is the *integral*, and its
 positive-definiteness is only for *matrices* / quadratic forms — there is no
 continuous-positive-definite-*function* notion, and no Bochner representation. So this is
 build-here. Two routes: (i) the positive linear functional `f ↦ ∫ f̂ · φ` + Riesz–Markov, or
@@ -173,12 +206,17 @@ Laplace–Fourier transform of a unique finite measure; develop existence (consu
 
 ```lean
 variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDimensional ℝ V]
+-- Mathlib Fourier convention (e^{-2πi⟨·,·⟩}); the real inner product is coerced to ℂ.
+-- (Alternatively phrase via `fourierChar`/`charFun` directly.)
 
 -- theorem bochner (F : V → ℂ) (hcont : Continuous F) (hpd : IsPositiveDefinite F) :
---     ∃! μ : Measure V, IsFiniteMeasure μ ∧ ∀ a, F a = ∫ q, Complex.exp (I * ⟪a, q⟫) ∂μ
--- theorem bcr_semigroup_bochner (F : ℝ × V → ℂ) (hpd : IsSemigroupGroupPD F) … :
---     ∃! μ : Measure (ℝ × V), IsFiniteMeasure μ ∧ … ∧
---       ∀ t ≥ 0, ∀ a, F (t, a) = ∫ (p, q), Real.exp (-t * p) * Complex.exp (I * ⟪a, q⟫) ∂μ
+--     ∃! μ : Measure V, IsFiniteMeasure μ ∧
+--       ∀ a, F a = ∫ q, Complex.exp (-2 * π * Complex.I * (⟪a, q⟫_ℝ : ℂ)) ∂μ
+-- -- time lives in ℝ≥0, so the representing measure has the right support automatically:
+-- theorem bcr_semigroup_bochner (F : ℝ≥0 × V → ℂ) (hpd : IsSemigroupGroupPD F) … :
+--     ∃! μ : Measure (ℝ≥0 × V), IsFiniteMeasure μ ∧
+--       ∀ t a, F (t, a) = ∫ (p, q), (Real.exp (-(t : ℝ) * p) : ℂ) *
+--         Complex.exp (-2 * π * Complex.I * (⟪a, q⟫_ℝ : ℂ)) ∂μ
 ```
 
 **Acceptance examples.** Bochner on `V = ℝ` recovers the classical statement; the case

--- a/TauCetiRoadmap/OneParameterSemigroups/README.md
+++ b/TauCetiRoadmap/OneParameterSemigroups/README.md
@@ -155,14 +155,16 @@ explicitly.
 - The bridge lemma: a finite measure's Fourier transform is continuous positive-definite
   (`pd_quadratic_form_of_measure`).
 
-**Milestone 1 — Bochner's theorem on `V`.** A continuous positive-definite function on a
-finite-dimensional real inner-product space `V` **iff** the Fourier transform of a finite
-positive measure on `V`. ⚠ **Verified absent from Mathlib (v4.31)** — Mathlib's "Bochner" is
-the *integral*, and positive-definiteness is only for *matrices*/quadratic forms; there is no
-continuous-PD-*function* notion or Bochner representation. Build it: define continuous PD
-functions on `V`, then either (i) the positive linear functional `f ↦ ∫ f̂ · φ` + Riesz–Markov,
-or (ii) `charFun` + Lévy/Prokhorov tightness. State for general `V`; specialize to `ℝᵈ` as a
-corollary. **Stretch:** LCA group via Pontryagin.
+**Milestone 1 — Bochner's theorem on `V`.** A function on a finite-dimensional real
+inner-product space `V` is continuous and positive-definite **iff** it is the Fourier
+transform of a finite positive measure on `V`. State it for general `V`, with `ℝᵈ` as a
+corollary.
+
+⚠ **Verified absent from Mathlib (v4.31):** Mathlib's "Bochner" is the *integral*, and its
+positive-definiteness is only for *matrices* / quadratic forms — there is no
+continuous-positive-definite-*function* notion, and no Bochner representation. So this is
+build-here. Two routes: (i) the positive linear functional `f ↦ ∫ f̂ · φ` + Riesz–Markov, or
+(ii) `charFun` + Lévy/Prokhorov tightness. **Stretch:** an LCA group via Pontryagin duality.
 
 **Milestone 2 — BCR semigroup–Bochner (Berg–Christensen–Ressel 4.1.13).** A bounded
 continuous positive-definite function on the involutive semigroup `[0,∞) × V` is the
@@ -179,9 +181,9 @@ variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V] [FiniteDim
 --       ∀ t ≥ 0, ∀ a, F (t, a) = ∫ (p, q), Real.exp (-t * p) * Complex.exp (I * ⟪a, q⟫) ∂μ
 ```
 
-**Acceptance examples.** Bochner on `V = ℝ` recovers the classical statement; **BCR at
-`V = 0`** recovers exactly Bernstein; a Gaussian `e^{−‖a‖²}` is positive-definite with the
-expected Gaussian representing measure.
+**Acceptance examples.** Bochner on `V = ℝ` recovers the classical statement; the case
+`V = 0` (no spatial variable) collapses BCR back to Bernstein; a Gaussian `a ↦ e^{−‖a‖²}` is
+positive-definite, with the expected Gaussian representing measure.
 
 ---
 

--- a/TauCetiRoadmap/OneParameterSemigroups/README.md
+++ b/TauCetiRoadmap/OneParameterSemigroups/README.md
@@ -1,0 +1,106 @@
+# Roadmap: one-parameter semigroups, completely monotone functions, and BCR Bochner
+
+Operator semigroups are the analytic backbone of evolution equations (heat, Fokker–Planck,
+Schrödinger) and of Markov-process theory. Mathlib has the static functional-analysis stack
+(Banach/Hilbert spaces, bounded operators, spectrum, the Bochner integral, Fourier theory)
+but **not** the dynamical layer: strongly continuous (C₀) semigroups, their generators and
+resolvents, the Hille–Yosida generation theorem, Bernstein's theorem on completely monotone
+functions, or the Berg–Christensen–Ressel (BCR) Bochner theorem for positive-definite
+functions on involutive semigroups.
+
+The bar for "done": a researcher in evolution equations or Markov semigroups looks at this
+material and says *"the C₀-semigroup / generator / resolvent API is here, in reusable form,
+and the Hille–Yosida and Bochner-type representation theorems are available."*
+
+> **Provenance note.** A substantial AI-authored development of this material already exists
+> (`mrdouglasny/hille-yosida`, sorry-free, 0 project axioms), covering the Hille–Yosida
+> resolvent identities, Bernstein's theorem, and the BCR semigroup-Bochner theorem. It is a
+> natural source for "make existing material ready to Tau Ceti" PRs. Two adaptation tasks:
+> it targets Lean v4.29.0 (Tau Ceti is on v4.31.0 — a Mathlib bump is needed), and its BCR
+> *existence* half depends on a separate Bochner–Minlos package, so the **resolvent and
+> Bernstein items below are the cleanly Mathlib-only first targets**; the BCR existence item
+> needs a Mathlib-only route to the spatial Bochner theorem first.
+
+## The end goal (v1)
+
+The three pillars, each a standalone, reusable theorem about contraction C₀-semigroups on a
+Banach space and the representation of the functions that arise from them.
+
+```lean
+-- the shapes we are building toward (state in Targets.lean as the supporting types land):
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
+
+-- A strongly continuous semigroup and its (unbounded) generator.
+-- structure C0Semigroup (X) : ...                 -- S 0 = id, S (s+t) = S s ∘ S t, strong continuity
+-- def C0Semigroup.generator (S : C0Semigroup X) : X →ₗ.[ℝ] X        -- A u = lim (S t u - u)/t
+
+-- 1. Hille–Yosida resolvent: for a contraction semigroup, R λ = ∫₀^∞ e^{-λt} S t dt
+--    inverts (λ - A) and is a contraction-scale bound.
+-- theorem resolvent_right_inverse (S : ContractionC0Semigroup X) {λ : ℝ} (hλ : 0 < λ) :
+--     (λ • 1 - S.generator) ∘L S.resolvent λ = 1
+-- theorem resolvent_norm_le (S : ContractionC0Semigroup X) {λ : ℝ} (hλ : 0 < λ) :
+--     ‖S.resolvent λ‖ ≤ 1 / λ
+
+-- 2. Hille–Yosida generation theorem (converse / Lumer–Phillips): a densely-defined
+--    dissipative operator whose range condition holds generates a contraction semigroup.
+-- theorem generates_of_dissipative (A : DenseLinearOperator X)
+--     (hdiss : A.IsDissipative) (hrange : ∀ λ > 0, Surjective (λ • 1 - A)) :
+--     ∃ S : ContractionC0Semigroup X, S.generator = A
+
+-- 3a. Bernstein's theorem: a completely monotone function on [0,∞) is the Laplace transform
+--     of a unique finite positive measure.
+-- theorem bernstein (f : ℝ → ℝ) (hcm : IsCompletelyMonotone f) :
+--     ∃! μ : Measure ℝ, IsFiniteMeasure μ ∧ μ.support ⊆ Ici 0 ∧
+--       ∀ t ≥ 0, f t = ∫ x, Real.exp (-t * x) ∂μ
+
+-- 3b. BCR Bochner (Berg–Christensen–Ressel 4.1.13): a bounded continuous positive-definite
+--     function on [0,∞) × ℝᵈ is the Laplace–Fourier transform of a unique finite measure.
+-- theorem bcr_semigroup_bochner (d : ℕ) (F : (ℝ × EuclideanSpace ℝ (Fin d)) → ℂ)
+--     (hpd : IsSemigroupGroupPD d F) :
+--     ∃! μ : Measure (ℝ × EuclideanSpace ℝ (Fin d)), IsFiniteMeasure μ ∧ ... ∧
+--       ∀ t ≥ 0, ∀ a, F (t, a) = ∫ (p, q), Real.exp (-t * p) * Complex.exp (I * ⟪a, q⟫) ∂μ
+```
+
+## Standing hypotheses (spell them out; never bundle)
+
+- **Contraction vs general C₀.** State the resolvent identities for **contraction**
+  semigroups (`‖S t‖ ≤ 1`); the general bounded case (`‖S t‖ ≤ M e^{ωt}`) is a separate,
+  later generalization via rescaling — carry `M, ω` explicitly, do not assume contraction
+  silently.
+- **Generator domain.** The generator is **unbounded**: track its dense domain as a genuine
+  `LinearPMap` / submodule, never as a total operator.
+- **Completely monotone** means `(-1)ⁿ f⁽ⁿ⁾ ≥ 0` for all `n` on `(0,∞)`; keep the endpoint
+  and finiteness hypotheses explicit (the measure is finite, supported on `[0,∞)`).
+- **Positive-definite** on a semigroup-with-involution: state the BCR hypothesis as a named
+  predicate (`IsSemigroupGroupPD`), not bundled into the conclusion.
+
+## Inventory: what Mathlib master gives us (consume)
+
+- Banach/Hilbert spaces, `ContinuousLinearMap`, operator norm, `spectrum`, the holomorphic
+  functional calculus; **unbounded operators** via `LinearPMap` (closure, adjoint, cores).
+- The **Bochner integral**, `MeasureTheory.integral`, dominated convergence, Fubini — the
+  resolvent `∫₀^∞ e^{-λt} S t dt` is a Bochner integral of an operator-valued map.
+- **Fourier theory**: `Real.fourierIntegral`, inversion, Plancherel; characteristic-function
+  uniqueness for finite measures — the spatial half of BCR.
+- **Laplace transforms** and `Real.exp`; Stieltjes/`Measure` API; Prokhorov tightness for the
+  measure-extraction in Bernstein.
+
+## Roadmap items
+
+1. **C₀-semigroup API** — `C0Semigroup`, generator, domain, strong continuity, basic laws.
+   *(Ready: `hille-yosida` `StronglyContinuousSemigroup.lean`.)*
+2. **Hille–Yosida resolvent** — `resolvent`, `resolvent_right_inverse`, `resolvent_norm_le`.
+   *(Ready: `hilleYosidaResolventBound`, `ContractingSemigroup.resolventRightInv`.)* **← suggested first PR.**
+3. **Generation theorem / Lumer–Phillips converse** — dissipative + range ⇒ generates.
+   *(Partial: `Future/GenerationTheorem.lean`; the `IsDissipative` scaffold exists.)*
+4. **Bernstein's theorem** — completely monotone ⇒ Laplace transform of a unique finite
+   measure. *(Ready: `bernstein_theorem`.)*
+5. **BCR Bochner (d = 0, then general)** — semigroup/Laplace positive-definite representation.
+   *(Existence depends on a Bochner-theorem prerequisite — needs a Mathlib-only route to the
+   spatial Bochner step before porting; uniqueness `laplaceFourier_unique` is Mathlib-only.)*
+
+## Suggested home
+
+`TauCeti/Analysis/Semigroups/` (C₀ API, resolvent, generation) with
+`TauCeti/Analysis/CompletelyMonotone/` (Bernstein) and `TauCeti/Analysis/BCR/` (the
+Bochner-type representations).

--- a/TauCetiRoadmap/OneParameterSemigroups/README.md
+++ b/TauCetiRoadmap/OneParameterSemigroups/README.md
@@ -1,7 +1,8 @@
 # Roadmap: one-parameter semigroups, completely monotone and positive-definite functions, and Bochner-type representations
 
-Operator semigroups are the analytic backbone of evolution equations (heat, Fokker–Planck,
-Schrödinger) and of Markov-process theory. Mathlib has the *static* functional-analysis
+Operator semigroups are the analytic backbone of evolution equations (heat, Fokker–Planck;
+the conservative Schrödinger case is a unitary *group*, a stretch goal below) and of
+Markov-process theory. Mathlib has the *static* functional-analysis
 stack — Banach/Hilbert spaces, bounded operators, `spectrum` and `resolvent`, the
 holomorphic functional calculus, the Bochner integral, Fourier theory, unbounded operators
 via `LinearPMap` — but **not the dynamical layer**: strongly continuous (C₀) semigroups,
@@ -28,6 +29,14 @@ Suggested home: `TauCeti/Analysis/Semigroups/`, `TauCeti/Analysis/CompletelyMono
   (`M = 1, ω = 0`) are a subclass. State the Hille–Yosida bounds at the general `(M, ω)`
   level (`‖R(λ,A)ⁿ‖ ≤ M / (λ−ω)ⁿ`); the contraction case is the corollary, never the
   silent default.
+- **Scalar field: real-Banach-first, stated explicitly.** Develop over a real Banach space
+  `X` (`[NormedSpace ℝ X]`) — Hille–Yosida / Lumer–Phillips hold there, and a complex Hilbert
+  space is usable as a real Banach space for the semigroup action. Get the complex resolvent
+  set and the analyticity of `λ ↦ R(λ,A)` via **complexification** `X_ℂ`. (An `[RCLike 𝕜]`
+  formulation is a possible later generalization.)
+- **C₀ groups as a stretch.** Two-sided strongly continuous groups `(S(t))_{t∈ℝ}` — e.g. the
+  unitary `e^{itH}` of Schrödinger — are *not* reached by the contraction-semigroup API;
+  include them as a stretch goal / example (Stone's theorem on Hilbert space).
 - **Generators are unbounded.** The generator carries a **dense domain**; model it as a
   `LinearPMap` / submodule, never a total operator. Mathlib's `resolvent`/`spectrum` are
   **Banach-algebra-only**, so an unbounded generator needs its **own** resolvent notion
@@ -81,7 +90,9 @@ examples**.
 
 **Objects.** `StronglyContinuousSemigroup` (general C₀, with a growth bound), its subclass
 `ContractionSemigroup`; the **generator** `A` with its dense domain `D(A)` (a `LinearPMap`);
-the **resolvent** `R(λ,A)`.
+the **resolvent** `R(λ,A)`. Model the generator with Mathlib's `LinearPMap` directly (plus a
+dense-domain hypothesis); the `DenseLinearOperator` named in the stubs below is exactly that
+thin wrapper, not a parallel unbounded-operator API.
 
 **API to develop.**
 - The semigroup laws, strong continuity, and the growth bound `‖S t‖ ≤ M e^{ω t}`
@@ -90,6 +101,13 @@ the **resolvent** `R(λ,A)`.
   `S(t)·D(A) ⊆ D(A)` and `A S(t)x = S(t) A x`, and `t ↦ S(t)x` differentiable for `x ∈ D(A)`.
 - **Bounded ↔ uniformly continuous:** `A` is bounded (`domain = ⊤`) iff the semigroup is
   uniformly (norm-) continuous; plus the bounded-perturbation theorem.
+- **Foundational lemmas:** `∫₀ᵗ S(s)x ds ∈ D(A)` with `A ∫₀ᵗ S(s)x ds = S(t)x − x`; a **named
+  density-of-`D(A)`** theorem for generated semigroups (density of `D(Aⁿ)` / smooth vectors is
+  a useful secondary target). These are the workhorses behind the generation theorem.
+- **Dissipativity:** the Lumer–Phillips **converse** (the generator of a contraction semigroup
+  is dissipative) and maximal dissipativity. ⚠ The Hilbert characterization `Re⟪Ax, x⟫ ≤ 0`
+  is a **Hilbert-only specialization**; the general Banach notion goes through duality maps /
+  resolvent-range inequalities.
 - **Resolvent theory** (its own unbounded-resolvent notion + the bridge lemma above):
   - `R(λ,A)x = ∫₀^∞ e^{−λt} S(t)x dt` (pointwise Bochner integral) for **real** `λ > ω` (use
     a complexification for the complex resolvent set and the analyticity below);
@@ -100,17 +118,26 @@ the **resolvent** `R(λ,A)`.
   - the **iterated-resolvent bounds** (for `λ > ω`, `n ≥ 1`) `‖R(λ,A)ⁿ‖ ≤ M / (λ − ω)ⁿ`
     (Hille–Yosida bound, general `(M, ω)`; contraction `‖R(λ,A)‖ ≤ 1/λ` is the corollary).
 
-**Milestone — Hille–Yosida generation theorem.** A densely-defined operator with the
-resolvent bounds above generates a C₀ semigroup; the contraction case via **Lumer–Phillips**:
-densely-defined dissipative `A` with a **range condition** (`∃ λ₀ > 0` with `λ₀ − A`
-surjective) generates a contraction semigroup. ⚠ **Genuinely open / build-here.** Discharge
-via **Yosida approximation**: `Aλ = λ² R(λ,A) − λI` (bounded, by the resolvent API), each
-generating a uniformly continuous contraction semigroup `e^{tAλ}`. ⚠ `S` does not exist yet,
-so do not phrase this as convergence "to `S(t)x`": instead prove the `e^{tAλ}x` are **Cauchy
-uniformly on compact `t`-intervals**, *define* `S(t)x` as the limit, and then identify its
-generator as `A`. Sub-lemmas: generator-domain density; the stability/approximation estimates
-+ the Cauchy property of the exponentials.
-Refs: Engel–Nagel II.3.5–3.8; Pazy Ch. 1.
+**Milestone — Hille–Yosida generation theorem.** A densely-defined operator whose resolvent
+set contains `(ω,∞)` and whose powers satisfy `‖R(λ,A)ⁿ‖ ≤ M/(λ−ω)ⁿ` generates a C₀ semigroup
+of growth `(M, ω)`.
+
+**Milestone — Lumer–Phillips theorem** (kept distinct — a different hypothesis set). A
+densely-defined **dissipative** operator with a **range condition** (`∃ λ₀ > 0` with `λ₀ − A`
+surjective) generates a **contraction** semigroup.
+
+⚠ **Both are genuinely open / build-here**, via the same **Yosida approximation**:
+`Aλ = λ² R(λ,A) − λI` (bounded, by the resolvent API), each generating a uniformly continuous
+contraction semigroup `e^{tAλ}`. `S` does not exist yet, so do not phrase this as convergence
+"to `S(t)x`": prove the `e^{tAλ}x` are **Cauchy uniformly on compact `t`-intervals**, *define*
+`S(t)x` as the limit, then identify its generator as `A`. Sub-lemmas: generator-domain density;
+the stability/approximation estimates + the Cauchy property of the exponentials. Refs:
+Engel–Nagel II.3.5–3.8; Pazy Ch. 1.
+
+**Milestone — abstract Cauchy problem.** `u(t) = S(t)x` is the solution of `u' = A u`,
+`u(0) = x`: a **classical** solution for `x ∈ D(A)` (`u(t) ∈ D(A)`, `u' = Au`), a **mild**
+solution for general `x`. It follows from generator-uniqueness, but it is the motivating
+payoff, so state it as a milestone.
 
 ```lean
 variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
@@ -153,15 +180,16 @@ differentiable, so `0 ≤ 0` would let a non-smooth `f` pass *vacuously*. The re
 `[0,∞)`. ⚠ Complete monotonicity on the *open* `(0,∞)` alone yields only a general (possibly
 infinite) positive measure — e.g. `1/t = ∫₀^∞ e^{−tx} dx` is completely monotone with the
 infinite Lebesgue representing measure (Hausdorff–Bernstein–Widder). Finiteness is exactly the
-`f(0⁺) < ∞` criterion, which our `Set.Ici 0` definition above builds in. Develop both
-directions and uniqueness (Laplace-transform injectivity); measure extraction via Prokhorov
-tightness.
+`f(0⁺) < ∞` criterion, which our `Set.Ici 0` definition above builds in. Encode the measure on
+`Measure ℝ≥0` (non-negative support automatic — the same convention as the BCR milestone, not a
+`support ⊆ Ici 0` side-condition). Develop both directions and uniqueness (Laplace-transform
+injectivity); measure extraction via Prokhorov tightness.
 
 ```lean
 -- theorem bernstein (f : ℝ → ℝ) :
 --     IsCompletelyMonotone f ↔
---       ∃! μ : Measure ℝ, IsFiniteMeasure μ ∧ μ.support ⊆ Set.Ici 0 ∧
---         ∀ t ≥ 0, f t = ∫ x, Real.exp (-t * x) ∂μ
+--       ∃! μ : Measure ℝ≥0, IsFiniteMeasure μ ∧
+--         ∀ t ≥ 0, f t = ∫ x, Real.exp (-t * (x : ℝ)) ∂μ
 ```
 
 **Acceptance examples.** `e^{−t} → δ₁`; `1/(1+t) → e^{−x}dx`; closure used to build new
@@ -174,7 +202,10 @@ completely monotone functions from these.
 finite-dimensional real inner-product space `V` (involution `a⋆ = −a`), and on `ℝ≥0 × V`,
 where the **product `StarAddMonoid` automatically supplies the BCR involution** `(t,a)⋆ = (t,−a)`
 (`ℝ≥0` carries the trivial involution, `V` the negation) — no hand-coding. `IsSemigroupGroupPD`
-is then this predicate on `ℝ≥0 × V`. (Stretch: an LCA group.)
+is then this predicate on `ℝ≥0 × V`. (Stretch: an LCA group.) The condition itself: for every
+finite family `(cᵢ, aᵢ)`, `Σ_{i,j} cᵢ · conj(cⱼ) · F(aᵢ + aⱼ⋆) ≥ 0` — note the **involution**
+`aⱼ⋆`, not the group form `F(aᵢ − aⱼ)`; this is exactly what makes the product involution
+`(t,a)⋆ = (t,−a)` yield the intended BCR notion.
 
 **API to develop.**
 - Basic properties: **closure under sums, products, Schur (pointwise) products**; for
@@ -182,8 +213,11 @@ is then this predicate on `ℝ≥0 × V`. (Stretch: an LCA group.)
   (the Lean-typed form of `F(0) ≥ |F(a)|`); **continuity at `0` ⇒ uniform continuity**.
   ⚠ Pointwise limits preserve positive-definiteness but **not** continuity — that needs an
   extra hypothesis (e.g. locally uniform convergence).
-- The **PD-function ↔ PD-kernel** equivalence (`K(a,b) = F(a − b)`), pullbacks, and the
-  GNS/Kolmogorov decomposition; normalization `F(0) = 1`.
+- The **PD-function ↔ PD-kernel** equivalence (`K(a,b) = F(a + b⋆)`; `F(a − b)` for a group),
+  pullbacks, and the GNS/Kolmogorov decomposition; normalization `F(0) = 1`.
+- A stated **Fourier-convention conversion lemma** between Mathlib's `2π` form
+  (`e^{−2πi⟨·,·⟩}`) and the characteristic-function form (`e^{i⟨·,·⟩}`) — downstream users will
+  mix the two, so a conversion lemma beats a `⚠`.
 - The bridge lemma: a finite measure's Fourier transform is continuous positive-definite
   (`pd_quadratic_form_of_measure`).
 


### PR DESCRIPTION
A roadmap for the **dynamical / representation-theoretic functional-analysis layer** that Mathlib lacks: strongly continuous (C₀) semigroups, generators and resolvents, the **Hille–Yosida** generation theorem; the theory of **completely monotone** functions and **Bernstein's** representation; **continuous positive-definite functions** and **Bochner's** theorem; and the **BCR (Berg–Christensen–Ressel)** representation on involutive semigroups.

**Revised per @kim-em's review.** Rebased onto current `main` (merge conflict resolved). The roadmap now has a **library-building focus** rather than racing to named theorems — each part lists the *API to develop*, then the representation theorem as a milestone, then acceptance examples:

- **General C₀ semigroups first, contraction as a subclass**; Hille–Yosida bounds stated at general `(M, ω)`, contraction as the corollary.
- A full **resolvent API** tied to Mathlib's `resolvent`/`spectrum`: resolvent identity, analyticity, power/derivative formulas, iterated bounds; generator-uniqueness.
- `IsCompletelyMonotone` **structural theory**: closure under sums/products/limits/composition with Bernstein functions, `e^{−tx}` extreme rays, Stieltjes/Bernstein relations.
- **Positive-definite function API** (closure under sums/products/Schur products/limits; continuity-at-0 ⇒ uniform continuity), and **Bochner stated on a general finite-dimensional real inner-product space** (not `Fin d`), with LCA-via-Pontryagin as a labeled stretch goal.
- **Dropped all references to external/our own material** so AI reviewers judge the statements intrinsically and adversarially.

Adds `TauCetiRoadmap/OneParameterSemigroups/README.md` and links it from the top-level README. Markdown only — no effect on the build.

---

*AI attribution:* drafted by **Claude (Opus 4.8)**, with advice from **Gemini** and **Codex**; human-directed and reviewed by M. Douglas.
