### PR TITLE
doc: move the reconciliation theorems onto the analytic Heegaard Floer roadmap

### DIFF
--- a/TauCetiRoadmap/CombinatorialHeegaardFloer/README.md
+++ b/TauCetiRoadmap/CombinatorialHeegaardFloer/README.md
@@ -13,7 +13,8 @@ Ozsváth–Stipsicz–Szabó stable HF̂ — carried all the way down (definitio
 proof, and applications). The analytic tower (Fredholm theory, transversality,
 Gromov compactness, gluing, Lagrangian Floer homology, holomorphic HF̂) is its
 companion [Heegaard Floer roadmap](../HeegaardFloer/README.md); the two meet at
-precisely-stated reconciliation theorems named in both.
+reconciliation theorems that the analytic roadmap states, since they wait on
+its slower track.
 
 This is **not a linear roadmap**. It is a family of lanes with many independent
 on-ramps; nearly every lane is publishable mathematics on its own, and several would
@@ -60,7 +61,8 @@ applications), plus one combinatorial neighbor:
 
 These three are exactly what this roadmap formalizes. The holomorphic theory is
 **on the roadmap, not a non-goal** — it is just the [other half](../HeegaardFloer/README.md),
-and the seams where the two halves meet are the reconciliation theorems below.
+and the seams where the two halves meet are the reconciliation theorems, which that
+roadmap owns (they are analytic-blocked, so they live with the slower track).
 
 ## The end goals
 
@@ -70,12 +72,12 @@ and the seams where the two halves meet are the reconciliation theorems below.
   Kronheimer–Mrowka with gauge theory), by pure combinatorics.
 - **v2 (3-manifolds, combinatorial).** Ozsváth–Stipsicz–Szabó's stable `HF̂_st(Y)`
   over 𝔽₂, with its purely topological invariance proof.
