### PR TITLE
doc: add a guide for writing roadmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,39 @@ industry groups.
 9. [Geometric topology and the Kirby-list problems](TauCetiRoadmap/GeometricTopology/README.md)
 10. [One-parameter semigroups, completely monotone functions, and BCR Bochner](TauCetiRoadmap/OneParameterSemigroups/README.md)
 
+## Writing a roadmap
+
+A roadmap is a specification for work we want done, written so an AI contributor, and its
+reviewers, can act on it without guessing.
+
+- **Build the library, don't race to the theorem.** For each object you introduce, ask for its
+  complete basic theory, not just the lemma the headline needs.
+  Named theorems are milestones inside a fuller development, not the whole of it.
+
+- **Everything is grounded.** Every part of the plan must be connected to existing material in
+  Mathlib and/or Tau Ceti. If we mention anything in the roadmap that doesn't already exist,
+  fully building the library for that object must become part of the roadmap. We know from
+  experience that the bigger the gap in the roadmap, the worse results AIs will produce.
+
+- **Specify the mathematics, not your existing code.** Say what each milestone should prove,
+  intrinsically, so a reviewer can judge it on its own terms. If you're porting existing work,
+  keep the file-by-file map in a clearly secondary provenance section, so reviewers don't treat
+  your code as the standard.
+
+- **Nothing is "optional".** Don't use the word, and don't imply it. Everything on a roadmap is
+  work we want. Sequencing is good, so split into milestones and put the harder material later,
+  but every item lives in *some* milestone, or a contributor reads "later" as "never".
+
+- **Do things right the first time.** Decide the generality up front and write it down. Don't
+  recommend intermediate implementations that will be replaced later.
+
+- **Write Lean code.** It's really helpful to prototype signatures, particularly for structures,
+  classes, and definitions, by writing Lean code, either embedded in markdown or in associated
+  Lean files using `sorry`.
+
+- **Pin conventions.** It's essential that you decide conventions ahead of time, or implementors
+  will make bad decisions.
+
 ## How changes are made
 
 Anyone can open a pull request against a roadmap. It merges automatically once it has an


### PR DESCRIPTION
This PR adds a "Writing a roadmap" section to the root README, distilling the recurring lessons from roadmap reviews into short principles for contributors: build the library rather than racing to the headline theorem, keep every dependency grounded in existing material, specify the mathematics rather than existing code, treat nothing as optional, do things right the first time, prototype signatures in Lean, and pin conventions up front.

🤖 Prepared with Claude Code