### PR TITLE
doc: add exchangeability and de Finetti roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ industry groups.
 8. [Effective arithmetic bounds and geometry of numbers](TauCetiRoadmap/EffectiveBounds/README.md)
 9. [Geometric topology and the Kirby-list problems](TauCetiRoadmap/GeometricTopology/README.md)
 10. [One-parameter semigroups, completely monotone functions, and BCR Bochner](TauCetiRoadmap/OneParameterSemigroups/README.md)
+11. [Exchangeability and de Finetti](TauCetiRoadmap/Exchangeability/README.md)
 
 ## How changes are made
 

--- a/TauCetiRoadmap.lean
+++ b/TauCetiRoadmap.lean
@@ -11,3 +11,4 @@ import TauCetiRoadmap.PDE.Targets
 import TauCetiRoadmap.CombinatorialHeegaardFloer.Targets
 import TauCetiRoadmap.HeegaardFloer.Targets
 import TauCetiRoadmap.GeometricTopology.Targets
+import TauCetiRoadmap.Exchangeability.Targets

--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -1,0 +1,598 @@
+# Roadmap: exchangeability and de Finetti
+
+This roadmap adds **de Finetti's theorem about exchangeable sequences** to Tau Ceti, along
+with the prerequisites it rests on: finite-dimensional exchangeability, contractability,
+conditionally i.i.d. sequences, tail σ-algebras for processes, reverse-martingale
+convergence along decreasing filtrations, the Koopman mean-ergodic bridge, and the
+de Finetti–Ryll-Nardzewski equivalence. It builds on Mathlib's substantial probability and
+analysis stack, which provides finite and product measures, kernels, `Measure.bind`,
+conditional expectation, filtrations and martingales, `Lp` spaces, Hilbert-space
+projections, measure-preserving maps, and the mean ergodic theorem, but none of the
+exchangeability theory on top.
+
+The source project
+[`cameronfreer/exchangeability`](https://github.com/cameronfreer/exchangeability)
+formalizes Kallenberg's Theorem 1.1 (in *Probabilistic Symmetries and Invariance
+Principles*) for infinite sequences on standard Borel spaces,
+
+```text
+contractable ↔ exchangeable ↔ conditionally i.i.d.
+```
+
+and carries three complete proof routes: reverse martingales, L² contractability bounds,
+and Koopman / mean ergodic theory. We migrate the mathematics in layers, separating
+general-purpose probability infrastructure from the final exchangeability-specific
+theorem.
+
+Suggested homes:
+
+```text
+TauCeti/Probability/Exchangeability/
+TauCeti/Probability/DeFinetti/
+TauCeti/Probability/Process/
+TauCeti/Probability/Martingale/
+TauCeti/Probability/Ergodic/
+TauCeti/MeasureTheory/Measure/
+```
+
+Migration sources, pinned at
+[`e0532e59ceff23edab44dda9ab0655debbc9cc22`](https://github.com/cameronfreer/exchangeability/tree/e0532e59ceff23edab44dda9ab0655debbc9cc22):
+
+The map below tracks the primary Lean sources. Source README, work-plan, and note files are
+background only.
+
+* Layer 0: `Exchangeability/Core.lean`, `Exchangeability/Contractability.lean`,
+  `Exchangeability/ConditionallyIID.lean`, `Exchangeability/Util/StrictMono.lean`, and
+  `Exchangeability/Util/ProductBounds.lean`.
+* Layer 1: `Exchangeability/Probability/MeasureKernels.lean`,
+  `Exchangeability/Probability/InfiniteProduct.lean`,
+  `Exchangeability/Probability/CondIndep.lean`, the
+  `Exchangeability/Probability/CondIndep/` subtree, and
+  `Exchangeability/DeFinetti/CommonEnding.lean`.
+* Layer 2: `Exchangeability/Tail/*.lean`, `Exchangeability/PathSpace/*.lean`, and
+  `Exchangeability/Probability/SigmaAlgebraHelpers.lean`.
+* Layer 3: `Exchangeability/DeFinetti/ViaL2.lean`,
+  `Exchangeability/DeFinetti/ViaL2/*.lean`, `Exchangeability/DeFinetti/L2Helpers.lean`,
+  `Exchangeability/DeFinetti/TheoremViaL2.lean`,
+  `Exchangeability/Bridge/CesaroToCondExp.lean`,
+  `Exchangeability/Probability/CenteredVariables.lean`,
+  `Exchangeability/Probability/IntegrationHelpers.lean`, and
+  `Exchangeability/Probability/LpNormHelpers.lean`.
+* Layer 4: `Exchangeability/Probability/Martingale.lean`,
+  `Exchangeability/Probability/Martingale/Reverse.lean`,
+  `Exchangeability/Probability/Martingale/Convergence.lean`,
+  `Exchangeability/Probability/Martingale/Crossings/*.lean`, and
+  `Exchangeability/Probability/TimeReversalCrossing.lean`. These source crossing and
+  convergence files are the reverse-direction delta; consume Mathlib for the forward
+  upcrossing and convergence API per the build plan below.
+* Layer 5: `Exchangeability/Ergodic/*.lean` and
+  `Exchangeability/DeFinetti/ViaKoopman.lean`,
+  `Exchangeability/DeFinetti/ViaKoopman/*.lean`, and
+  `Exchangeability/DeFinetti/TheoremViaKoopman.lean`.
+* Layer 6: `Exchangeability/DeFinetti/ViaMartingale.lean`,
+  `Exchangeability/DeFinetti/ViaMartingale/*.lean`,
+  `Exchangeability/DeFinetti/MartingaleHelpers.lean`, and
+  `Exchangeability/DeFinetti/TheoremViaMartingale.lean`.
+* Layer 7: `Exchangeability/DeFinetti/BridgeProperty.lean`,
+  `Exchangeability/DeFinetti/Theorem.lean`, `Exchangeability/DeFinetti.lean`, and top-level
+  `Exchangeability.lean`.
+* Cross-layer helpers: `Exchangeability/Probability/CondExp.lean`,
+  `Exchangeability/Probability/TripleLawDropInfo.lean`, and the
+  `Exchangeability/Probability/TripleLawDropInfo/` subtree. Pull these into whichever Tau
+  Ceti layer first needs the corresponding general-purpose facts.
+
+Credit `cameronfreer/exchangeability` in each ported or adapted file, and record when a
+Tau Ceti file intentionally diverges from this source API.
+
+## The end goal (v1)
+
+For a probability space `(Ω, μ)` and a measurable sequence
+
+```lean
+X : ℕ → Ω → α
+```
+
+with `α` a standard Borel space, prove the de Finetti–Ryll-Nardzewski equivalence:
+
+```lean
+-- the shape we are building toward, once the definitions land in TauCeti:
+-- theorem deFinetti_RyllNardzewski_equivalence
+--     {Ω : Type*} [MeasurableSpace Ω]
+--     {α : Type*} [MeasurableSpace α] [StandardBorelSpace α] [Nonempty α]
+--     {μ : Measure Ω} [IsProbabilityMeasure μ]
+--     (X : ℕ → Ω → α)
+--     (hX_meas : ∀ i, Measurable (X i)) :
+--     Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X
+--
+-- theorem deFinetti
+--     {Ω : Type*} [MeasurableSpace Ω]
+--     {α : Type*} [MeasurableSpace α] [StandardBorelSpace α] [Nonempty α]
+--     {μ : Measure Ω} [IsProbabilityMeasure μ]
+--     (X : ℕ → Ω → α)
+--     (hX_meas : ∀ i, Measurable (X i))
+--     (hX_exch : Exchangeable μ X) :
+--     ConditionallyIID μ X
+```
+
+The standard-Borel hypothesis is on the value space `α`, where the directing measure and
+the conditional distributions live; the sample space `Ω` needs only a measurable structure
+here. If the martingale proof routes the directing measure through `condExpKernel` (or
+through `condDistrib` specialized to an identity-valued kernel with value space `Ω`), it
+may temporarily also require `[StandardBorelSpace Ω]`, which is a constraint of that route
+rather than of the statement.
+
+The default public theorem should eventually use the reverse-martingale proof. The L²
+route remains as a lighter real-valued theorem, and the Koopman route remains as the
+ergodic-theory route with reusable operator-theoretic infrastructure.
+
+## Standing hypotheses
+
+Spell hypotheses out; do not bundle them.
+
+The basic definitions should be as hypothesis-light as possible:
+
+* `Exchangeable μ X`: invariance of finite-dimensional laws under permutations of `Fin n`.
+* `FullyExchangeable μ X`: invariance of the path law under all permutations of `ℕ`.
+* `Contractable μ X`: invariance under strictly increasing finite subsequences.
+* `ConditionallyIID μ X`: existence of a measurable random probability measure whose
+  finite product kernels give the finite-dimensional laws. Pin the directing-measure API
+  before stating it: either `ν : Ω → ProbabilityMeasure α` (with Mathlib's
+  `ProbabilityMeasure.pi`, and `ProbabilityMeasure.toMeasure_pi` / `ProbabilityMeasure.pi_pi`
+  for the bridge to `Measure.pi` and rectangle evaluation), or a raw `ν : Ω → Measure α`
+  together with an explicit `∀ ω, IsProbabilityMeasure (ν ω)` hypothesis. A
+  `ConditionallyIIDWith μ X ν` relation plus an existential wrapper keeps the directing
+  measure nameable in proofs.
+
+The standard-Borel hypotheses belong in the directing-measure construction and final
+de Finetti theorem, not in every elementary definition. Similarly, L² assumptions belong
+only in the L² route, and shift-preservation assumptions belong only in the Koopman /
+ergodic-theory lane.
+
+Index the v1 theorem by `ℕ`. General exchangeability over other countable index types,
+exchangeable arrays, Aldous–Hoover, Markov exchangeability, and finite de Finetti bounds
+are long-horizon generalizations, not prerequisites for v1.
+
+## What Mathlib already has (consume)
+
+* **Finite products and path laws:** `Measure.map`, finite product measurable spaces,
+  `Measure.pi`, and product-measure API.
+* **π-system uniqueness:** measure extension / uniqueness from a generating π-system,
+  used to prove that finite-dimensional marginals determine laws on sequence space.
+* **Kernels and bind:** `Kernel`, `Measure.bind`, and the Giry-style measure API needed
+  for mixtures of finite product measures.
+* **Conditional expectation:** `μ[f | m]`, tower properties, `condExpL2`, and
+  conditional-expectation estimates.
+* **Filtrations and martingales:** `Filtration`, martingales, submartingales, and the
+  available upcrossing machinery.
+* **`Lp` and Hilbert-space machinery:** `MemLp`, `Lp`, orthogonal projections, symmetric
+  idempotents, and conditional expectation as an `L²` projection.
+* **Ergodic and operator theory:** measure-preserving maps, composition with a
+  measure-preserving map on `Lp`, and the mean ergodic theorem for suitable continuous
+  linear maps.
+
+Consume these directly rather than re-proving Mathlib's product-measure,
+conditional-expectation, Hilbert-space, or mean-ergodic infrastructure.
+
+## What is missing (build here)
+
+The missing pieces are:
+
+* finite-dimensional exchangeability and full exchangeability for sequence laws;
+* contractability and the proof `Exchangeable → Contractable`;
+* finite-dimensional marginal uniqueness on `ℕ → α`;
+* product-kernel measurability for random finite product measures;
+* the common de Finetti ending turning a directing-measure bridge into `ConditionallyIID`;
+* process-relative tail σ-algebras and their antitone filtration structure;
+* reverse martingale convergence for conditional expectations along decreasing filtrations;
+* Koopman operators and the identification of the mean-ergodic projection with conditional
+  expectation onto the invariant σ-algebra;
+* the L², Koopman, and reverse-martingale proof routes for de Finetti.
+
+State the general infrastructure at full generality: reverse martingales for arbitrary
+decreasing filtrations, and Koopman machinery for arbitrary measure-preserving
+transformations, before specializing to path-space shifts.
+
+---
+
+## The build, in layers
+
+The ordering below is the dependency order. As each layer makes the next layer's *types*
+expressible in `TauCeti/`, state its milestones in `Targets.lean` with `sorry`.
+
+### Layer 0: core exchangeability and finite marginals
+
+Suggested home:
+
+```text
+TauCeti/Probability/Exchangeability/Basic.lean
+TauCeti/Probability/Exchangeability/Contractability.lean
+TauCeti/Probability/Exchangeability/FullyExchangeable.lean
+```
+
+Build:
+
+* `Exchangeable μ X`;
+* `FullyExchangeable μ X`;
+* `ExchangeableAt μ X n`;
+* `Contractable μ X`;
+* `pathLaw μ X`;
+* prefix projections and prefix cylinders;
+* finite-dimensional marginal uniqueness for laws on `ℕ → α`;
+* finite approximation of infinite permutations;
+* extension of strictly monotone finite selections to finite permutations.
+
+Key milestones:
+
+```lean
+measure_eq_of_fin_marginals_eq
+measure_eq_of_fin_marginals_eq_prob
+exchangeable_iff_fullyExchangeable
+exists_perm_extending_strictMono
+contractable_of_exchangeable
+Contractable.map_single
+Contractable.map_pair
+Contractable.comp
+```
+
+⚠ **API warning.** Do not define exchangeability as a property of a measure on path space
+only, or as a property of a process only, without bridges. Both viewpoints are useful:
+the process-level statements are what users want, while the path-law statements make
+π-system and shift arguments cleaner.
+
+### Layer 1: product kernels and the common ending
+
+Suggested home:
+
+```text
+TauCeti/MeasureTheory/Measure/ProductKernel.lean
+TauCeti/Probability/DeFinetti/CommonEnding.lean
+```
+
+Build general product-kernel infrastructure:
+
+* measurable rectangles form a π-system;
+* measurable rectangles generate the finite product σ-algebra;
+* measurability of `ω ↦ Measure.pi fun _ : Fin m => ν ω`;
+* the AE-measurable version needed for `Measure.bind_apply`;
+* rectangle evaluation for finite product measures;
+* equality of finite measures from agreement on rectangles.
+
+Then build the common de Finetti ending:
+
+```lean
+conditional_iid_from_directing_measure
+```
+
+The intended bridge hypothesis is an indicator-product factorization: for every finite
+injective selection `k : Fin m → ℕ` and measurable rectangle `B`, the law of
+`(X (k i))ᵢ` equals the mixture of product measures induced by `ν`.
+
+This layer is shared by the L² and Koopman routes, and also useful for the martingale
+route's final finite-product step.
+
+### Layer 2: tail σ-algebras and path-space shift
+
+Suggested home:
+
+```text
+TauCeti/Probability/Process/Tail.lean
+TauCeti/Probability/PathSpace/Shift.lean
+TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
+```
+
+Build process-relative tails:
+
+```lean
+tailFamily X n
+tailProcess X
+tailFamily_antitone
+tailProcess_le_tailFamily
+tailProcess_le_ambient
+tailProcess_eq_iInf_revFiltration
+```
+
+Build path-space shift:
+
+```lean
+shift : (ℕ → α) → (ℕ → α)
+shift_measurable
+shift_iterate_measurable
+```
+
+Build shift-invariant σ-algebras:
+
+```lean
+isShiftInvariant
+shiftInvariantSigma
+shiftInvariantSigma_le
+mem_shiftInvariantSigma_iff
+shiftInvariantSigma_measurable_shift_eq
+shiftInvariant_implies_shiftInvariantMeasurable
+```
+
+⚠ **Tail vs invariant σ-algebra.** Do not silently identify the tail σ-algebra with the
+shift-invariant σ-algebra. For one-sided sequences, the relationship runs through
+invariance, almost invariance, and completions. State exactly the theorem each proof
+route needs.
+
+### Layer 3: the L² contractability proof
+
+Suggested home:
+
+```text
+TauCeti/Probability/Exchangeability/L2/Covariance.lean
+TauCeti/Probability/Exchangeability/L2/BlockAverages.lean
+TauCeti/Probability/DeFinetti/ViaL2.lean
+```
+
+This is the first proof route to port after the shared layers. It is real-valued and
+requires L² assumptions.
+
+Build:
+
+* equality of means and integrals from equal one-dimensional laws;
+* equality of pair covariances from equal two-dimensional laws;
+* the uniform covariance structure of a contractable L² sequence;
+* two-window L² bounds for block averages;
+* long-average versus tail-average bounds;
+* L¹ convergence of weighted block averages;
+* the directing-measure bridge;
+* the call to `conditional_iid_from_directing_measure`.
+
+Key milestones:
+
+```lean
+contractable_covariance_structure
+l2_bound_two_windows_uniform
+l2_bound_long_vs_tail
+weighted_sums_converge_L1
+directing_measure_satisfies_requirements
+conditionallyIID_of_contractable_viaL2
+deFinetti_viaL2
+deFinetti_RyllNardzewski_equivalence_viaL2
+```
+
+The final route should make clear that it proves a real-valued L² theorem, not the full
+standard-Borel theorem.
+
+### Layer 4: reverse martingales and Lévy downward theorem
+
+Suggested home:
+
+```text
+TauCeti/Probability/Martingale/Reverse.lean
+TauCeti/Probability/Martingale/AntitoneUpcrossing.lean
+TauCeti/Probability/Martingale/LevyDownward.lean
+```
+
+Mathlib already provides the upcrossing API (`upcrossingsBefore`, `upcrossings`, and the
+submartingale upcrossing bound in `Mathlib/Probability/Martingale/Upcrossing.lean`) and the
+forward, upward convergence theorems (`Submartingale.ae_tendsto_limitProcess` and
+`tendsto_ae_condExp` in `Mathlib/Probability/Martingale/Convergence.lean`). What it does not
+have is the downward theorem along an antitone filtration. Consume the former, and build
+only the reversal, the antitone adapter, and the `⨅ n, 𝔽 n` identification:
+
+1. **Finite-horizon reversal.**
+
+   ```lean
+   revFiltration
+   revCEFinite
+   revCEFinite_martingale
+   ```
+
+   For an antitone filtration `𝔽 : ℕ → MeasurableSpace Ω`, the finite-horizon reversal
+   `n ↦ 𝔽 (N - n)` is an ordinary filtration, and the reversed conditional expectations
+   form a martingale by the tower property.
+
+2. **Antitone adapter for the upcrossing bound.**
+
+   ```lean
+   upcrossings_bdd_uniform
+   ```
+
+   Apply Mathlib's upcrossing bound to the reversed finite-horizon martingale to get a
+   uniform crossing bound for the antitone sequence `n ↦ μ[f | 𝔽 n]`. The crossing counts
+   are Mathlib's; only this adapter is new.
+
+3. **Existence and identification of the limit.**
+
+   ```lean
+   condExp_exists_ae_limit_antitone
+   ae_limit_is_condexp_iInf
+   condExp_tendsto_iInf
+   ```
+
+Target theorem:
+
+```lean
+theorem condExp_tendsto_iInf
+    [IsProbabilityMeasure μ]
+    {𝔽 : ℕ → MeasurableSpace Ω}
+    (h_filtration : Antitone 𝔽)
+    (h_le : ∀ n, 𝔽 n ≤ (inferInstance : MeasurableSpace Ω))
+    (f : Ω → ℝ)
+    (h_f_int : Integrable f μ) :
+    ∀ᵐ ω ∂μ,
+      Tendsto
+        (fun n => μ[f | 𝔽 n] ω)
+        atTop
+        (𝓝 (μ[f | ⨅ n, 𝔽 n] ω))
+```
+
+This theorem should be independent of exchangeability and later consumed by the martingale
+proof.
+
+### Layer 5: Koopman and mean ergodic machinery
+
+Suggested home:
+
+```text
+TauCeti/Probability/Ergodic/Koopman.lean
+TauCeti/Probability/Ergodic/InvariantSigma.lean
+TauCeti/Probability/DeFinetti/ViaKoopman.lean
+```
+
+Build the generic operator-theoretic lane first:
+
+```lean
+koopman
+koopman_isometry
+fixedSpace
+metProjection
+birkhoffAverage_tendsto_metProjection
+```
+
+Then specialize to path-space shift and identify the projection:
+
+```lean
+fixedSubspace
+metProjectionShift
+condexpL2
+koopman_eq_self_of_shiftInvariant
+aestronglyMeasurable_shiftInvariant_of_koopman
+lpMeas_eq_fixedSubspace
+proj_eq_condexp
+metProjectionShift_tendsto
+```
+
+Finally build the exchangeability-specific bridge:
+
+```lean
+pathSpace_contractable_of_contractable
+measure_map_shift_eq_of_contractable
+pathSpace_shift_preserving_of_contractable
+conditionallyIID_transfer
+conditionallyIID_bind_of_contractable
+deFinetti_viaKoopman
+```
+
+⚠ **Warning.** The mean ergodic theorem gives convergence to an orthogonal projection, and
+the probabilistic statement still needs that projection identified with conditional
+expectation onto the invariant σ-algebra. That identification is a separate theorem, not a
+simp step.
+
+### Layer 6: the martingale proof of de Finetti
+
+Suggested home:
+
+```text
+TauCeti/Probability/DeFinetti/ViaMartingale/ContractionIndependence.lean
+TauCeti/Probability/DeFinetti/ViaMartingale/FutureFiltration.lean
+TauCeti/Probability/DeFinetti/ViaMartingale/DirectingMeasure.lean
+TauCeti/Probability/DeFinetti/ViaMartingale/FiniteProduct.lean
+TauCeti/Probability/DeFinetti/ViaMartingale.lean
+TauCeti/Probability/DeFinetti/Theorem.lean
+```
+
+Build:
+
+* Kallenberg's contraction-independence lemma;
+* future filtrations and their relation to `tailProcess X`;
+* conditional-law convergence by `condExp_tendsto_iInf`;
+* the directing measure from tail conditional laws;
+* finite-product factorization;
+* the final theorem wrappers.
+
+Key milestones:
+
+```lean
+conditionallyIID_of_contractable
+deFinetti
+deFinetti_equivalence
+deFinetti_RyllNardzewski_equivalence
+```
+
+This is the default route for the final public API.
+
+### Layer 7: public API and examples
+
+Suggested home:
+
+```text
+TauCeti/Probability/Exchangeability.lean
+TauCeti/Probability/DeFinetti.lean
+TauCeti/Examples/Probability/DeFinetti.lean
+```
+
+Expose:
+
+```lean
+Exchangeable
+FullyExchangeable
+Contractable
+ConditionallyIID
+
+exchangeable_iff_fullyExchangeable
+contractable_of_exchangeable
+exchangeable_of_conditionallyIID
+
+conditionallyIID_of_contractable
+deFinetti
+deFinetti_equivalence
+deFinetti_RyllNardzewski_equivalence
+
+deFinetti_viaL2
+deFinetti_viaKoopman
+```
+
+Route-specific theorem names should keep their suffixes. The unsuffixed theorem should be
+the general martingale route.
+
+### Long horizon
+
+After v1:
+
+* finite de Finetti bounds;
+* de Finetti for other countable index types;
+* exchangeable arrays and Aldous–Hoover;
+* Markov exchangeability;
+* ergodic decomposition of exchangeable laws;
+* Mathlib extraction of general infrastructure.
+
+These are not prerequisites for the v1 theorem.
+
+## Worked examples
+
+Discharge these alongside the layers; they are checks against vacuous definitions.
+
+* A conditionally i.i.d. sequence is exchangeable.
+* An exchangeable sequence is contractable.
+* Finite-dimensional marginals determine a probability measure on `ℕ → α`.
+* The tail-family of a process is antitone.
+* Lévy downward theorem for an eventually constant decreasing filtration.
+* Koopman projection equals conditional expectation for the trivial shift.
+* The L² theorem applies to a bounded real-valued exchangeable sequence.
+* The default `deFinetti` theorem applies to a standard-Borel exchangeable sequence.
+
+## Ordering
+
+Layer 0 first: all proof routes need the core definitions and finite-marginal uniqueness.
+Layer 1 next: product kernels and the common ending are shared by the proof routes.
+Layer 2 next: tails and shifts are needed by the martingale and Koopman routes.
+
+After that, the L² route can land first because it validates the common ending with the
+least global infrastructure. Reverse martingales and Koopman can proceed in parallel as
+general infrastructure. The martingale de Finetti proof comes after reverse martingales
+and becomes the default public theorem.
+
+## References
+
+* Olav Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Springer, 2005,
+  Chapter 1, Theorem 1.1.
+* David Aldous, *Exchangeability and related topics*, École d'Été de Probabilités de
+  Saint-Flour XIII, 1983.
+* Bruno de Finetti, "La prévision : ses lois logiques, ses sources subjectives", 1937.
+* Czesław Ryll-Nardzewski, "On stationary sequences of random variables and the de
+  Finetti's equivalence", 1957.
+* Edwin Hewitt and Leonard Savage, "Symmetric measures on Cartesian products", 1955.
+* Cameron Freer, *Three Roads to de Finetti's Theorem in Lean* (short paper),
+  [ITP 2026](https://itp-conference-2026.github.io/program.html).
+* `cameronfreer/exchangeability`, Lean 4 formalization of exchangeability and de Finetti.
+
+## Acknowledgements
+
+This roadmap is based on Cameron Freer's `exchangeability` formalization. It also benefits
+from the anonymous reviewers of Cameron Freer, *Three Roads to de Finetti's Theorem in
+Lean* (short paper), whose feedback helped golf and simplify the library and make fuller
+use of Mathlib. Ported files should preserve source attribution and document any
+substantial API changes made during migration to Tau Ceti.

--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -1,28 +1,29 @@
 # Roadmap: exchangeability and de Finetti
 
-This roadmap adds **de Finetti's theorem about exchangeable sequences** to Tau Ceti, along
-with the prerequisites it rests on: finite-dimensional exchangeability, contractability,
-conditionally i.i.d. sequences, tail σ-algebras for processes, reverse-martingale
-convergence along decreasing filtrations, the Koopman mean-ergodic bridge, and the
-de Finetti–Ryll-Nardzewski equivalence. It builds on Mathlib's substantial probability and
-analysis stack, which provides finite and product measures, kernels, `Measure.bind`,
-conditional expectation, filtrations and martingales, `Lp` spaces, Hilbert-space
-projections, measure-preserving maps, and the mean ergodic theorem, but none of the
-exchangeability theory on top.
+Exchangeability is the first large probability-symmetry theory missing from Mathlib:
+finite-dimensional laws invariant under permutations, spreadability/contractability, tail
+σ-algebras for processes, random directing measures, and the conditional-product
+representation of invariant laws. Mathlib supplies the ambient stack this rests on: finite
+and product measures, kernels, `Measure.bind`, conditional expectation, filtrations and
+martingales, `Lp` spaces, Hilbert-space projections, measure-preserving maps, and the mean
+ergodic theorem. It does not, however, carry the exchangeability theory on top.
 
-The source project
-[`cameronfreer/exchangeability`](https://github.com/cameronfreer/exchangeability)
-formalizes Kallenberg's Theorem 1.1 (in *Probabilistic Symmetries and Invariance
-Principles*) for infinite sequences on standard Borel spaces,
+The first summit is the de Finetti–Ryll-Nardzewski theorem for sequences on a standard
+Borel space:
 
 ```text
 contractable ↔ exchangeable ↔ conditionally i.i.d.
 ```
 
-and carries three complete proof routes: reverse martingales, L² contractability bounds,
-and Koopman / mean ergodic theory. We migrate the mathematics in layers, separating
-general-purpose probability infrastructure from the final exchangeability-specific
-theorem.
+It has three classical proof routes: reverse martingales, L² contractability bounds, and
+Koopman / mean ergodic theory. This roadmap builds the reusable probability-symmetry
+library those routes need, in dependency order, with de Finetti as its first summit theorem.
+
+A completed Lean formalization exists in
+[`cameronfreer/exchangeability`](https://github.com/cameronfreer/exchangeability); it is a
+migration source and API-warning map (see [Migration source](#migration-source)), not the
+specification. The specification here is Kallenberg's theorem and the reusable library
+needed to state and prove it.
 
 Suggested homes:
 
@@ -34,55 +35,6 @@ TauCeti/Probability/Martingale/
 TauCeti/Probability/Ergodic/
 TauCeti/MeasureTheory/Measure/
 ```
-
-Migration sources, pinned at
-[`e0532e59ceff23edab44dda9ab0655debbc9cc22`](https://github.com/cameronfreer/exchangeability/tree/e0532e59ceff23edab44dda9ab0655debbc9cc22):
-
-The map below tracks the primary Lean sources. Source README, work-plan, and note files are
-background only.
-
-* Layer 0: `Exchangeability/Core.lean`, `Exchangeability/Contractability.lean`,
-  `Exchangeability/ConditionallyIID.lean`, `Exchangeability/Util/StrictMono.lean`, and
-  `Exchangeability/Util/ProductBounds.lean`.
-* Layer 1: `Exchangeability/Probability/MeasureKernels.lean`,
-  `Exchangeability/Probability/InfiniteProduct.lean`,
-  `Exchangeability/Probability/CondIndep.lean`, the
-  `Exchangeability/Probability/CondIndep/` subtree, and
-  `Exchangeability/DeFinetti/CommonEnding.lean`.
-* Layer 2: `Exchangeability/Tail/*.lean`, `Exchangeability/PathSpace/*.lean`, and
-  `Exchangeability/Probability/SigmaAlgebraHelpers.lean`.
-* Layer 3: `Exchangeability/DeFinetti/ViaL2.lean`,
-  `Exchangeability/DeFinetti/ViaL2/*.lean`, `Exchangeability/DeFinetti/L2Helpers.lean`,
-  `Exchangeability/DeFinetti/TheoremViaL2.lean`,
-  `Exchangeability/Bridge/CesaroToCondExp.lean`,
-  `Exchangeability/Probability/CenteredVariables.lean`,
-  `Exchangeability/Probability/IntegrationHelpers.lean`, and
-  `Exchangeability/Probability/LpNormHelpers.lean`.
-* Layer 4: `Exchangeability/Probability/Martingale.lean`,
-  `Exchangeability/Probability/Martingale/Reverse.lean`,
-  `Exchangeability/Probability/Martingale/Convergence.lean`,
-  `Exchangeability/Probability/Martingale/Crossings/*.lean`, and
-  `Exchangeability/Probability/TimeReversalCrossing.lean`. These source crossing and
-  convergence files are the reverse-direction delta; consume Mathlib for the forward
-  upcrossing and convergence API per the build plan below.
-* Layer 5: `Exchangeability/Ergodic/*.lean` and
-  `Exchangeability/DeFinetti/ViaKoopman.lean`,
-  `Exchangeability/DeFinetti/ViaKoopman/*.lean`, and
-  `Exchangeability/DeFinetti/TheoremViaKoopman.lean`.
-* Layer 6: `Exchangeability/DeFinetti/ViaMartingale.lean`,
-  `Exchangeability/DeFinetti/ViaMartingale/*.lean`,
-  `Exchangeability/DeFinetti/MartingaleHelpers.lean`, and
-  `Exchangeability/DeFinetti/TheoremViaMartingale.lean`.
-* Layer 7: `Exchangeability/DeFinetti/BridgeProperty.lean`,
-  `Exchangeability/DeFinetti/Theorem.lean`, `Exchangeability/DeFinetti.lean`, and top-level
-  `Exchangeability.lean`.
-* Cross-layer helpers: `Exchangeability/Probability/CondExp.lean`,
-  `Exchangeability/Probability/TripleLawDropInfo.lean`, and the
-  `Exchangeability/Probability/TripleLawDropInfo/` subtree. Pull these into whichever Tau
-  Ceti layer first needs the corresponding general-purpose facts.
-
-Credit `cameronfreer/exchangeability` in each ported or adapted file, and record when a
-Tau Ceti file intentionally diverges from this source API.
 
 ## The end goal (v1)
 
@@ -115,15 +67,36 @@ with `α` a standard Borel space, prove the de Finetti–Ryll-Nardzewski equival
 ```
 
 The standard-Borel hypothesis is on the value space `α`, where the directing measure and
-the conditional distributions live; the sample space `Ω` needs only a measurable structure
-here. If the martingale proof routes the directing measure through `condExpKernel` (or
-through `condDistrib` specialized to an identity-valued kernel with value space `Ω`), it
-may temporarily also require `[StandardBorelSpace Ω]`, which is a constraint of that route
-rather than of the statement.
+the conditional distributions live; the public statement keeps `Ω` with only a measurable
+structure. Build the tail-conditional path law via `condDistrib` on `ℕ → α` (standard Borel
+because `α` is), which needs standard Borel only on its codomain; the directing measure is
+the one-coordinate conditional law extracted from that conditional path law, with the product
+factorization proved separately. An extra `[StandardBorelSpace Ω]` would arise only from
+`condExpKernel` (or `condDistrib` specialized to an identity-valued kernel with value space
+`Ω`); such a hypothesis is internal to that route and does not appear in the public
+statement.
 
 The default public theorem should eventually use the reverse-martingale proof. The L²
 route remains as a lighter real-valued theorem, and the Koopman route remains as the
 ergodic-theory route with reusable operator-theoretic infrastructure.
+
+## The library spine
+
+The deliverable is a reusable probability-symmetry library, not just a proof script for one
+theorem. The de Finetti–Ryll-Nardzewski theorem is the summit of this spine, not its only
+output. The spine is:
+
+1. sequence laws and finite-dimensional marginals;
+2. exchangeability, full exchangeability, spreadability/contractability, and the bridges
+   between the process-level and path-law formulations;
+3. product kernels and mixtures of finite product measures;
+4. conditional independence and conditionally i.i.d. APIs;
+5. process-relative tail σ-algebras and path-space shifts;
+6. reverse martingales for arbitrary decreasing filtrations;
+7. Koopman operators and invariant σ-algebras for arbitrary measure-preserving maps.
+
+Each item is worth building for its own sake, so that a later probability-symmetry roadmap
+(exchangeable arrays, Markov exchangeability, ergodic decomposition) can consume it directly.
 
 ## Standing hypotheses
 
@@ -192,6 +165,62 @@ State the general infrastructure at full generality: reverse martingales for arb
 decreasing filtrations, and Koopman machinery for arbitrary measure-preserving
 transformations, before specializing to path-space shifts.
 
+## Migration source
+
+A completed Lean formalization of this theory exists at
+[`cameronfreer/exchangeability`](https://github.com/cameronfreer/exchangeability), pinned at
+[`e0532e59ceff23edab44dda9ab0655debbc9cc22`](https://github.com/cameronfreer/exchangeability/tree/e0532e59ceff23edab44dda9ab0655debbc9cc22).
+Use it as a source of sorry-free proof scripts to migrate or adapt, a declaration map for
+the three proof routes, an API-warning source (where a local definition was convenient but
+should be generalized for Tau Ceti), and an attribution source for ported files. It is
+**not** the mathematical specification: the specification is the standalone library above,
+with Kallenberg, Aldous, Hewitt–Savage, and Ryll-Nardzewski as references. The map below is
+"where to look", not "what is correct"; judge each milestone on its own terms. Source
+README, work-plan, and note files are background only.
+
+* Layer 0: `Exchangeability/Core.lean`, `Exchangeability/Contractability.lean`,
+  `Exchangeability/ConditionallyIID.lean`, `Exchangeability/Util/StrictMono.lean`, and
+  `Exchangeability/Util/ProductBounds.lean`.
+* Layer 1: `Exchangeability/Probability/MeasureKernels.lean`,
+  `Exchangeability/Probability/InfiniteProduct.lean`,
+  `Exchangeability/Probability/CondIndep.lean`, the
+  `Exchangeability/Probability/CondIndep/` subtree, and
+  `Exchangeability/DeFinetti/CommonEnding.lean`.
+* Layer 2: `Exchangeability/Tail/*.lean`, `Exchangeability/PathSpace/*.lean`, and
+  `Exchangeability/Probability/SigmaAlgebraHelpers.lean`.
+* Layer 3: `Exchangeability/DeFinetti/ViaL2.lean`,
+  `Exchangeability/DeFinetti/ViaL2/*.lean`, `Exchangeability/DeFinetti/L2Helpers.lean`,
+  `Exchangeability/DeFinetti/TheoremViaL2.lean`,
+  `Exchangeability/Bridge/CesaroToCondExp.lean`,
+  `Exchangeability/Probability/CenteredVariables.lean`,
+  `Exchangeability/Probability/IntegrationHelpers.lean`, and
+  `Exchangeability/Probability/LpNormHelpers.lean`.
+* Layer 4: `Exchangeability/Probability/Martingale.lean`,
+  `Exchangeability/Probability/Martingale/Reverse.lean`,
+  `Exchangeability/Probability/Martingale/Convergence.lean`,
+  `Exchangeability/Probability/Martingale/Crossings/*.lean`, and
+  `Exchangeability/Probability/TimeReversalCrossing.lean`. These source crossing and
+  convergence files are the reverse-direction delta; consume Mathlib for the forward
+  upcrossing and convergence API per the build plan below.
+* Layer 5: `Exchangeability/Ergodic/*.lean` and
+  `Exchangeability/DeFinetti/ViaKoopman.lean`,
+  `Exchangeability/DeFinetti/ViaKoopman/*.lean`, and
+  `Exchangeability/DeFinetti/TheoremViaKoopman.lean`.
+* Layer 6: `Exchangeability/DeFinetti/ViaMartingale.lean`,
+  `Exchangeability/DeFinetti/ViaMartingale/*.lean`,
+  `Exchangeability/DeFinetti/MartingaleHelpers.lean`, and
+  `Exchangeability/DeFinetti/TheoremViaMartingale.lean`.
+* Layer 7: `Exchangeability/DeFinetti/BridgeProperty.lean`,
+  `Exchangeability/DeFinetti/Theorem.lean`, `Exchangeability/DeFinetti.lean`, and top-level
+  `Exchangeability.lean`.
+* Cross-layer helpers: `Exchangeability/Probability/CondExp.lean`,
+  `Exchangeability/Probability/TripleLawDropInfo.lean`, and the
+  `Exchangeability/Probability/TripleLawDropInfo/` subtree. Pull these into whichever Tau
+  Ceti layer first needs the corresponding general-purpose facts.
+
+Credit `cameronfreer/exchangeability` in each ported or adapted file, and record when a
+Tau Ceti file intentionally diverges from this source API.
+
 ---
 
 ## The build, in layers
@@ -199,7 +228,7 @@ transformations, before specializing to path-space shifts.
 The ordering below is the dependency order. As each layer makes the next layer's *types*
 expressible in `TauCeti/`, state its milestones in `Targets.lean` with `sorry`.
 
-### Layer 0: core exchangeability and finite marginals
+### Layer 0: sequence laws, finite marginals, and symmetry notions
 
 Suggested home:
 
@@ -221,6 +250,10 @@ Build:
 * finite approximation of infinite permutations;
 * extension of strictly monotone finite selections to finite permutations.
 
+`Contractable` (invariance under strictly increasing finite subsequences) is the first
+formal target for this spreadability notion; `Spreadable` is the standard synonym, mentioned
+for orientation. The roadmap commits to the single `Contractable` API, not two parallel ones.
+
 Key milestones:
 
 ```lean
@@ -239,7 +272,7 @@ only, or as a property of a process only, without bridges. Both viewpoints are u
 the process-level statements are what users want, while the path-law statements make
 π-system and shift arguments cleaner.
 
-### Layer 1: product kernels and the common ending
+### Layer 1: product kernels, conditional independence, and mixtures
 
 Suggested home:
 
@@ -270,7 +303,7 @@ injective selection `k : Fin m → ℕ` and measurable rectangle `B`, the law of
 This layer is shared by the L² and Koopman routes, and also useful for the martingale
 route's final finite-product step.
 
-### Layer 2: tail σ-algebras and path-space shift
+### Layer 2: process tails and path-space dynamics
 
 Suggested home:
 
@@ -315,7 +348,7 @@ shift-invariant σ-algebra. For one-sided sequences, the relationship runs throu
 invariance, almost invariance, and completions. State exactly the theorem each proof
 route needs.
 
-### Layer 3: the L² contractability proof
+### Layer 3: L² averaging library and real-valued de Finetti
 
 Suggested home:
 
@@ -355,7 +388,7 @@ deFinetti_RyllNardzewski_equivalence_viaL2
 The final route should make clear that it proves a real-valued L² theorem, not the full
 standard-Borel theorem.
 
-### Layer 4: reverse martingales and Lévy downward theorem
+### Layer 4: reverse martingales and conditional-expectation limits
 
 Suggested home:
 
@@ -420,9 +453,11 @@ theorem condExp_tendsto_iInf
 ```
 
 This theorem should be independent of exchangeability and later consumed by the martingale
-proof.
+proof. The L¹ and Lᵖ convergence forms (for `f ∈ L¹` / `Lᵖ`, using Mathlib's
+uniform-integrability and eLp-norm conditional-expectation tools) are follow-up Layer 4
+targets; the L¹ form is what most uses want.
 
-### Layer 5: Koopman and mean ergodic machinery
+### Layer 5: Koopman operators and invariant σ-algebras
 
 Suggested home:
 
@@ -471,7 +506,7 @@ the probabilistic statement still needs that projection identified with conditio
 expectation onto the invariant σ-algebra. That identification is a separate theorem, not a
 simp step.
 
-### Layer 6: the martingale proof of de Finetti
+### Layer 6: directing measures and de Finetti representation
 
 Suggested home:
 
@@ -549,20 +584,38 @@ After v1:
 * ergodic decomposition of exchangeable laws;
 * Mathlib extraction of general infrastructure.
 
+Optional extensions of the core theory, valuable but not part of v1:
+
+* the empirical-measure and mixture forms of de Finetti (the law-of-large-numbers form
+  `(1/n) Σ_{i<n} δ_{Xᵢ} ⇒ ν` in `P(α)`, and `pathLaw X = ∫ p^{⊗ℕ} dπ(p)` with `π` unique on
+  `P(α)`);
+* the Hewitt–Savage zero-one law (triviality of the symmetric σ-algebra for i.i.d.
+  sequences) and the extreme-point / ergodic-decomposition corollary;
+* the full Koopman Markov-operator API (positive, unital, multiplicative on `L^∞`);
+* the detailed directing-measure API: a.e. uniqueness, measurability with respect to the
+  tail/exchangeable σ-algebra, and the conditional-factorization identity
+  `E[∏_j f_j(X_{i_j}) | σ(ν)] = ∏_j ∫ f_j dν`;
+* a boundary worked example marking the limits of the theory: a stationary-not-exchangeable
+  two-state Markov chain (`P(0→0) = P(1→1) = q`, `0 < q < 1`, `q ≠ ½`).
+
 These are not prerequisites for the v1 theorem.
 
 ## Worked examples
 
-Discharge these alongside the layers; they are checks against vacuous definitions.
+Discharge these alongside the layers; they check that the API describes real probability
+objects, not just the final theorem.
 
-* A conditionally i.i.d. sequence is exchangeable.
-* An exchangeable sequence is contractable.
-* Finite-dimensional marginals determine a probability measure on `ℕ → α`.
+* The law of an i.i.d. sequence is `ConditionallyIID`, `Exchangeable`, and `Contractable`.
+* A mixture of i.i.d. `Bool`-valued laws, parameterized by a random `θ`, is exchangeable,
+  with `ω ↦ κ (θ ω)` (`κ` a two-point kernel) as the directing measure. The directing
+  measure is the random probability measure induced by `θ`, not `θ` itself; phrasing it via
+  the two-point kernel keeps the example independent of a mature `Bernoulli` API.
+* Finite-dimensional prefix marginals determine a probability measure on `ℕ → α`.
+* Full exchangeability of a path law implies shift-preservation.
 * The tail-family of a process is antitone.
-* Lévy downward theorem for an eventually constant decreasing filtration.
-* Koopman projection equals conditional expectation for the trivial shift.
-* The L² theorem applies to a bounded real-valued exchangeable sequence.
-* The default `deFinetti` theorem applies to a standard-Borel exchangeable sequence.
+* The Lévy downward theorem specializes correctly to an eventually constant decreasing
+  filtration (a test of `condExp_tendsto_iInf`, not a de Finetti example).
+* In the real-valued L² lane, bounded observables give `MemLp 2` automatically.
 
 ## Ordering
 
@@ -591,7 +644,8 @@ and becomes the default public theorem.
 
 ## Acknowledgements
 
-This roadmap is based on Cameron Freer's `exchangeability` formalization. It also benefits
+This roadmap uses Cameron Freer's `exchangeability` formalization as its primary migration
+source. It also benefits
 from the anonymous reviewers of Cameron Freer, *Three Roads to de Finetti's Theorem in
 Lean* (short paper), whose feedback helped golf and simplify the library and make fuller
 use of Mathlib. Ported files should preserve source attribution and document any

--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -130,9 +130,14 @@ roadmap.
 ## What Mathlib already has (consume)
 
 * **Finite products and path laws:** `Measure.map`, finite product measurable spaces,
-  `Measure.pi`, and product-measure API.
-* **π-system uniqueness:** measure extension / uniqueness from a generating π-system,
-  used to prove that finite-dimensional marginals determine laws on sequence space.
+  `Measure.pi` (`Measure.pi_eq`, `Measure.pi_pi`), and the cylinder/rectangle API:
+  `generateFrom_pi`, `isPiSystem_pi`, `MeasureTheory.squareCylinders`,
+  `isPiSystem_squareCylinders`, and `generateFrom_squareCylinders`.
+* **Finite-dimensional laws determine the law** (general index, finite measures):
+  `ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq` and
+  `identDistrib_iff_forall_finset_identDistrib`
+  (`Mathlib/Probability/Process/FiniteDimensionalLaws.lean`). Tau Ceti only adds the
+  `pathLaw` / `Fin n`-prefix wrappers, not this core fact.
 * **Kernels and bind:** `Kernel`, `Measure.bind`, and the Giry-style measure API needed
   for mixtures of finite product measures.
 * **Conditional expectation:** `μ[f | m]`, tower properties, `condExpL2`, and
@@ -154,7 +159,8 @@ The missing pieces are:
 
 * finite-dimensional exchangeability and full exchangeability for sequence laws;
 * contractability and the proof `Exchangeable → Contractable`;
-* finite-dimensional marginal uniqueness on `ℕ → α`;
+* the `pathLaw` / `Fin n`-prefix wrappers over Mathlib's general finite-dimensional-law
+  uniqueness (the core theorem is Mathlib's, cited above);
 * product-kernel measurability for random finite product measures;
 * the common de Finetti ending turning a directing-measure bridge into `ConditionallyIID`;
 * process-relative tail σ-algebras and their antitone filtration structure;
@@ -248,7 +254,8 @@ Build:
 * `Contractable μ X`;
 * `pathLaw μ X`;
 * prefix projections and prefix cylinders;
-* finite-dimensional marginal uniqueness for laws on `ℕ → α`;
+* `pathLaw` / `Fin n`-prefix wrappers over Mathlib's finite-dimensional-law uniqueness
+  (`ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq`);
 * finite approximation of infinite permutations;
 * extension of strictly monotone finite selections to finite permutations.
 
@@ -268,6 +275,10 @@ Contractable.map_single
 Contractable.map_pair
 Contractable.comp
 ```
+
+Mathlib's `ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq` already proves that
+finite-dimensional laws determine the law (for any index); `measure_eq_of_fin_marginals_eq`
+and its probability variant are the `ℕ`-prefix wrappers over it, not new measure theory.
 
 Also build the implication lattice and the alternate characterizations as named API:
 
@@ -300,14 +311,15 @@ TauCeti/MeasureTheory/Measure/ProductKernel.lean
 TauCeti/Probability/DeFinetti/CommonEnding.lean
 ```
 
-Build general product-kernel infrastructure:
+Consume Mathlib's product/cylinder infrastructure — `generateFrom_pi`, `isPiSystem_pi`,
+`MeasureTheory.squareCylinders`, `isPiSystem_squareCylinders`, `generateFrom_squareCylinders`,
+`Measure.pi_eq`, `Measure.pi_pi` — and build only the de Finetti-facing adapters over it:
 
-* measurable rectangles form a π-system;
-* measurable rectangles generate the finite product σ-algebra;
-* measurability of `ω ↦ Measure.pi fun _ : Fin m => ν ω`;
+* measurability of `ω ↦ Measure.pi fun _ : Fin m => ν ω` (the random product kernel);
 * the AE-measurable version needed for `Measure.bind_apply`;
-* rectangle evaluation for finite product measures;
-* equality of finite measures from agreement on rectangles.
+* rectangle evaluation and equality-from-rectangles specialized to those random product
+  measures (that rectangles form a π-system and generate the product σ-algebra is Mathlib's
+  `isPiSystem_pi` / `generateFrom_pi`).
 
 Then build the common de Finetti ending:
 

--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -77,8 +77,9 @@ factorization proved separately. An extra `[StandardBorelSpace Ω]` would arise 
 statement.
 
 The default public theorem should eventually use the reverse-martingale proof. The L²
-route remains as a lighter real-valued theorem, and the Koopman route remains as the
-ergodic-theory route with reusable operator-theoretic infrastructure.
+route reaches the same standard-Borel theorem through the common ending, with its real-valued
+L² statement as an internal intermediate step, and the Koopman route is the ergodic-theory
+route with reusable operator-theoretic infrastructure.
 
 ## The library spine
 
@@ -267,6 +268,23 @@ Contractable.map_pair
 Contractable.comp
 ```
 
+Also build the implication lattice and the alternate characterizations as named API:
+
+* exchangeability via all finite permutations, and via adjacent transpositions (which
+  generate the finite permutations, stated finite-dimensionally over `Fin n`);
+* contractability/spreadability via the monoid of strictly increasing maps `ℕ → ℕ`;
+* closure of each symmetry class under coordinatewise pushforward `X ↦ (f ∘ Xᵢ)`;
+* mixtures of i.i.d. laws are exchangeable, and exchangeable laws are stationary;
+* the implication lattice among `ExchangeableAt n`, `Exchangeable`, `FullyExchangeable`,
+  `Contractable`, and `ConditionallyIID`, with every easy arrow named and the hard arrow
+  `Contractable → ConditionallyIID` isolated;
+* the process-level ↔ path-law bridges in both directions.
+
+State each equivalence with its hypotheses: finite ↔ full exchangeability needs a probability
+(or finite) measure and finite-marginal uniqueness, and the adjacent-transposition reduction
+is the finitary `Exchangeable`, not `FullyExchangeable`. Downstream users should be able to
+name the symmetry notion they mean and move between equivalent formulations by theorem.
+
 ⚠ **API warning.** Do not define exchangeability as a property of a measure on path space
 only, or as a property of a process only, without bridges. Both viewpoints are useful:
 the process-level statements are what users want, while the path-law statements make
@@ -348,7 +366,27 @@ shift-invariant σ-algebra. For one-sided sequences, the relationship runs throu
 invariance, almost invariance, and completions. State exactly the theorem each proof
 route needs.
 
-### Layer 3: L² averaging library and real-valued de Finetti
+Build the exchangeable σ-algebra and the directing-measure measurability API (the σ-algebra
+target Layer 6 consumes; `ν` itself is constructed in Layer 6, not here):
+
+```lean
+exchangeableSigma
+exchangeableSigma_le
+tail_le_exchangeableSigma
+hewittSavage_trivial_of_iIndep
+```
+
+* the exchangeable / symmetric σ-algebra on path space, and its relationship to the tail and
+  shift-invariant σ-algebras (and their completions and a.e. versions) under the de Finetti
+  hypotheses;
+* the measurability target for a directing measure `ν` with respect to the tail or
+  exchangeable σ-algebra;
+* the **Hewitt–Savage zero-one law**: for an i.i.d. sequence the *symmetric / exchangeable*
+  σ-algebra is trivial. This is stronger than Kolmogorov's tail 0-1 law: tail triviality holds
+  for any independent sequence, whereas Hewitt–Savage is the symmetric-σ-algebra statement and
+  needs the identically-distributed hypothesis.
+
+### Layer 3: L² averaging library and the standard-Borel de Finetti route
 
 Suggested home:
 
@@ -358,8 +396,9 @@ TauCeti/Probability/Exchangeability/L2/BlockAverages.lean
 TauCeti/Probability/DeFinetti/ViaL2.lean
 ```
 
-This is the first proof route to port after the shared layers. It is real-valued and
-requires L² assumptions.
+This is the first proof route to port after the shared layers. Its analytic core is
+real-valued and second-moment, but the Layer 3 milestone is the standard-Borel de Finetti
+statement, not a relabeled real-valued theorem.
 
 Build:
 
@@ -369,6 +408,8 @@ Build:
 * two-window L² bounds for block averages;
 * long-average versus tail-average bounds;
 * L¹ convergence of weighted block averages;
+* extension from bounded measurable real observables to a countable determining class on the
+  standard Borel state space;
 * the directing-measure bridge;
 * the call to `conditional_iid_from_directing_measure`.
 
@@ -379,14 +420,18 @@ contractable_covariance_structure
 l2_bound_two_windows_uniform
 l2_bound_long_vs_tail
 weighted_sums_converge_L1
+realObservables_determine_directing_measure
 directing_measure_satisfies_requirements
 conditionallyIID_of_contractable_viaL2
 deFinetti_viaL2
 deFinetti_RyllNardzewski_equivalence_viaL2
 ```
 
-The final route should make clear that it proves a real-valued L² theorem, not the full
-standard-Borel theorem.
+Real-valued L² convergence is the intermediate analytic step. Through the common ending and a
+determining class of bounded measurable real observables on the standard Borel state space,
+the route reaches the standard-Borel de Finetti statement; the roadmap target is this
+library-level theorem, stronger than the bare real-valued conclusion the source currently
+carries.
 
 ### Layer 4: reverse martingales and conditional-expectation limits
 
@@ -477,6 +522,18 @@ metProjection
 birkhoffAverage_tendsto_metProjection
 ```
 
+State the operator at the right level of generality (it is the same operator everywhere, not
+just on `L²`):
+
+* the Koopman operator on `Lᵖ` for `1 ≤ p < ∞` (via Mathlib's `Lp.compMeasurePreserving`), an
+  isometric embedding — not unitary for the one-sided shift, since it is surjective only when
+  the map is invertible mod null sets;
+* the associated Markov operator on bounded measurable functions / `L^∞`: positive and unital;
+* multiplicativity **for the deterministic Koopman operator** on `L^∞` — this is special to
+  composition operators; a general Markov operator is positive and unital but not
+  multiplicative;
+* compatibility with composition and with the invariant σ-algebra.
+
 Then specialize to path-space shift and identify the projection:
 
 ```lean
@@ -537,6 +594,21 @@ deFinetti_equivalence
 deFinetti_RyllNardzewski_equivalence
 ```
 
+The directing-measure theorem should expose a real API, not just an existence proof:
+
+* construction of the directing measure `ν`;
+* **a.e.** uniqueness of `ν` (equality of probability measures a.e. under the base law, tested
+  against a determining class — not pointwise);
+* the finite-dimensional factorization identity;
+* the empirical-measure form: `(1/n) Σ_{i<n} δ_{Xᵢ}(ω) ⇒ ν(ω)` weakly in `P(α)`, tested
+  against bounded continuous functions (a milestone in its own right, bringing in the weak
+  topology on `ProbabilityMeasure α`; not a prerequisite for the base directing-measure
+  theorem);
+* the mixture-of-product-measures form: `pathLaw X = ∫ p^{⊗ℕ} dπ(p)` with `π` the unique law
+  of `ν` on `P(α)`;
+* the extreme-point corollary, once π-system uniqueness and the Hewitt–Savage input (Layer 2)
+  are available: the extreme exchangeable laws are exactly the i.i.d. laws.
+
 This is the default route for the final public API.
 
 ### Layer 7: public API and examples
@@ -568,37 +640,33 @@ deFinetti_RyllNardzewski_equivalence
 
 deFinetti_viaL2
 deFinetti_viaKoopman
+
+deFinetti_empiricalMeasure
+deFinetti_mixture
+conditionallyIID_ae_unique
+exchangeable_extreme_iff_iid
 ```
 
 Route-specific theorem names should keep their suffixes. The unsuffixed theorem should be
 the general martingale route.
 
-### Long horizon
+### Layer 8: generalized exchangeability and representation theorems
 
-After v1:
+This layer is not needed before the v1 sequence theorem, but it is part of the roadmap: it
+extends the library from exchangeable sequences to the next standard representation theorems
+and approximation results.
 
-* finite de Finetti bounds;
+Build:
+
+* finite de Finetti bounds, including quantitative approximation by mixtures of products;
 * de Finetti for other countable index types;
-* exchangeable arrays and Aldous–Hoover;
-* Markov exchangeability;
 * ergodic decomposition of exchangeable laws;
-* Mathlib extraction of general infrastructure.
+* Markov exchangeability;
+* exchangeable arrays and the Aldous–Hoover representation (a substantially larger tower than
+  the sequence theorem, with its own prerequisites).
 
-Optional extensions of the core theory, valuable but not part of v1:
-
-* the empirical-measure and mixture forms of de Finetti (the law-of-large-numbers form
-  `(1/n) Σ_{i<n} δ_{Xᵢ} ⇒ ν` in `P(α)`, and `pathLaw X = ∫ p^{⊗ℕ} dπ(p)` with `π` unique on
-  `P(α)`);
-* the Hewitt–Savage zero-one law (triviality of the symmetric σ-algebra for i.i.d.
-  sequences) and the extreme-point / ergodic-decomposition corollary;
-* the full Koopman Markov-operator API (positive, unital, multiplicative on `L^∞`);
-* the detailed directing-measure API: a.e. uniqueness, measurability with respect to the
-  tail/exchangeable σ-algebra, and the conditional-factorization identity
-  `E[∏_j f_j(X_{i_j}) | σ(ν)] = ∏_j ∫ f_j dν`;
-* a boundary worked example marking the limits of the theory: a stationary-not-exchangeable
-  two-state Markov chain (`P(0→0) = P(1→1) = q`, `0 < q < 1`, `q ≠ ½`).
-
-These are not prerequisites for the v1 theorem.
+Mathlib extraction of the general-purpose infrastructure built along the way — reverse
+martingales, Koopman operators, product kernels — is a parallel ongoing goal.
 
 ## Worked examples
 
@@ -612,6 +680,11 @@ objects, not just the final theorem.
   the two-point kernel keeps the example independent of a mature `Bernoulli` API.
 * Finite-dimensional prefix marginals determine a probability measure on `ℕ → α`.
 * Full exchangeability of a path law implies shift-preservation.
+* A stationary non-reversible finite-state Markov chain — for instance the deterministic
+  3-cycle with uniform stationary law — is shift-invariant but not exchangeable, since the law
+  of `(X₀, X₁)` differs from that of `(X₁, X₀)`. This keeps stationarity, shift-invariance, and
+  exchangeability distinct.
+* Hewitt–Savage: the symmetric σ-algebra of an i.i.d. sequence is trivial.
 * The tail-family of a process is antitone.
 * The Lévy downward theorem specializes correctly to an eventually constant decreasing
   filtration (a test of `condExp_tendsto_iInf`, not a de Finetti example).
@@ -626,7 +699,8 @@ Layer 2 next: tails and shifts are needed by the martingale and Koopman routes.
 After that, the L² route can land first because it validates the common ending with the
 least global infrastructure. Reverse martingales and Koopman can proceed in parallel as
 general infrastructure. The martingale de Finetti proof comes after reverse martingales
-and becomes the default public theorem.
+and becomes the default public theorem. Layer 8 (generalized exchangeability and
+representation theorems) sequences after the v1 theorem.
 
 ## References
 

--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -124,7 +124,8 @@ ergodic-theory lane.
 
 Index the v1 theorem by `ℕ`. General exchangeability over other countable index types,
 exchangeable arrays, Aldous–Hoover, Markov exchangeability, and finite de Finetti bounds
-are long-horizon generalizations, not prerequisites for v1.
+are Layer 8 milestones, sequenced after the v1 sequence theorem but still part of this
+roadmap.
 
 ## What Mathlib already has (consume)
 

--- a/TauCetiRoadmap/Exchangeability/Targets.lean
+++ b/TauCetiRoadmap/Exchangeability/Targets.lean
@@ -9,17 +9,20 @@ worked examples, and the references are in `README.md`.
 This file holds the **Layer 0** target signatures: the core symmetry notions (sequence
 laws, finite and full exchangeability, contractability), the directing-measure object
 (`ConditionallyIID`, with `ν : Ω → ProbabilityMeasure α`), path-space data (`pathLaw`,
-`prefixProj`, `shift`), finite-dimensional marginal uniqueness, and the easy bridges among
-the symmetry classes; the implication lattice and the adjacent-transposition and
-strictly-increasing-map characterizations are described in `README.md`. These elaborate
+`prefixProj`, `shift`), finite-dimensional marginal uniqueness (an ℕ-prefix wrapper over
+Mathlib's `FiniteDimensionalLaws`), and the easy bridges among the symmetry classes; the
+implication lattice and the adjacent-transposition and strictly-increasing-map
+characterizations are described in `README.md`. These elaborate
 against the pinned Mathlib and are stated with `sorry` (allowed in this human-owned roadmap
 library).
 
 Layer 0 needs only Mathlib, not any not-yet-chosen Tau Ceti API. Later layers add their
 milestones here as their types become expressible:
 
-* Layer 1 (product kernels, conditional independence, mixtures): product-kernel
-  measurability and the common ending `conditional_iid_from_directing_measure`.
+* Layer 1 (product kernels, conditional independence, mixtures): consume Mathlib's
+  cylinder/π-system facts (`generateFrom_pi`, `generateFrom_squareCylinders`); build the
+  random product-kernel measurability and the common ending
+  `conditional_iid_from_directing_measure`.
 * Layer 2 (process tails and path-space dynamics): `tailFamily`, `tailProcess`, and the
   shift-invariant σ-algebra.
 * Layer 3 (L² averaging and the standard-Borel de Finetti route, with the real-valued L²
@@ -94,7 +97,10 @@ def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
         μ.bind (fun ω => (ProbabilityMeasure.pi (fun _ : Fin m => ν ω)).toMeasure)
 
 /-- **Layer 0, finite-marginal uniqueness.** Two finite measures on path space agreeing on
-every finite-dimensional prefix marginal are equal. -/
+every finite-dimensional prefix marginal are equal. This and the probability variant below
+are roadmap-local ℕ-prefix wrappers over Mathlib's general
+`ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq`, not new measure theory; the
+`sorry` is the thin `Fin n`-prefix ↔ finite-subset adapter. -/
 example {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ] [IsFiniteMeasure ν]
     (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) :

--- a/TauCetiRoadmap/Exchangeability/Targets.lean
+++ b/TauCetiRoadmap/Exchangeability/Targets.lean
@@ -3,13 +3,13 @@ import Mathlib
 /-!
 # Exchangeability and de Finetti: target signatures
 
-The narrative roadmap, the layer-by-layer build plan (Layers 0–7), the worked examples,
-and the references are in `README.md`.
+The narrative roadmap, the library spine, the layer-by-layer build plan (Layers 0–7), the
+worked examples, and the references are in `README.md`.
 
 Mathlib already has much of the ambient probability and analysis stack: finite products
 of measures, kernels and `Measure.bind`, conditional expectation, filtrations and
 martingales, `Lp` spaces, Hilbert-space projections, measure-preserving maps, and the
-mean ergodic theorem. What is missing is the exchangeability/de Finetti package on top:
+mean ergodic theorem. What is missing is the exchangeability/de Finetti library on top:
 exchangeable and contractable sequences, conditionally i.i.d. sequences, tail σ-algebras
 for processes, reverse martingale convergence along decreasing filtrations, the Koopman
 projection/conditional-expectation bridge, and the de Finetti–Ryll-Nardzewski theorem.
@@ -22,23 +22,24 @@ Natural first targets, in order:
 * Layer 0: `Exchangeable`, `FullyExchangeable`, `Contractable`, finite-dimensional
   marginal uniqueness on `ℕ → α`, `exchangeable_iff_fullyExchangeable`, and
   `contractable_of_exchangeable`.
-* Layer 1: product-kernel measurability
-  `Measurable fun ω => Measure.pi fun _ : Fin m => ν ω`, and the common ending
+* Layer 1: product kernels, conditional independence, and mixtures — product-kernel
+  measurability `Measurable fun ω => Measure.pi fun _ : Fin m => ν ω` and the common ending
   `conditional_iid_from_directing_measure`.
 * Layer 2: `tailFamily`, `tailProcess`, `tailFamily_antitone`, path-space `shift`, and
   `shiftInvariantSigma`.
-* Layer 3: the real-valued L² route:
+* Layer 3: the L² averaging library and real-valued de Finetti —
   `conditionallyIID_of_contractable_viaL2` and `deFinetti_viaL2`.
-* Layer 4: Lévy downward theorem
+* Layer 4: reverse martingales and conditional-expectation limits, starting with
   `condExp_tendsto_iInf` for antitone filtrations.
-* Layer 5: Koopman mean-ergodic route, ending in `deFinetti_viaKoopman`.
-* Layer 6: the general martingale route, ending in the default `deFinetti` and
-  `deFinetti_RyllNardzewski_equivalence`.
+* Layer 5: Koopman operators and invariant σ-algebras, ending in `deFinetti_viaKoopman`.
+* Layer 6: directing measures and the de Finetti representation, ending in the default
+  `deFinetti` and `deFinetti_RyllNardzewski_equivalence`.
 * Layer 7: the public API surface (`Exchangeable`, `FullyExchangeable`, `Contractable`,
   `ConditionallyIID`, and the route theorems) together with the worked examples.
 
-The first implementation PR should add compiled signatures here only for Layer 0
-milestones whose statements elaborate cleanly against the then-current Tau Ceti API.
+Compiled `sorry`-signatures (the Layer 0 core API and the easy bridges between the symmetry
+notions) come in a follow-up PR; this file stays a placeholder while the roadmap stance is
+settled.
 -/
 
 namespace TauCetiRoadmap.Exchangeability

--- a/TauCetiRoadmap/Exchangeability/Targets.lean
+++ b/TauCetiRoadmap/Exchangeability/Targets.lean
@@ -1,0 +1,48 @@
+import Mathlib
+
+/-!
+# Exchangeability and de Finetti: target signatures
+
+The narrative roadmap, the layer-by-layer build plan (Layers 0–7), the worked examples,
+and the references are in `README.md`.
+
+Mathlib already has much of the ambient probability and analysis stack: finite products
+of measures, kernels and `Measure.bind`, conditional expectation, filtrations and
+martingales, `Lp` spaces, Hilbert-space projections, measure-preserving maps, and the
+mean ergodic theorem. What is missing is the exchangeability/de Finetti package on top:
+exchangeable and contractable sequences, conditionally i.i.d. sequences, tail σ-algebras
+for processes, reverse martingale convergence along decreasing filtrations, the Koopman
+projection/conditional-expectation bridge, and the de Finetti–Ryll-Nardzewski theorem.
+
+As each layer makes the next layer's *types* expressible in `TauCeti/`, state that layer's
+milestones here with `sorry` (human-owned roadmap territory, so `sorry` is allowed).
+
+Natural first targets, in order:
+
+* Layer 0: `Exchangeable`, `FullyExchangeable`, `Contractable`, finite-dimensional
+  marginal uniqueness on `ℕ → α`, `exchangeable_iff_fullyExchangeable`, and
+  `contractable_of_exchangeable`.
+* Layer 1: product-kernel measurability
+  `Measurable fun ω => Measure.pi fun _ : Fin m => ν ω`, and the common ending
+  `conditional_iid_from_directing_measure`.
+* Layer 2: `tailFamily`, `tailProcess`, `tailFamily_antitone`, path-space `shift`, and
+  `shiftInvariantSigma`.
+* Layer 3: the real-valued L² route:
+  `conditionallyIID_of_contractable_viaL2` and `deFinetti_viaL2`.
+* Layer 4: Lévy downward theorem
+  `condExp_tendsto_iInf` for antitone filtrations.
+* Layer 5: Koopman mean-ergodic route, ending in `deFinetti_viaKoopman`.
+* Layer 6: the general martingale route, ending in the default `deFinetti` and
+  `deFinetti_RyllNardzewski_equivalence`.
+* Layer 7: the public API surface (`Exchangeable`, `FullyExchangeable`, `Contractable`,
+  `ConditionallyIID`, and the route theorems) together with the worked examples.
+
+The first implementation PR should add compiled signatures here only for Layer 0
+milestones whose statements elaborate cleanly against the then-current Tau Ceti API.
+-/
+
+namespace TauCetiRoadmap.Exchangeability
+
+-- (no compiled targets yet; see README.md)
+
+end TauCetiRoadmap.Exchangeability

--- a/TauCetiRoadmap/Exchangeability/Targets.lean
+++ b/TauCetiRoadmap/Exchangeability/Targets.lean
@@ -6,44 +6,121 @@ import Mathlib
 The narrative roadmap, the library spine, the layer-by-layer build plan (Layers 0–7), the
 worked examples, and the references are in `README.md`.
 
-Mathlib already has much of the ambient probability and analysis stack: finite products
-of measures, kernels and `Measure.bind`, conditional expectation, filtrations and
-martingales, `Lp` spaces, Hilbert-space projections, measure-preserving maps, and the
-mean ergodic theorem. What is missing is the exchangeability/de Finetti library on top:
-exchangeable and contractable sequences, conditionally i.i.d. sequences, tail σ-algebras
-for processes, reverse martingale convergence along decreasing filtrations, the Koopman
-projection/conditional-expectation bridge, and the de Finetti–Ryll-Nardzewski theorem.
+This file holds the **Layer 0** target signatures: the core symmetry notions (sequence
+laws, finite and full exchangeability, contractability), the directing-measure object
+(`ConditionallyIID`, with `ν : Ω → ProbabilityMeasure α`), path-space data (`pathLaw`,
+`prefixProj`, `shift`), finite-dimensional marginal uniqueness, and the easy bridges among
+the symmetry classes. These elaborate against the pinned Mathlib and are stated with `sorry`
+(allowed in this human-owned roadmap library).
 
-As each layer makes the next layer's *types* expressible in `TauCeti/`, state that layer's
-milestones here with `sorry` (human-owned roadmap territory, so `sorry` is allowed).
+Layer 0 needs only Mathlib, not any not-yet-chosen Tau Ceti API. Later layers add their
+milestones here as their types become expressible:
 
-Natural first targets, in order:
+* Layer 1 (product kernels, conditional independence, mixtures): product-kernel
+  measurability and the common ending `conditional_iid_from_directing_measure`.
+* Layer 2 (process tails and path-space dynamics): `tailFamily`, `tailProcess`, and the
+  shift-invariant σ-algebra.
+* Layer 3 (L² averaging library and real-valued de Finetti): `deFinetti_viaL2`.
+* Layer 4 (reverse martingales and conditional-expectation limits): `condExp_tendsto_iInf`
+  for antitone filtrations.
+* Layer 5 (Koopman operators and invariant σ-algebras): `deFinetti_viaKoopman`.
+* Layer 6 (directing measures and the de Finetti representation): the default `deFinetti`
+  and `deFinetti_RyllNardzewski_equivalence`.
 
-* Layer 0: `Exchangeable`, `FullyExchangeable`, `Contractable`, finite-dimensional
-  marginal uniqueness on `ℕ → α`, `exchangeable_iff_fullyExchangeable`, and
-  `contractable_of_exchangeable`.
-* Layer 1: product kernels, conditional independence, and mixtures — product-kernel
-  measurability `Measurable fun ω => Measure.pi fun _ : Fin m => ν ω` and the common ending
-  `conditional_iid_from_directing_measure`.
-* Layer 2: `tailFamily`, `tailProcess`, `tailFamily_antitone`, path-space `shift`, and
-  `shiftInvariantSigma`.
-* Layer 3: the L² averaging library and real-valued de Finetti —
-  `conditionallyIID_of_contractable_viaL2` and `deFinetti_viaL2`.
-* Layer 4: reverse martingales and conditional-expectation limits, starting with
-  `condExp_tendsto_iInf` for antitone filtrations.
-* Layer 5: Koopman operators and invariant σ-algebras, ending in `deFinetti_viaKoopman`.
-* Layer 6: directing measures and the de Finetti representation, ending in the default
-  `deFinetti` and `deFinetti_RyllNardzewski_equivalence`.
-* Layer 7: the public API surface (`Exchangeable`, `FullyExchangeable`, `Contractable`,
-  `ConditionallyIID`, and the route theorems) together with the worked examples.
-
-Compiled `sorry`-signatures (the Layer 0 core API and the easy bridges between the symmetry
-notions) come in a follow-up PR; this file stays a placeholder while the roadmap stance is
-settled.
+These are roadmap-local target shapes; the implementation in `TauCeti/` may refine names and
+namespaces, but the statements below pin the intended early milestones and dependency order.
 -/
+
+noncomputable section
+
+open MeasureTheory
 
 namespace TauCetiRoadmap.Exchangeability
 
--- (no compiled targets yet; see README.md)
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **Layer 0, finite exchangeability at `n`.** The law of the first `n` coordinates is
+invariant under permutations of `Fin n`. -/
+def ExchangeableAt (μ : Measure Ω) (X : ℕ → Ω → α) (n : ℕ) : Prop :=
+  ∀ σ : Equiv.Perm (Fin n),
+    μ.map (fun ω => fun i : Fin n => X (σ i).val ω) =
+      μ.map (fun ω => fun i : Fin n => X i.val ω)
+
+/-- **Layer 0, finite exchangeability.** Exchangeable means `ExchangeableAt` at every `n`
+(not a single-`n` statement). -/
+def Exchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∀ n, ExchangeableAt μ X n
+
+/-- **Layer 0, full exchangeability.** The path law is invariant under all permutations of
+`ℕ`. -/
+def FullyExchangeable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∀ π : Equiv.Perm ℕ,
+    μ.map (fun ω => fun i : ℕ => X (π i) ω) = μ.map (fun ω => fun i : ℕ => X i ω)
+
+/-- **Layer 0, contractability.** Invariance under strictly increasing finite subsequences.
+(Equivalently, invariance under the monoid of strictly increasing maps `ℕ → ℕ`;
+`Spreadable` is the standard synonym, with `Contractable` the first formal target.) -/
+def Contractable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∀ (m : ℕ) (k : Fin m → ℕ), StrictMono k →
+    μ.map (fun ω => fun i : Fin m => X (k i) ω) =
+      μ.map (fun ω => fun i : Fin m => X i.val ω)
+
+/-- **Layer 0, path law.** The law of the whole process as a measure on `ℕ → α`. -/
+def pathLaw (μ : Measure Ω) (X : ℕ → Ω → α) : Measure (ℕ → α) :=
+  μ.map (fun ω => fun i => X i ω)
+
+/-- **Layer 0, prefix projection** to the first `n` coordinates. -/
+def prefixProj (α : Type*) (n : ℕ) (x : ℕ → α) : Fin n → α := fun i => x i.val
+
+/-- **Layer 0, left shift** on path space. -/
+def shift (α : Type*) (x : ℕ → α) : ℕ → α := fun n => x (n + 1)
+
+/-- **Layer 0, conditionally i.i.d.** There is a measurable random probability measure
+`ν : Ω → ProbabilityMeasure α` so that every finite block of distinct coordinates is
+distributed as the `ν`-mixture of the corresponding product measure (the explicit
+finite-index factorization; `ProbabilityMeasure.pi` supplies the product). -/
+def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∃ ν : Ω → ProbabilityMeasure α, Measurable ν ∧
+    ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      μ.map (fun ω => fun i : Fin m => X (k i) ω) =
+        μ.bind (fun ω => (ProbabilityMeasure.pi (fun _ : Fin m => ν ω)).toMeasure)
+
+/-- **Layer 0, finite-marginal uniqueness.** Two finite measures on path space agreeing on
+every finite-dimensional prefix marginal are equal. -/
+example {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
+      μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) :
+    μ = ν := by
+  sorry
+
+/-- **Layer 0, finite-marginal uniqueness (probability version).** -/
+example {μ ν : Measure (ℕ → α)} [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
+    (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
+      μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) :
+    μ = ν := by
+  sorry
+
+variable {μ : Measure Ω} {X : ℕ → Ω → α}
+
+/-- **Layer 0 bridge, finite ↔ full exchangeability** for a measurable process under a
+probability law. -/
+example [IsProbabilityMeasure μ] (hX : ∀ i, Measurable (X i)) :
+    Exchangeable μ X ↔ FullyExchangeable μ X := by
+  sorry
+
+/-- **Layer 0 bridge, exchangeable ⇒ contractable.** -/
+example (hX : ∀ i, Measurable (X i)) (h : Exchangeable μ X) : Contractable μ X := by
+  sorry
+
+/-- **Layer 0 bridge, conditionally i.i.d. ⇒ exchangeable.** Permutation invariance of the
+finite product measures; will later move to the product-kernel layer once that lands. -/
+example (hX : ∀ i, Measurable (X i)) (h : ConditionallyIID μ X) : Exchangeable μ X := by
+  sorry
+
+/-- **Layer 0 bridge, full exchangeability ⇒ shift-preservation** of the path law (the link
+from symmetry to the Koopman lane). -/
+example (hX : ∀ i, Measurable (X i)) (h : FullyExchangeable μ X) :
+    MeasurePreserving (shift α) (pathLaw μ X) (pathLaw μ X) := by
+  sorry
 
 end TauCetiRoadmap.Exchangeability

--- a/TauCetiRoadmap/Exchangeability/Targets.lean
+++ b/TauCetiRoadmap/Exchangeability/Targets.lean
@@ -119,7 +119,7 @@ example (hX : ∀ i, Measurable (X i)) (h : ConditionallyIID μ X) : Exchangeabl
 
 /-- **Layer 0 bridge, full exchangeability ⇒ shift-preservation** of the path law (the link
 from symmetry to the Koopman lane). -/
-example (hX : ∀ i, Measurable (X i)) (h : FullyExchangeable μ X) :
+example [IsProbabilityMeasure μ] (hX : ∀ i, Measurable (X i)) (h : FullyExchangeable μ X) :
     MeasurePreserving (shift α) (pathLaw μ X) (pathLaw μ X) := by
   sorry
 

--- a/TauCetiRoadmap/Exchangeability/Targets.lean
+++ b/TauCetiRoadmap/Exchangeability/Targets.lean
@@ -3,15 +3,17 @@ import Mathlib
 /-!
 # Exchangeability and de Finetti: target signatures
 
-The narrative roadmap, the library spine, the layer-by-layer build plan (Layers 0–7), the
+The narrative roadmap, the library spine, the layer-by-layer build plan (Layers 0–8), the
 worked examples, and the references are in `README.md`.
 
 This file holds the **Layer 0** target signatures: the core symmetry notions (sequence
 laws, finite and full exchangeability, contractability), the directing-measure object
 (`ConditionallyIID`, with `ν : Ω → ProbabilityMeasure α`), path-space data (`pathLaw`,
 `prefixProj`, `shift`), finite-dimensional marginal uniqueness, and the easy bridges among
-the symmetry classes. These elaborate against the pinned Mathlib and are stated with `sorry`
-(allowed in this human-owned roadmap library).
+the symmetry classes; the implication lattice and the adjacent-transposition and
+strictly-increasing-map characterizations are described in `README.md`. These elaborate
+against the pinned Mathlib and are stated with `sorry` (allowed in this human-owned roadmap
+library).
 
 Layer 0 needs only Mathlib, not any not-yet-chosen Tau Ceti API. Later layers add their
 milestones here as their types become expressible:
@@ -20,12 +22,18 @@ milestones here as their types become expressible:
   measurability and the common ending `conditional_iid_from_directing_measure`.
 * Layer 2 (process tails and path-space dynamics): `tailFamily`, `tailProcess`, and the
   shift-invariant σ-algebra.
-* Layer 3 (L² averaging library and real-valued de Finetti): `deFinetti_viaL2`.
+* Layer 3 (L² averaging and the standard-Borel de Finetti route, with the real-valued L²
+  convergence theorem as the intermediate analytic step): `deFinetti_viaL2`.
 * Layer 4 (reverse martingales and conditional-expectation limits): `condExp_tendsto_iInf`
   for antitone filtrations.
-* Layer 5 (Koopman operators and invariant σ-algebras): `deFinetti_viaKoopman`.
-* Layer 6 (directing measures and the de Finetti representation): the default `deFinetti`
-  and `deFinetti_RyllNardzewski_equivalence`.
+* Layer 5 (Koopman operators and invariant σ-algebras): the positive/unital Markov-operator
+  API, multiplicativity for deterministic Koopman operators, and `deFinetti_viaKoopman`.
+* Layer 6 (directing measures and the de Finetti representation): the default `deFinetti`,
+  `deFinetti_RyllNardzewski_equivalence`, the directing-measure API (a.e. uniqueness, the
+  factorization identity), and the empirical-measure and mixture forms.
+* Layer 8 (generalized exchangeability and representation theorems): finite de Finetti bounds,
+  other countable index types, ergodic decomposition, Markov exchangeability, and
+  Aldous–Hoover.
 
 These are roadmap-local target shapes; the implementation in `TauCeti/` may refine names and
 namespaces, but the statements below pin the intended early milestones and dependency order.


### PR DESCRIPTION
## Summary

Adds a new roadmap for Tau Ceti’s library regarding probabilistic symmetries and conditionally independent representations, with de Finetti’s theorem as the first summit theorem.

[Cameron Freer's](https://github.com/cameronfreer) formalization of [exchangeability and  de Finetti's theorem](https://github.com/cameronfreer/exchangeability) is one pinned migration source and source of API warnings, but not the mathematical specification per se.

The roadmap follows the existing TauCetiRoadmap format:

- narrative `README.md`
- `Targets.lean` with compiled Layer 0 `sorry`-signatures
- root `README.md` index entry
- root `TauCetiRoadmap.lean` import

`Targets.lean` compiles the Layer 0 signatures (the symmetry notions, the directing-measure object `ν : Ω → ProbabilityMeasure α`, finite-marginal uniqueness, and the easy bridges) as `sorry`-signatures against Mathlib. Later layers' signatures for product kernels, tails, reverse martingales, Koopman, and the de Finetti representation land as their types become expressible in `TauCeti/`.

## Roadmap shape

The roadmap organizes the project into nine layers:

1. sequence laws, finite marginals, and symmetry notions
2. product kernels, conditional independence, and mixtures
3. process tails and path-space dynamics
4. L² averaging library and the standard-Borel de Finetti route
5. reverse martingales and conditional-expectation limits
6. Koopman operators and invariant σ-algebras
7. directing measures and de Finetti representation
8. public API and examples
9. generalized exchangeability and representation theorems

It also records the reusable library spine, likely Mathlib extraction candidates, a pinned migration source, worked model examples, and later milestones beyond the v1 sequence theorem.

## Files changed

```text
TauCetiRoadmap/Exchangeability/README.md
TauCetiRoadmap/Exchangeability/Targets.lean
TauCetiRoadmap.lean
README.md
```

## AI attribution

Initial proposal seeded with advice from GPT Pro 5.5. PR contents and description drafted by Claude (Opus 4.8) with review by Codex (GPT 5.5). Moderately human-edited and directed by me. 