### PR TITLE
feat: adopt the claim-bot for task coordination

### DIFF
--- a/.github/workflows/claim-sweep.yml
+++ b/.github/workflows/claim-sweep.yml
@@ -1,0 +1,20 @@
+name: Claim bot sweep
+
+on:
+  schedule:
+    # Every 30 minutes, so short (hour-scale) TTLs from fast-moving workers are
+    # released reasonably promptly. GitHub cron is loose, so release lags somewhat.
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+jobs:
+  sweep:
+    uses: leanprover-community/claim-bot/.github/workflows/claim-sweep.yml@v1
+    with:
+      project-title: "Tau Ceti"
+      default-ttl: "30d"
+      expire-in-progress: false
+      backfill-legacy: "grace"
+      app-id: ${{ vars.CLAIM_BOT_APP_ID }}
+    secrets:
+      app-private-key: ${{ secrets.CLAIM_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/claim.yml
+++ b/.github/workflows/claim.yml
@@ -1,0 +1,16 @@
+name: Claim bot
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  claim:
+    uses: leanprover-community/claim-bot/.github/workflows/claim-commands.yml@v1
+    with:
+      project-title: "Tau Ceti"
+      default-ttl: "30d"
+      max-ttl: "90d"
+      app-id: ${{ vars.CLAIM_BOT_APP_ID }}
+    secrets:
+      app-private-key: ${{ secrets.CLAIM_BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
This PR adopts [`leanprover-community/claim-bot`](https://github.com/leanprover-community/claim-bot) so contributors and workers can coordinate who works on which roadmap targets. Comment `claim` on an issue to take it (optionally `claim 2w` / `claim 5 hours` / `claim 2026-08-01` for a custom expiry), `disclaim` to release it, and `propose PR #N` / `withdraw PR #N` as work progresses. The bot assigns the issue and moves a card on the [Tau Ceti](https://github.com/orgs/FormalFrontier/projects/1) Projects v2 board; claims carry a 30-day default TTL (90-day max) and a periodic sweep returns abandoned claims to Unclaimed.

It authenticates as a GitHub App, so before merging this needs the `CLAIM_BOT_APP_ID` variable and `CLAIM_BOT_APP_PRIVATE_KEY` secret set on this repo.

🤖 Prepared with Claude Code