### PR TITLE
chore: only auto-add intention issues to the board

### DIFF
--- a/.github/workflows/intentions.yml
+++ b/.github/workflows/intentions.yml
@@ -23,6 +23,8 @@ jobs:
       project-title: "Tau Ceti"
       default-ttl: "30d"
       max-ttl: "90d"
+      # Only intention issues belong on the board; keep roadmap-feedback / meta off it.
+      auto-add-labels: "intention"
       app-id: ${{ vars.CLAIM_BOT_APP_ID }}
     secrets:
       app-private-key: ${{ secrets.CLAIM_BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Sets `auto-add-labels: intention` (the new knob in `leanprover-community/intentions@v1`) so only **intention** issues land on the Tau Ceti board; roadmap-feedback and meta issues no longer get auto-added.

🤖 Prepared with Claude Code