-- **Reconciliations (shared with the analytic roadmap).** Grid homology = knot Floer
-  homology ([arXiv:math/0607691](https://arxiv.org/abs/math/0607691)); `HF̂_st` =
-  stabilized holomorphic `HF̂` (the appendix of 0912.0830); lattice homology = `HF⁻`
-  of plumbed manifolds (Zemke). Each is a precise "the two definitions agree" theorem
-  where a combinatorial lane here meets the analytic one there; they are stated in
-  both roadmaps.
+- **Reconciliations (owned by the analytic roadmap).** Each invariant here has a
+  "the two definitions agree" theorem matching it to its holomorphic counterpart
+  (grid homology = knot Floer homology; `HF̂_st` = stabilized holomorphic `HF̂`;
+  lattice homology = `HF⁻` of plumbed manifolds). These seams wait on the
+  analytic tower, which is the long pole, so they are stated and tracked in the
+  [analytic roadmap](../HeegaardFloer/README.md), not here.
 
 ```lean
 -- the shapes we are building toward (state in Targets.lean as the types land):
@@ -302,14 +304,13 @@ holomorphic side lives.
 - C. Manolescu, P. Ozsváth, S. Sarkar,
   [arXiv:math/0607691](https://arxiv.org/abs/math/0607691); Manolescu–Ozsváth–
   Szabó–Thurston [arXiv:math/0610559](https://arxiv.org/abs/math/0610559): grid
-  homology's origins; the latter is the self-contained one. The former is the
-  **grid homology = HFK** reconciliation, shared with the analytic roadmap.
+  homology's origins; the latter is the self-contained one. (The former is also the
+  **grid homology = HFK** reconciliation, which the analytic roadmap owns.)
 - P. Ozsváth, A. Stipsicz, Z. Szabó,
   [arXiv:0912.0830](https://arxiv.org/abs/0912.0830) and
   [arXiv:1301.0480](https://arxiv.org/abs/1301.0480): Lane H.
-- A. Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841); I. Zemke,
-  [arXiv:2111.14962](https://arxiv.org/abs/2111.14962): Lane L and its
-  reconciliation.
+- A. Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841): Lane L. (Zemke's
+  `ℍ⁻ ≅ HF⁻` reconciliation is cited and tracked in the analytic roadmap.)
 - É. Gallais, [arXiv:0706.0089](https://arxiv.org/abs/0706.0089): sign assignments
   and ℤ coefficients for grid homology (G.12).
 - A. Juhász, D. Thurston, I. Zemke,
@@ -326,7 +327,7 @@ Lanes G.1–3 (with ALG), L, and K can all start immediately and independently. 
 spine to push hardest is **G**: it reaches a famous theorem (Milnor conjecture)
 entirely within reach of current technology. Lane H follows G once the nice-move
 idiom is established. Nothing here waits for the analytic roadmap; the seams between
-them are the reconciliation theorems, each stated on both sides.
+them are the reconciliation theorems, which the analytic roadmap states and tracks.
 
 ## Acknowledgements
 

--- a/TauCetiRoadmap/CombinatorialHeegaardFloer/Targets.lean
+++ b/TauCetiRoadmap/CombinatorialHeegaardFloer/Targets.lean
@@ -7,8 +7,9 @@ The narrative roadmap is in `README.md`: the combinatorial bodies of theory that
 formalizable now — grid homology (Lane G), bigraded and filtered homological algebra
 (Lane ALG), knot-theory reconciliation (Lane K), lattice homology (Lane L), and the
 Ozsváth–Stipsicz–Szabó stable `HF̂` of 3-manifolds (Lane H). The analytic tower lives
-in the sibling `HeegaardFloer` roadmap; the two meet at precisely-stated
-reconciliation theorems stated on both sides.
+in the sibling `HeegaardFloer` roadmap, which also owns the reconciliation theorems
+that match each invariant here to its holomorphic counterpart (they are
+analytic-blocked, so they are tracked with the slower track).
 
 Nothing knot-theoretic or Floer-theoretic exists in Mathlib yet, so there are no
 compiled targets to state against the pin. As the prerequisite *types* land in

--- a/TauCetiRoadmap/HeegaardFloer/README.md
+++ b/TauCetiRoadmap/HeegaardFloer/README.md
@@ -13,7 +13,8 @@ homology, and `HF̂` via holomorphic disks in `Sym^g(Σ)`. The theories that are
 combinatorial all the way down (grid homology, lattice homology, the
 Ozsváth–Stipsicz–Szabó stable `HF̂`) are its companion
 [Combinatorial Heegaard Floer roadmap](../CombinatorialHeegaardFloer/README.md);
-the two meet at precisely-stated reconciliation theorems named in both.
+the two meet at precisely-stated reconciliation theorems, which this roadmap owns
+(they depend on the analytic tower, the long pole).
 
 This is **not a linear roadmap**. It is a family of lanes with several independent
 on-ramps; nearly every lane is publishable mathematics on its own, and each would be
@@ -47,15 +48,12 @@ substrate yields quickly to blueprint-driven effort.
 
 - **v3 (the long game, analytic).** Morse homology; Lagrangian Floer homology of
   exact Lagrangians; `HF̂(Y)` over 𝔽₂ via holomorphic disks in `Sym^g(Σ)`.
-- **Reconciliations (shared with the combinatorial roadmap).** `HF̂_st` = stabilized
-  holomorphic `HF̂` (the appendix of
-  [arXiv:0912.0830](https://arxiv.org/abs/0912.0830)); lattice homology = `HF⁻` of
-  plumbed manifolds (Zemke [arXiv:2111.14962](https://arxiv.org/abs/2111.14962));
-  grid homology = knot Floer homology
-  ([arXiv:math/0607691](https://arxiv.org/abs/math/0607691), via the cylindrical
-  reformulation of Lane F5). Each is a precise "the two definitions agree" theorem
-  where the analytic tower here meets a combinatorial lane there; they are stated in
-  both roadmaps.
+- **Reconciliations (this roadmap owns them).** The three "the two definitions
+  agree" theorems that join each combinatorial invariant to its holomorphic
+  counterpart. They depend on the analytic tower, which is the long pole, so they
+  live here rather than being split across both roadmaps; see the
+  [Reconciliations](#reconciliations-the-seams-and-the-long-pole) section below for
+  the precise statements.
 
 ```lean
 -- the shape we are building toward (state in Targets.lean as the types land):
@@ -251,10 +249,39 @@ Lipshitz's cylindrical reformulation
 SFT/Bourgeois–Eliashberg–Hofer–Wysocki–Zehnder compactness
 ([arXiv:math/0308183](https://arxiv.org/abs/math/0308183)), and, through it,
 bordered Floer homology ([arXiv:0810.0687](https://arxiv.org/abs/0810.0687)).
-Knot Floer homology via doubly-pointed diagrams and the reconciliation **grid
-homology = HFK** ([arXiv:math/0607691](https://arxiv.org/abs/math/0607691)) also
-live here, joining this roadmap to the combinatorial one's Lane G. ⚠ Polyfolds and
+Knot Floer homology via doubly-pointed diagrams lives here too; it is what the
+**grid homology = HFK** reconciliation (below) is stated against. ⚠ Polyfolds and
 virtual techniques stay off this roadmap: nothing here needs them.
+
+## Reconciliations (the seams, and the long pole)
+
+These are the "the two definitions agree" theorems that join each combinatorial
+invariant (built in the
+[combinatorial roadmap](../CombinatorialHeegaardFloer/README.md)) to its holomorphic
+counterpart built here. Every one depends on the analytic tower above, so the
+analytic track is the blocker, and the reconciliations are owned and tracked here
+rather than split across both roadmaps. The combinatorial side keeps only pointers
+back to this section.
+
+1. **`HF̂_st` = stabilized holomorphic `HF̂`** (the appendix of
+   [arXiv:0912.0830](https://arxiv.org/abs/0912.0830)): the Ozsváth–Stipsicz–Szabó
+   stable invariant agrees with the holomorphic `HF̂` of Lane F4 up to the tracked
+   `(𝔽 ⊕ 𝔽)`-factors, exactly `HF̂` for `b₁(Y) = 0`. Depends on F4.4 (stabilization
+   and diagram-move invariance) and the combinatorial Lane H.
+2. **Lattice homology = `HF⁻` of plumbed manifolds** (Zemke
+   [arXiv:2111.14962](https://arxiv.org/abs/2111.14962)): Némethi's `ℍ⁻` computes the
+   holomorphic `HF⁻` of every plumbed 3-manifold. Depends on the staged `HF^-`/`HF^∞`
+   flavors of F4.5 and the combinatorial Lane L.
+3. **Grid homology = knot Floer homology**
+   ([arXiv:math/0607691](https://arxiv.org/abs/math/0607691)): the combinatorial grid
+   invariant agrees with `HFK̂`, computed holomorphically from doubly-pointed
+   diagrams via the cylindrical reformulation of Lane F5. Depends on F5 and the
+   combinatorial Lane G.
+
+The first seam crossed end to end is the genus-1 computation below: `HF̂(L(p,q))`
+read off the holomorphic theory matches the combinatorial Lane H answer. ⚠ State
+each reconciliation naturality-ready (JTZ): the agreement is an isomorphism attached
+to a specific identification of the two complexes, not a bare rank equality.
 
 ## Acceptance criteria ("checks along the way")
 
@@ -292,7 +319,7 @@ Concrete checks that rule out vacuous or mis-stated definitions:
   Thurston [arXiv:0810.0687](https://arxiv.org/abs/0810.0687): Lane F5.
 - I. Zemke, [arXiv:2111.14962](https://arxiv.org/abs/2111.14962); Manolescu–
   Ozsváth–Sarkar [arXiv:math/0607691](https://arxiv.org/abs/math/0607691): the
-  reconciliation targets, shared with the combinatorial roadmap.
+  reconciliation targets (lattice = `HF⁻`, grid = HFK), owned by this roadmap.
 - A. Juhász, D. Thurston, I. Zemke,
   [arXiv:1210.4996](https://arxiv.org/abs/1210.4996): naturality, the capstone.
 - P. Kronheimer, T. Mrowka, *Monopoles and Three-Manifolds*, Cambridge, 2007: not
@@ -309,7 +336,8 @@ the bare symplectic/almost-complex definitions of F2.1; none of them waits for t
 [combinatorial roadmap](../CombinatorialHeegaardFloer/README.md). F1 should be
 planned jointly with the PDE roadmap rather than alone; F3 is the first analytic
 headline and F4 the second. The seams that join the two roadmaps are the
-reconciliation theorems, each stated on both sides.
+reconciliation theorems above; because each depends on this tower, the analytic
+track is what paces them, which is why they are tracked here.
 
 ## Acknowledgements
 

--- a/TauCetiRoadmap/HeegaardFloer/Targets.lean
+++ b/TauCetiRoadmap/HeegaardFloer/Targets.lean
@@ -8,8 +8,8 @@ The narrative roadmap is in `README.md`: the analytic tower — Morse homology
 package (Lane F1), J-holomorphic curves (Lane F2), exact Lagrangian Floer homology
 (Lane F3), and `HF̂` via holomorphic disks in `Sym^g(Σ)` (Lanes F4–F5). The
 combinatorial bodies of theory live in the sibling `CombinatorialHeegaardFloer`
-roadmap; the two meet at precisely-stated reconciliation theorems stated on both
-sides.
+roadmap; the reconciliation theorems that join each combinatorial invariant to its
+holomorphic counterpart are owned here, since they depend on this analytic tower.
 
 Nothing Floer-theoretic exists in Mathlib yet, so there are no compiled targets to
 state against the pin. As the prerequisite *types* land in `TauCeti/` (the analytic


### PR DESCRIPTION
This PR moves the three reconciliation theorems (grid homology = knot Floer homology, HF̂_st = stabilized holomorphic HF̂, lattice homology = HF⁻ of plumbed manifolds) entirely onto the analytic `HeegaardFloer` roadmap, which now owns them under a dedicated Reconciliations section with precise statements and the analytic prerequisite each depends on. Because every seam depends on the analytic tower — the long pole — the analytic track is what paces them, so they belong with the slower track. The combinatorial roadmap keeps only brief pointers back to that section in its end goals, Lane L/H, acceptance criteria, references, and intro; no substantive reconciliation content remains there.

🤖 Prepared with Claude Code