### PR TITLE
chore: add issue templates (intention, roadmap issue, meta)

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-intention.yml
+++ b/.github/ISSUE_TEMPLATE/1-intention.yml
@@ -45,14 +45,6 @@ body:
         - BCR semigroup–Bochner (existence + uniqueness)
     validations:
       required: true
-  - type: input
-    id: timeframe
-    attributes:
-      label: Intended timeframe
-      description: Roughly how long do you expect this to take? (Sets a credible expectation; pick a matching claim duration.)
-      placeholder: e.g. ~2 weeks
-    validations:
-      required: false
   - type: textarea
     id: notes
     attributes:

--- a/.github/ISSUE_TEMPLATE/1-intention.yml
+++ b/.github/ISSUE_TEMPLATE/1-intention.yml
@@ -1,0 +1,62 @@
+name: Intention (claim part of a roadmap)
+description: Register that you intend to work on a subset of a roadmap, then claim it on the board so others avoid it.
+title: "[Intention]: "
+labels: ["intention"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to stake out a slice of a roadmap (one or more targets), so other
+        contributors and worker agents don't duplicate it.
+
+        After opening this issue, **comment `claim`** on it to take it on the Tau Ceti board
+        (optionally with a duration, e.g. `claim 3 weeks`). It will auto-release when the claim
+        expires. Keep the scope as specific as you reasonably can.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Roadmap area
+      description: Which roadmap does this intention sit in?
+      options:
+        - CombinatorialHeegaardFloer
+        - EffectiveBounds
+        - GeometricTopology
+        - HeegaardFloer
+        - JacobianChallenge
+        - Multiquadratic
+        - OneParameterSemigroups
+        - PDE
+        - ReductiveGroups
+        - UniversalCovers
+    validations:
+      required: true
+  - type: textarea
+    id: items
+    attributes:
+      label: Items in scope
+      description: >
+        The specific targets/items from this roadmap you intend to work on. Cite them from the
+        roadmap's `README.md` / `Targets.lean` (declaration names or the key phrases). List only
+        what you're actually taking, so the rest stays open.
+      placeholder: |
+        e.g. the representation theorems for OneParameterSemigroups:
+        - Bernstein (completely monotone ⇔ Laplace transform)
+        - Bochner on a finite-dim inner-product space
+        - BCR semigroup–Bochner (existence + uniqueness)
+    validations:
+      required: true
+  - type: input
+    id: timeframe
+    attributes:
+      label: Intended timeframe
+      description: Roughly how long do you expect this to take? (Sets a credible expectation; pick a matching claim duration.)
+      placeholder: e.g. ~2 weeks
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Anything else, e.g. dependencies, who is doing this, links to draft work.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/2-roadmap-issue.yml
+++ b/.github/ISSUE_TEMPLATE/2-roadmap-issue.yml
@@ -1,0 +1,42 @@
+name: Roadmap issue (problem with an existing roadmap)
+description: Report a problem with a roadmap's content — a wrong or unclear target, a missing prerequisite, a bad dependency, etc.
+title: "[Roadmap]: "
+labels: ["roadmap-feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For problems with the **content** of an existing roadmap. (To register that you want to
+        work on part of a roadmap, use the *Intention* template instead. For problems with how
+        the repository itself operates, use the *Meta* template.)
+  - type: dropdown
+    id: area
+    attributes:
+      label: Roadmap area
+      options:
+        - CombinatorialHeegaardFloer
+        - EffectiveBounds
+        - GeometricTopology
+        - HeegaardFloer
+        - JacobianChallenge
+        - Multiquadratic
+        - OneParameterSemigroups
+        - PDE
+        - ReductiveGroups
+        - UniversalCovers
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's the problem?
+      description: What's wrong, unclear, missing, or mis-stated? Point to the specific target/item where you can.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested change
+      description: How would you fix it? (Optional.)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-meta.yml
+++ b/.github/ISSUE_TEMPLATE/3-meta.yml
@@ -1,0 +1,30 @@
+name: Meta (repository operation)
+description: Raise a problem about how the TauCetiRoadmap repository operates — CI/workflows, the intentions bot, labels, process, etc.
+title: "[Meta]: "
+labels: ["meta"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For problems with the **operation** of this repository rather than the mathematics of a
+        roadmap: workflows/CI, the intentions (claim) bot, labels, templates, conventions, or
+        process.
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      options:
+        - Workflows / CI
+        - Intentions (claim) bot
+        - Labels / templates
+        - Process / conventions
+        - Other
+    validations:
+      required: false
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What's the problem, and what would good look like?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true


### PR DESCRIPTION
This PR adds three issue forms so issues arrive structured and pre-labelled. **Intention** registers a slice of a roadmap to claim on the board (label `intention`); **Roadmap issue** reports a content problem with an existing roadmap (label `roadmap-feedback`); **Meta** raises problems with how the repository operates (label `meta`). The three `kind` labels already exist.

Known follow-ups (tracked separately): the roadmap-area dropdowns and the `roadmap/<area>` labels are maintained by hand for now, and forms can't map a dropdown choice to a `roadmap/<area>` label — both want the same lifecycle automation we noted (auto-create labels for new roadmaps; ensure issues carry the right `roadmap/<area>` label).

🤖 Prepared with Claude Code