### PR TITLE
doc: sharpen the grounding advice to rule out leaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ reviewers, can act on it without guessing.
   complete basic theory, not just the lemma the headline needs.
   Named theorems are milestones inside a fuller development, not the whole of it.
 
-- **Everything is grounded.** Every part of the plan must be connected to existing material in
-  Mathlib and/or Tau Ceti. If we mention anything in the roadmap that doesn't already exist,
-  fully building the library for that object must become part of the roadmap. We know from
-  experience that the bigger the gap in the roadmap, the worse results AIs will produce.
+- **Everything is grounded, with no leaps.** Every milestone must rest on existing Mathlib or
+  Tau Ceti material, on earlier material in the same roadmap, or on an explicitly cited
+  dependency in another roadmap. Anything else is a leap: a forward reference to a later layer, a
+  connection between two developments that nobody builds, an object named but never made a
+  target. If the roadmap needs something that doesn't exist, building it must itself be a target,
+  here or in a roadmap you cite. The bigger the gap, the worse AIs do with it.
 
 - **Use Mathlib's vocabulary.** Where Mathlib already has a way to say something, use it rather
   than a private version, both in the roadmap and in the code. A standard notion said in our own


### PR DESCRIPTION
This PR reworks the "Everything is grounded" item in the roadmap-writing guide so it names the three sources a milestone may rest on (existing Mathlib or Tau Ceti material, earlier material in the same roadmap, or an explicitly cited dependency in another roadmap) and spells out the leap failure modes that are not missing-from-Mathlib: forward references to a later layer, a connection between two developments that nobody builds, and an object named but never made a target.

🤖 Prepared with Claude Code