### PR TITLE
doc: tell roadmaps to use Mathlib's vocabulary, with boundedness as the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ reviewers, can act on it without guessing.
   fully building the library for that object must become part of the roadmap. We know from
   experience that the bigger the gap in the roadmap, the worse results AIs will produce.
 
+- **Use Mathlib's vocabulary.** Where Mathlib already has a way to say something, use it rather
+  than a private version, both in the roadmap and in the code. A standard notion said in our own
+  dialect drifts from the library it builds on and grows a redundant theory of lemmas Mathlib
+  already proves. Boundedness is the example: Mathlib has no "bounded on a set" predicate, so a
+  result that needs an explicit bound carries `∀ x ∈ s, ‖f x‖ ≤ C` directly in its hypotheses (as
+  in `norm_cfc_le`), and uses `Bornology.IsBounded` when no constant is needed
+  (`isBounded_iff_forall_norm_le'` relates the two). We do the same, and never wrap a one-line
+  bound in a new predicate.
+
 - **Specify the mathematics, not your existing code.** Say what each milestone should prove,
   intrinsically, so a reviewer can judge it on its own terms. If you're porting existing work,
   keep the file-by-file map in a clearly secondary provenance section, so reviewers don't treat

--- a/TauCetiRoadmap/PDE/README.md
+++ b/TauCetiRoadmap/PDE/README.md
@@ -46,7 +46,7 @@ For a **bounded open `Ω ⊆ ℝⁿ`** and a **uniformly elliptic, divergence-fo
 --     ∃ α ∈ Set.Ioc (0:ℝ) 1, HolderOnWith C α u K
 ```
 
-## Standing hypotheses (spell them out; never bundle)
+## Standing hypotheses (spell them out)
 
 PDE theory is **example-driven and hypothesis-sensitive**: the same theorem is true in
 many incomparable forms, and the art is in tracking exactly which structure each proof
@@ -67,6 +67,13 @@ separate hypothesis:
   - *continuous / VMO* `aⁱʲ` gives **Calderón–Zygmund** `W^{2,p}` estimates (strong solutions).
   Keep these lanes distinct; do not state one result and silently assume the regularity of
   another.
+
+"Named and separate" describes the hypotheses a statement carries, not new vocabulary to
+define. Follow "Use Mathlib's vocabulary" in the top-level README: a coefficient bound is the
+inline hypothesis `∀ x ∈ Ω, ‖b x‖ ≤ β`, never a bespoke boundedness predicate, because Mathlib
+states such bounds inline and has `Bornology.IsBounded` when no constant is needed. Uniform
+ellipticity is the case that does earn a named definition: its two-sided bound
+`λ‖ξ‖² ≤ aⁱʲ ξᵢ ξⱼ ≤ Λ‖ξ‖²` has no Mathlib spelling, so define it once, with explicit `λ, Λ`.
 
 ## Getting the statements right
 


### PR DESCRIPTION
This PR adds a "Writing a roadmap" principle that, where Mathlib already has a way to say something, the roadmap and the code use it rather than a private version, since a standard notion stated in our own dialect drifts from the library it builds on and accretes lemmas Mathlib already proves. It spells out the boundedness case concretely, because that one has already produced bespoke coefficient-bound predicates in the PDE lane (`DriftBoundedOn`, `MassBoundedOn`, and friends): Mathlib has no "bounded on a set" predicate, so a result needing an explicit bound carries `∀ x ∈ s, ‖f x‖ ≤ C` inline (as in `norm_cfc_le`) and otherwise uses `Bornology.IsBounded`, and we follow that rather than wrapping a one-line hypothesis in a new predicate.

A `TauCeti` cleanup that removes those predicates from the PDE files follows separately.

🤖 Prepared with Claude Code