### PR TITLE
Add roadmap: Conformal mapping & geometric function theory (RMT summit)

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-intention.yml
+++ b/.github/ISSUE_TEMPLATE/1-intention.yml
@@ -19,6 +19,7 @@ body:
       description: Which roadmap does this intention sit in?
       options:
         - CombinatorialHeegaardFloer
+        - ConformalMapping
         - EffectiveBounds
         - GeometricTopology
         - HeegaardFloer

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ industry groups.
 9. [Geometric topology and the Kirby-list problems](TauCetiRoadmap/GeometricTopology/README.md)
 10. [One-parameter semigroups, completely monotone functions, and BCR Bochner](TauCetiRoadmap/OneParameterSemigroups/README.md)
 11. [Exchangeability and de Finetti](TauCetiRoadmap/Exchangeability/README.md)
+12. [Conformal mapping and the geometric theory of holomorphic functions](TauCetiRoadmap/ConformalMapping/README.md)
 
 ## Writing a roadmap
 

--- a/TauCetiRoadmap.lean
+++ b/TauCetiRoadmap.lean
@@ -12,3 +12,4 @@ import TauCetiRoadmap.CombinatorialHeegaardFloer.Targets
 import TauCetiRoadmap.HeegaardFloer.Targets
 import TauCetiRoadmap.GeometricTopology.Targets
 import TauCetiRoadmap.Exchangeability.Targets
+import TauCetiRoadmap.ConformalMapping.Targets

--- a/TauCetiRoadmap/ConformalMapping/README.md
+++ b/TauCetiRoadmap/ConformalMapping/README.md
@@ -1,0 +1,128 @@
+# Conformal mapping and the geometric theory of holomorphic functions
+
+The narrative roadmap for the conformal-mapping / geometric-function-theory area of complex
+analysis, with the **Riemann mapping theorem** as its summit; `Targets.lean` states the
+milestones as `sorry`-goals. Among its applications: the modular-`λ` uniformization
+`ℍ/Γ(2) ≅ ℂ∖{0,1}` (hence Picard's little theorem and the elliptic/modular uniformization)
+and the boundary regularity of conformal maps — but the area is foundational complex analysis
+in its own right.
+
+Mathlib has the **Cauchy foundations** of complex analysis — contour integration and the
+Cauchy integral formula, power series / analyticity, the **open mapping theorem**
+(`Complex.AnalyticOnNhd.is_constant_or_isOpenMap`), the **maximum modulus principle**
+(`Analysis/Complex/AbsMax`), the **Schwarz lemma** (`Analysis/Complex/Schwarz`), the
+**Riemann removable-singularity** theorem, the rectangle-integral vanishing lemmas, the unit
+disc `Complex.UnitDisc`, `conjCLE`/`starRingEnd ℂ` — but **almost none of the geometric /
+boundary superstructure built on them**: no argument principle, no Rouché or Hurwitz, no
+Morera as a named theorem, no normal families / Montel, **no Riemann mapping theorem**, no
+Schwarz reflection, no Carathéodory boundary correspondence, no Schwarz–Christoffel, no
+Schwarz–Pick / hyperbolic metric, no analytic continuation / monodromy theorem.
+
+The goal is to **build that geometric theory as a reusable library**, with the **Riemann
+mapping theorem** (RMT) as the summit. "Done" means a researcher in conformal geometry,
+several-complex-variables, modular forms, or PDE finds the objects — conformal
+isomorphisms, normal families, the reflected continuation, the boundary correspondence — at
+their natural generality with full basic API, so RMT and its boundary regularity are
+*consequences of a developed theory*, not isolated endpoints.
+
+Suggested home: `TauCeti/Analysis/Complex/Conformal/` (with
+`…/Conformal/ArgumentPrinciple.lean`, `…/NormalFamilies.lean`, `…/RiemannMapping.lean`,
+`…/Reflection.lean`, `…/BoundaryCorrespondence.lean`).
+
+## Prior art
+
+- **Mathlib:** none of the layer summits below (RMT, reflection, Rouché, Montel, …) are
+  present; only the foundations listed above. (`Analysis/Complex/Schwarz.lean` is the
+  Schwarz *lemma*, not the reflection *principle*.)
+- **Isabelle/HOL:** the **Riemann mapping theorem is formalized** (Paulson, `Riemann_Mapping`
+  in `HOL-Complex_Analysis`), so RMT is *achievable* — Lean simply lacks it. The reflection
+  principle and Schwarz–Christoffel appear unformalized in Lean and were not found in a
+  search of other provers. So this area ports/re-proves RMT into Lean and adds genuinely new
+  material on top.
+
+## Generality bar (decide up front; do not silently specialize)
+
+- **Scalar `ℂ`, the geometric (one-complex-variable) theory.** RMT and the boundary theory
+  are `ℂ`-specific; state them for `f : ℂ → ℂ`. The layer-0 lemmas that are naturally
+  Banach-`E`-valued — Schwarz reflection and the maximum-principle pieces — are **stated at
+  that generality**, matching Mathlib's `E`-valued forms; everything from normal families
+  (L1) and the Riemann mapping theorem upward is scalar `ℂ`.
+- **Domains: open + connected, simple-connectivity via Mathlib.** Use `IsOpen`,
+  `IsConnected`/`IsPreconnected`, and `SimplyConnectedSpace ↥Ω` (Mathlib's class) — never an
+  ad hoc "no holes". RMT's hypotheses are: `Ω` open, simply connected, `Ω ≠ univ`, nonempty.
+- **Conformal isomorphism = holomorphic bijection.** A biholomorphism `Ω ≃ Ω'` is a
+  `DifferentiableOn ℂ` bijection with `DifferentiableOn ℂ` inverse; since holomorphic +
+  injective ⇒ open with holomorphic inverse (open mapping), state RMT's conclusion as
+  `∃ f, DifferentiableOn ℂ f Ω ∧ Set.InjOn f Ω ∧ f '' Ω = Metric.ball 0 1` and derive the
+  packaged `≃` / `ConformalAt` API as companions. Relate to Mathlib's `ConformalAt`.
+- **Target disc: `Complex.UnitDisc` / `Metric.ball (0:ℂ) 1`.** Reuse the existing disc and
+  its automorphism/`Schwarz` API; do not re-encode the disc.
+- **Convergence of holomorphic families: `TendstoLocallyUniformlyOn`** (compact-open), the
+  topology under which "holomorphic" is closed and Montel lives. Local boundedness =
+  "bounded on each compact `K ⊆ Ω`".
+- **Reflection: real-axis first; conjugation is `starRingEnd ℂ`; explicit witness.** See L4.
+
+## Layers (each a discharge-gated milestone; `sorry` in `Targets.lean` is the goal)
+
+- **L0 — the local-mapping engine** (consumes the sibling **ContourIntegration** roadmap,
+  PR #35). The *argument principle*, residues, winding numbers, and the *global/homological
+  Cauchy theorem* are #35's deliverables (`TauCeti/Analysis/Contour/`) — **consume them, do
+  not re-derive**. This layer adds the *conformal-geometric* consequences on top: *Rouché*,
+  *Hurwitz* (locally-uniform limits of zero-free maps are zero-free or `≡ 0`), the
+  open-mapping degree, and *Morera* as a named theorem. The open mapping theorem and `AbsMax`
+  are consumed from Mathlib.
+- **L1 — normal families / Montel.** Locally bounded ⇒ precompact for
+  `TendstoLocallyUniformlyOn` (every sequence has a locally-uniformly-convergent subsequence
+  with holomorphic limit); Vitali. The compactness engine RMT runs on.
+- **L2 — Schwarz lemma extensions.** *Schwarz–Pick* (holomorphic disc self-maps contract the
+  pseudo-hyperbolic metric), the **hyperbolic / Poincaré metric** on `𝔻`, and the disc
+  automorphism group `Aut(𝔻) = {e^{iθ}(z−a)/(1−āz)}`. Built on Mathlib's Schwarz lemma.
+- **L3 — the Riemann mapping theorem (summit).** Every simply connected proper open
+  `Ω ⊊ ℂ` (nonempty) is biholomorphic to `𝔻`. Standard route: the family of injective
+  holomorphic `Ω → 𝔻` fixing a point is nonempty (square-root trick on simple-connectivity)
+  and normal (L1); maximize `|f′(z₀)|`; the maximizer is onto (else compose with a disc
+  automorphism + square root to beat it — L2). Uniqueness up to `Aut(𝔻)`.
+- **L4 — analytic continuation & the reflection principle.** Morera-based **Schwarz
+  reflection** across `ℝ` (witness `F z = if 0 ≤ z.im then f z else conj (f (conj z))`),
+  then across an analytic arc / circle by Möbius reduction; **Painlevé removability** across
+  an arc; the **monodromy theorem** (continuations along homotopic paths agree). Reflection's
+  reflected branch needs the antiholomorphic-composition lemma (L4.0). *This is the layer the
+  SW modular-`λ` covering consumes.*
+- **L5 — Carathéodory boundary correspondence.** The RMT map of a Jordan domain extends to a
+  homeomorphism of closures; prime ends in general. Uses L4 (reflection) for analytic
+  boundary arcs.
+- **L6 — Schwarz–Christoffel.** Explicit conformal maps onto polygons, built on L4 + L5
+  (sequenced last, after the boundary theory it needs).
+
+## Relation to sibling roadmaps (this entry is the connective layer)
+
+This area sits **between two of Chris Birkbeck's roadmaps** and feeds two more, so it is
+deliberately scoped to the conformal-mapping spine that none of them build:
+
+- **Below — `ContourIntegration` (PR #35).** Provides residues, winding numbers, the
+  argument principle, and the global Cauchy theorem (Dixon). **L0 consumes it.**
+- **Above — `ModularForms` (PR #36).** A 13-layer entry targeting modular curves as moduli
+  with `Y(Γ)(ℂ) ≅ Γ\ℍ`. The **modular & elliptic uniformization** — including the
+  `ℍ/Γ(2) ≅ ℂ∖{0,1}` `λ`-covering, the
+  `j`-invariant, and Picard's theorem — belongs there; it **consumes our L4 (reflection) +
+  L5 (boundary correspondence)** together with `UniversalCovers` (deck group). We do **not**
+  claim the modular layer here; we supply the conformal inputs it needs.
+- **Consumers — `HeegaardFloer` (merged)** uses **L4 Schwarz reflection** for its
+  Cauchy–Riemann boundary conditions; **`UniversalCovers` (merged)** supplies the deck-group
+  Galois correspondence the `λ`-covering pairs with L4/L5.
+
+So the unique content of this entry — **Montel/normal families, the Riemann mapping theorem,
+Schwarz–Pick, reflection, Carathéodory** — is exactly the conformal spine missing between the
+residue engine (#35) and the modular/geometric consumers (#36, HeegaardFloer, UniversalCovers).
+
+## Other downstream
+
+Several complex variables, PDE (conformal/quasiconformal mappings), and special-function
+theory all consume the conformal-mapping and boundary layers.
+
+## References
+
+Ahlfors, *Complex Analysis* (Ch. 4–6) and *Conformal Invariants*; Conway, *Functions of One
+Complex Variable I* (VII–IX); Rudin, *Real and Complex Analysis* (Ch. 14); Stein–Shakarchi,
+*Complex Analysis* (Ch. 2, 8); Remmert, *Classical Topics in Complex Function Theory*. RMT:
+cf. Paulson's Isabelle/HOL `Riemann_Mapping`. New Lean formalization; credit none — original.

--- a/TauCetiRoadmap/ConformalMapping/README.md
+++ b/TauCetiRoadmap/ConformalMapping/README.md
@@ -137,8 +137,9 @@ deliberately scoped to the conformal-mapping spine that none of them build:
 
 - **Below — `ContourIntegration` (PR #35).** Provides residues, winding numbers, the
   argument principle, and the global Cauchy theorem (Dixon). **L0 consumes it.**
-- **Above — `ModularForms` (PR #36).** A 13-layer entry targeting modular curves as moduli
-  with `Y(Γ)(ℂ) ≅ Γ\ℍ`. The **modular & elliptic uniformization** — including the
+- **Above — `ModularForms` (PR #47).** A 13-layer entry targeting the complex modular curves
+  `Y(Γ)(ℂ) ≅ Γ\ℍ` (the complex-analytic versions, not the moduli-space framing). The
+  **modular & elliptic uniformization** — including the
   `ℍ/Γ(2) ≅ ℂ∖{0,1}` `λ`-covering, the
   `j`-invariant, and Picard's theorem — belongs there; it **consumes our L4 (reflection) +
   L5 (boundary correspondence)** together with `UniversalCovers` (deck group). We do **not**
@@ -149,7 +150,7 @@ deliberately scoped to the conformal-mapping spine that none of them build:
 
 So the unique content of this entry — **Montel/normal families, the Riemann mapping theorem,
 Schwarz–Pick, reflection, Carathéodory** — is exactly the conformal spine missing between the
-residue engine (#35) and the modular/geometric consumers (#36, HeegaardFloer, UniversalCovers).
+residue engine (#35) and the modular/geometric consumers (#47, HeegaardFloer, UniversalCovers).
 
 ## Coordination with upstream Mathlib (RMT is being formalized at Mathlib)
 

--- a/TauCetiRoadmap/ConformalMapping/README.md
+++ b/TauCetiRoadmap/ConformalMapping/README.md
@@ -158,7 +158,7 @@ A complete RMT proof exists upstream as [mathlib4#33505](https://github.com/lean
 (at the time of writing a **stalled draft** — last updated 2026-05, merge-conflicted), slated to
 land in `Analysis/Complex/RiemannMapping.lean` as a series of smaller, human-curated PRs. The key
 fact for scoping: **`#33505` does not reach RMT by magic — it proves the L0–L2 prerequisites
-internally**, as ad-hoc *unnamed* lemmas: an argument principle
+internally**, as private lemmas: an argument principle
 (`circleIntegral_logDeriv_eq_finsum_analyticOrderNatAdd`), Hurwitz
 (`eqOn_zero_or_forall_ne_zero_of_tendstoLocallyUniformlyOn`,
 `eqOn_const_or_injOn_of_tendstoLocallyUniformlyOn`), Montel/normal-families equicontinuity

--- a/TauCetiRoadmap/ConformalMapping/README.md
+++ b/TauCetiRoadmap/ConformalMapping/README.md
@@ -56,7 +56,7 @@ shim once the Mathlib theorem lands, and refactor downstream consumers to it —
   set — holomorphic when the input is) and `exists_continuousOn_pow_eq` (continuous n-th roots,
   likewise) — **consume these, do not rebuild them.** Beyond
   those, `#33505` itself proves the **L0–L2 prerequisites** — an argument principle, Hurwitz, and
-  the Montel/normal-families equicontinuity — internally, as ad-hoc *unnamed* lemmas rather than
+  the Montel/normal-families equicontinuity — internally, as private lemmas rather than
   reusable API. So the overlap with this roadmap is **L0–L3, not just L3**; see *Coordination with
   upstream Mathlib* below for the (correspondingly broadened) shim-deletion commitment.
 - **Isabelle/HOL:** the **Riemann mapping theorem is formalized** (Paulson, `Riemann_Mapping`

--- a/TauCetiRoadmap/ConformalMapping/README.md
+++ b/TauCetiRoadmap/ConformalMapping/README.md
@@ -14,9 +14,14 @@ Cauchy integral formula, power series / analyticity, the **open mapping theorem*
 **Riemann removable-singularity** theorem, the rectangle-integral vanishing lemmas, the unit
 disc `Complex.UnitDisc`, `conjCLE`/`starRingEnd ℂ` — but **almost none of the geometric /
 boundary superstructure built on them**: no argument principle, no Rouché or Hurwitz, no
-Morera as a named theorem, no normal families / Montel, **no Riemann mapping theorem**, no
-Schwarz reflection, no Carathéodory boundary correspondence, no Schwarz–Christoffel, no
-Schwarz–Pick / hyperbolic metric, no analytic continuation / monodromy theorem.
+Morera as a named theorem, no analytic **normal-families / Montel theorem** (note:
+`Analysis/LocallyConvex/Montel.lean` is about Montel *spaces* — locally convex spaces where
+closed bounded sets are compact — a different notion from the normal-families theorem L1
+targets, and unrelated to its `TendstoLocallyUniformlyOn` formulation), **no complete Riemann
+mapping theorem** (only the partial, private results in `Analysis/Complex/RiemannMapping.lean`
+— see Prior art), no Schwarz reflection, no Carathéodory boundary correspondence, no
+Schwarz–Christoffel, no Schwarz–Pick / hyperbolic metric, no analytic continuation / monodromy
+theorem.
 
 The goal is to **build that geometric theory as a reusable library**, with the **Riemann
 mapping theorem** (RMT) as the summit. "Done" means a researcher in conformal geometry,
@@ -29,11 +34,31 @@ Suggested home: `TauCeti/Analysis/Complex/Conformal/` (with
 `…/Conformal/ArgumentPrinciple.lean`, `…/NormalFamilies.lean`, `…/RiemannMapping.lean`,
 `…/Reflection.lean`, `…/BoundaryCorrespondence.lean`).
 
+**RMT is being formalized upstream — we coordinate.** A complete Riemann mapping theorem is
+already in progress at Mathlib ([mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505)),
+being merged as a series of human-curated PRs. Tau Ceti may proceed with RMT in the meantime,
+but any duplicating L3 statement is a temporary shim: we cite the upstream work, delete the
+shim once the Mathlib theorem lands, and refactor downstream consumers to it — see
+*[Coordination with upstream Mathlib](#coordination-with-upstream-mathlib-rmt-is-being-formalized-at-mathlib)* below.
+
 ## Prior art
 
-- **Mathlib:** none of the layer summits below (RMT, reflection, Rouché, Montel, …) are
-  present; only the foundations listed above. (`Analysis/Complex/Schwarz.lean` is the
-  Schwarz *lemma*, not the reflection *principle*.)
+- **Mathlib:** none of the layer summits below (reflection, Rouché, the normal-families
+  Montel theorem, Carathéodory, …) are present; only the foundations listed above.
+  (`Analysis/Complex/Schwarz.lean` is the Schwarz *lemma*, not the reflection *principle*.)
+- **Mathlib RMT, in progress (must coordinate).** `Analysis/Complex/RiemannMapping.lean`
+  (Kudryashov) holds *partial* results toward RMT; its docstring points to
+  [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), a complete
+  draft proof being brought to Mathlib standards and merged as a series of smaller PRs (its
+  current lemmas are private and strictly weaker than the theorem). The square-root/log trick
+  L3 relies on is **already in Mathlib**: `Analysis/Complex/BranchLogRoot.lean` has
+  `exists_continuousOn_eqOn_exp_comp` (a continuous branch of `log` on a simply connected open
+  set — holomorphic when the input is) and `exists_continuousOn_pow_eq` (continuous n-th roots,
+  likewise) — **consume these, do not rebuild them.** Beyond
+  those, `#33505` itself proves the **L0–L2 prerequisites** — an argument principle, Hurwitz, and
+  the Montel/normal-families equicontinuity — internally, as ad-hoc *unnamed* lemmas rather than
+  reusable API. So the overlap with this roadmap is **L0–L3, not just L3**; see *Coordination with
+  upstream Mathlib* below for the (correspondingly broadened) shim-deletion commitment.
 - **Isabelle/HOL:** the **Riemann mapping theorem is formalized** (Paulson, `Riemann_Mapping`
   in `HOL-Complex_Analysis`), so RMT is *achievable* — Lean simply lacks it. The reflection
   principle and Schwarz–Christoffel appear unformalized in Lean and were not found in a
@@ -42,11 +67,14 @@ Suggested home: `TauCeti/Analysis/Complex/Conformal/` (with
 
 ## Generality bar (decide up front; do not silently specialize)
 
-- **Scalar `ℂ`, the geometric (one-complex-variable) theory.** RMT and the boundary theory
-  are `ℂ`-specific; state them for `f : ℂ → ℂ`. The layer-0 lemmas that are naturally
-  Banach-`E`-valued — Schwarz reflection and the maximum-principle pieces — are **stated at
-  that generality**, matching Mathlib's `E`-valued forms; everything from normal families
-  (L1) and the Riemann mapping theorem upward is scalar `ℂ`.
+- **Scalar `ℂ` throughout the conformal layers (L0–L6).** RMT, the reflection principle, and
+  the boundary theory are `ℂ`-specific; state them for `f : ℂ → ℂ`. In particular **Schwarz
+  reflection (L4) is scalar**: its real-boundary condition `(f z).im = 0` has no Banach-`E`
+  analogue without introducing a real form/subspace, which this entry does not do. The
+  maximum-principle, open-mapping, and Morera *inputs* are **consumed** from Mathlib at
+  whatever generality (often `E`-valued) Mathlib already provides — we do not restate them. But
+  every theorem this entry *adds*, from L0 (Rouché / Hurwitz / Morera-as-named) through L6, is
+  scalar `ℂ`.
 - **Domains: open + connected, simple-connectivity via Mathlib.** Use `IsOpen`,
   `IsConnected`/`IsPreconnected`, and `SimplyConnectedSpace ↥Ω` (Mathlib's class) — never an
   ad hoc "no holes". RMT's hypotheses are: `Ω` open, simply connected, `Ω ≠ univ`, nonempty.
@@ -62,7 +90,7 @@ Suggested home: `TauCeti/Analysis/Complex/Conformal/` (with
   "bounded on each compact `K ⊆ Ω`".
 - **Reflection: real-axis first; conjugation is `starRingEnd ℂ`; explicit witness.** See L4.
 
-## Layers (each a discharge-gated milestone; `sorry` in `Targets.lean` is the goal)
+## Layers (each a discharge-gated milestone; the `sorry` goal in `Targets.lean` is stated for the core layers L0–L4, with L5–L6 deferred)
 
 - **L0 — the local-mapping engine** (consumes the sibling **ContourIntegration** roadmap,
   PR #35). The *argument principle*, residues, winding numbers, and the *global/homological
@@ -71,9 +99,11 @@ Suggested home: `TauCeti/Analysis/Complex/Conformal/` (with
   *Hurwitz* (locally-uniform limits of zero-free maps are zero-free or `≡ 0`), the
   open-mapping degree, and *Morera* as a named theorem. The open mapping theorem and `AbsMax`
   are consumed from Mathlib.
-- **L1 — normal families / Montel.** Locally bounded ⇒ precompact for
-  `TendstoLocallyUniformlyOn` (every sequence has a locally-uniformly-convergent subsequence
-  with holomorphic limit); Vitali. The compactness engine RMT runs on.
+- **L1 — normal families / Montel (the analytic theorem, not `MontelSpace`).** Locally bounded
+  ⇒ precompact for `TendstoLocallyUniformlyOn` (every sequence has a locally-uniformly-convergent
+  subsequence with holomorphic limit); Vitali. This is independent of Mathlib's
+  `Analysis/LocallyConvex/Montel.lean` (`MontelSpace`): we do not route through that API. The
+  compactness engine RMT runs on.
 - **L2 — Schwarz lemma extensions.** *Schwarz–Pick* (holomorphic disc self-maps contract the
   pseudo-hyperbolic metric), the **hyperbolic / Poincaré metric** on `𝔻`, and the disc
   automorphism group `Aut(𝔻) = {e^{iθ}(z−a)/(1−āz)}`. Built on Mathlib's Schwarz lemma.
@@ -81,16 +111,22 @@ Suggested home: `TauCeti/Analysis/Complex/Conformal/` (with
   `Ω ⊊ ℂ` (nonempty) is biholomorphic to `𝔻`. Standard route: the family of injective
   holomorphic `Ω → 𝔻` fixing a point is nonempty (square-root trick on simple-connectivity)
   and normal (L1); maximize `|f′(z₀)|`; the maximizer is onto (else compose with a disc
-  automorphism + square root to beat it — L2). Uniqueness up to `Aut(𝔻)`.
+  automorphism + square root to beat it — L2). Uniqueness up to `Aut(𝔻)`. The square-root /
+  holomorphic-log step **consumes Mathlib's `BranchLogRoot` API** (`exists_continuousOn_pow_eq`,
+  `exists_continuousOn_eqOn_exp_comp`) rather than rebuilding it; coordinate with the in-progress
+  Mathlib RMT (#33505) per *Coordination with upstream Mathlib*.
 - **L4 — analytic continuation & the reflection principle.** Morera-based **Schwarz
   reflection** across `ℝ` (witness `F z = if 0 ≤ z.im then f z else conj (f (conj z))`),
   then across an analytic arc / circle by Möbius reduction; **Painlevé removability** across
   an arc; the **monodromy theorem** (continuations along homotopic paths agree). Reflection's
   reflected branch needs the antiholomorphic-composition lemma (L4.0). *This is the layer the
   SW modular-`λ` covering consumes.*
-- **L5 — Carathéodory boundary correspondence.** The RMT map of a Jordan domain extends to a
-  homeomorphism of closures; prime ends in general. Uses L4 (reflection) for analytic
-  boundary arcs.
+- **L5 — Carathéodory boundary correspondence.** The concrete L5 milestone is the
+  **Jordan-domain case**: the RMT map of a Jordan domain extends to a homeomorphism of
+  closures. Uses L4 (reflection) for analytic boundary arcs. The general **prime-ends**
+  correspondence (Mathlib has no prime-ends definition) is materially heavier and is *not* part
+  of the L5 milestone; if pursued it is scoped as its own follow-on target rather than folded
+  into L5.
 - **L6 — Schwarz–Christoffel.** Explicit conformal maps onto polygons, built on L4 + L5
   (sequenced last, after the boundary theory it needs).
 
@@ -114,6 +150,39 @@ deliberately scoped to the conformal-mapping spine that none of them build:
 So the unique content of this entry — **Montel/normal families, the Riemann mapping theorem,
 Schwarz–Pick, reflection, Carathéodory** — is exactly the conformal spine missing between the
 residue engine (#35) and the modular/geometric consumers (#36, HeegaardFloer, UniversalCovers).
+
+## Coordination with upstream Mathlib (RMT is being formalized at Mathlib)
+
+A complete RMT proof exists upstream as [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505)
+(at the time of writing a **stalled draft** — last updated 2026-05, merge-conflicted), slated to
+land in `Analysis/Complex/RiemannMapping.lean` as a series of smaller, human-curated PRs. The key
+fact for scoping: **`#33505` does not reach RMT by magic — it proves the L0–L2 prerequisites
+internally**, as ad-hoc *unnamed* lemmas: an argument principle
+(`circleIntegral_logDeriv_eq_finsum_analyticOrderNatAdd`), Hurwitz
+(`eqOn_zero_or_forall_ne_zero_of_tendstoLocallyUniformlyOn`,
+`eqOn_const_or_injOn_of_tendstoLocallyUniformlyOn`), Montel/normal-families equicontinuity
+(`uniformEquicontinuousOn_…`), and holomorphic log / n-th-root (`exists_branch_log`,
+`exists_branch_nthRoot`). So the overlap with this roadmap is **L0–L3, not just L3** — while
+**L4–L6 (reflection, Carathéodory, Schwarz–Christoffel) are absent from `#33505` entirely** and
+unformalized elsewhere. Tau Ceti may proceed with L0–L3 in the meantime, under explicit conditions:
+
+1. **Cite the upstream work.** Every Tau Ceti L0–L3 file and PR cites #33505 and the Mathlib
+   `RiemannMapping.lean` / `BranchLogRoot.lean` work as the preceding human-curated effort, and
+   reuses Mathlib API (`BranchLogRoot`, and `#33505`'s lemmas once they land) wherever it already
+   exists rather than re-deriving it.
+2. **Declare the shims temporary — across L0–L3, not only L3.** Any Tau Ceti statement that
+   duplicates content destined for Mathlib — the RMT itself *and* the argument-principle /
+   Hurwitz / Montel-equicontinuity / branch-log-root prerequisites `#33505` proves internally —
+   is a **temporary shim**: we delete it once the human-curated Mathlib version lands and
+   refactor every downstream consumer (L4/L5, the SW modular-`λ` covering, `HeegaardFloer`) to it.
+3. **Our distinctive L0–L2 value is API, not first proof.** Because `#33505` already contains this
+   mathematics (buried and unnamed), what Tau Ceti adds at L0–L2 is to expose it as the **named,
+   discoverable library API** (`argument_principle`, `Hurwitz`, `Montel`, …); once `#33505` lands,
+   those names should be backed by Mathlib's lemmas rather than independent re-proofs.
+4. **Follow through.** PRs introducing these shims state that intent in their description, and the
+   AIs carry out the deletion + downstream refactor promptly once the Mathlib lemmas are
+   available. (The reflection / Carathéodory / Schwarz–Christoffel layers **L4–L6 are genuinely
+   new** and not subject to this shim-deletion clause.)
 
 ## Other downstream
 

--- a/TauCetiRoadmap/ConformalMapping/Targets.lean
+++ b/TauCetiRoadmap/ConformalMapping/Targets.lean
@@ -1,0 +1,93 @@
+import Mathlib
+
+/-!
+# Conformal mapping and geometric function theory: target signatures
+
+The narrative roadmap (layers, proof routes, generality bar, references, downstream uses)
+is in `README.md`. Mathlib has the Cauchy foundations — open mapping
+(`Complex.AnalyticOnNhd.is_constant_or_isOpenMap`), maximum modulus (`Analysis/Complex/AbsMax`),
+the Schwarz lemma (`Analysis/Complex/Schwarz`), Riemann removable singularities, the
+rectangle-integral vanishing lemmas, `Complex.UnitDisc`, `conjCLE`/`starRingEnd ℂ`,
+`TendstoLocallyUniformlyOn` — but not the geometric superstructure. We build it in
+`TauCeti/Analysis/Complex/Conformal/`, with the Riemann mapping theorem as the summit.
+
+A representative milestone from each layer is stated below with `sorry` (allowed in this
+human-owned roadmap library); what lands in `TauCeti/` must be proved with only the three
+kernel axioms. The residue/winding/global-Cauchy and argument-principle layer is the sibling
+`ContourIntegration` roadmap (PR #35, `TauCeti/Analysis/Contour/`) — **consumed**, not
+re-derived here; L0 below adds only the conformal-geometric consequences (Rouché, Hurwitz,
+Morera-as-named). The modular/elliptic uniformization that L4/L5 feed lives in the
+`ModularForms` roadmap (PR #36), not here.
+
+Conventions (pinned in `README.md`): scalar `ℂ`; domains open + `SimplyConnectedSpace`;
+disc `Metric.ball (0:ℂ) 1`; convergence `TendstoLocallyUniformlyOn`; conjugation
+`starRingEnd ℂ`; the reflection extension is the explicit witness
+`F z = if 0 ≤ z.im then f z else conj (f (conj z))`.
+-/
+
+namespace TauCetiRoadmap.ConformalMapping
+
+open Complex Filter Topology
+
+/-- **L0 — Hurwitz.** A locally-uniform limit of nowhere-zero holomorphic functions on a
+connected open set is either nowhere zero or identically zero. (Built on the argument
+principle / residue theory from the sibling `ContourIntegration` roadmap, PR #35; the
+perturbation backbone for RMT injectivity in the limit.) -/
+example {Ω : Set ℂ} (hΩ : IsOpen Ω) (hconn : IsConnected Ω) {f : ℕ → ℂ → ℂ} {g : ℂ → ℂ}
+    (hf : ∀ n, DifferentiableOn ℂ (f n) Ω) (hg : DifferentiableOn ℂ g Ω)
+    (hconv : TendstoLocallyUniformlyOn f g atTop Ω)
+    (hne : ∀ n, ∀ z ∈ Ω, f n z ≠ 0) :
+    (∀ z ∈ Ω, g z ≠ 0) ∨ (∀ z ∈ Ω, g z = 0) :=
+  sorry
+
+/-- **L1 — Montel / normal families.** A sequence of holomorphic functions, uniformly
+bounded on every compact subset of an open set, has a subsequence converging locally
+uniformly to a holomorphic limit. The compactness engine of RMT. -/
+example {Ω : Set ℂ} (hΩ : IsOpen Ω) {f : ℕ → ℂ → ℂ}
+    (hf : ∀ n, DifferentiableOn ℂ (f n) Ω)
+    (hb : ∀ K ⊆ Ω, IsCompact K → ∃ C, ∀ n, ∀ z ∈ K, ‖f n z‖ ≤ C) :
+    ∃ (φ : ℕ → ℕ) (g : ℂ → ℂ), StrictMono φ ∧ DifferentiableOn ℂ g Ω ∧
+      TendstoLocallyUniformlyOn (fun n => f (φ n)) g atTop Ω :=
+  sorry
+
+/-- **L2 — Schwarz–Pick.** A holomorphic self-map of the unit disc does not increase the
+pseudo-hyperbolic distance `|(z−w)/(1−w̄z)|`. (Mathlib's Schwarz lemma is the `w = 0` case.) -/
+example {f : ℂ → ℂ} (hf : DifferentiableOn ℂ f (Metric.ball 0 1))
+    (hmaps : Set.MapsTo f (Metric.ball 0 1) (Metric.ball 0 1))
+    {z w : ℂ} (hz : z ∈ Metric.ball (0 : ℂ) 1) (hw : w ∈ Metric.ball (0 : ℂ) 1) :
+    ‖(f z - f w) / (1 - (starRingEnd ℂ) (f w) * f z)‖
+      ≤ ‖(z - w) / (1 - (starRingEnd ℂ) w * z)‖ :=
+  sorry
+
+/-- **L3 — the Riemann mapping theorem (summit).** Every nonempty, simply connected, open
+proper subset of `ℂ` is biholomorphic to the unit disc: there is a holomorphic injection
+onto `Metric.ball 0 1` (its inverse is then holomorphic by the open mapping theorem). -/
+example {Ω : Set ℂ} (hopen : IsOpen Ω) (hconn : IsConnected Ω)
+    (hsc : SimplyConnectedSpace Ω) (hne_univ : Ω ≠ Set.univ) :
+    ∃ f : ℂ → ℂ, DifferentiableOn ℂ f Ω ∧ Set.InjOn f Ω ∧ f '' Ω = Metric.ball 0 1 :=
+  sorry
+
+/-- **L4.0 — antiholomorphic composition** (reflection prerequisite). If `f` is
+`ℂ`-differentiable on `S`, then `z ↦ conj (f (conj z))` is `ℂ`-differentiable on `conj '' S`. -/
+example {f : ℂ → ℂ} {S : Set ℂ} (hf : DifferentiableOn ℂ f S) :
+    DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
+      ((starRingEnd ℂ) '' S) :=
+  sorry
+
+/-- **L4 — the Schwarz reflection principle (real axis).** On a conjugation-symmetric open
+`Ω`, a function continuous on the closed upper part, holomorphic on the open upper part, and
+real on `Ω ∩ ℝ`, extends holomorphically to all of `Ω` (via the witness
+`F z = if 0 ≤ z.im then f z else conj (f (conj z))`) with the reflection symmetry. The layer
+the SW modular-`λ` covering consumes. -/
+example {Ω : Set ℂ} (hΩ : IsOpen Ω) (hsymm : ∀ z, z ∈ Ω ↔ (starRingEnd ℂ) z ∈ Ω)
+    {f : ℂ → ℂ}
+    (hcont : ContinuousOn f (Ω ∩ {z | 0 ≤ z.im}))
+    (hholo : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im}))
+    (hreal : ∀ z ∈ Ω, z.im = 0 → (f z).im = 0) :
+    ∃ F : ℂ → ℂ,
+      DifferentiableOn ℂ F Ω ∧
+      Set.EqOn F f (Ω ∩ {z | 0 ≤ z.im}) ∧
+      ∀ z ∈ Ω, F ((starRingEnd ℂ) z) = (starRingEnd ℂ) (F z) :=
+  sorry
+
+end TauCetiRoadmap.ConformalMapping

--- a/TauCetiRoadmap/ConformalMapping/Targets.lean
+++ b/TauCetiRoadmap/ConformalMapping/Targets.lean
@@ -11,9 +11,13 @@ rectangle-integral vanishing lemmas, `Complex.UnitDisc`, `conjCLE`/`starRingEnd 
 `TendstoLocallyUniformlyOn` — but not the geometric superstructure. We build it in
 `TauCeti/Analysis/Complex/Conformal/`, with the Riemann mapping theorem as the summit.
 
-A representative milestone from each layer is stated below with `sorry` (allowed in this
-human-owned roadmap library); what lands in `TauCeti/` must be proved with only the three
-kernel axioms. The residue/winding/global-Cauchy and argument-principle layer is the sibling
+A representative milestone from each of the core layers **L0–L4** is stated below with `sorry`
+(allowed in this human-owned roadmap library); what lands in `TauCeti/` must be proved with only
+the three kernel axioms. The boundary layers **L5 (Carathéodory, Jordan-domain case)** and **L6
+(Schwarz–Christoffel)** are described narratively in `README.md` and do not yet carry
+representative target signatures here (no Jordan-domain / prime-ends or polygon-map vocabulary in
+the pinned Mathlib to state them cleanly against); they will be added as the boundary API takes
+shape. The residue/winding/global-Cauchy and argument-principle layer is the sibling
 `ContourIntegration` roadmap (PR #35, `TauCeti/Analysis/Contour/`) — **consumed**, not
 re-derived here; L0 below adds only the conformal-geometric consequences (Rouché, Hurwitz,
 Morera-as-named). The modular/elliptic uniformization that L4/L5 feed lives in the


### PR DESCRIPTION
@CBirkbeck — flagging this for you, since it lands right between your two roadmaps.

I drafted this `ConformalMapping` area because I needed it for a WIP of my own (a Lean formalization of the Seiberg–Witten solution): getting the rank-1 rigidity result axiom-free needs the modular-`λ` uniformization `ℍ/Γ(2) ≅ ℂ∖{0,1}`, which bottoms out in the **Schwarz reflection principle** and the **Riemann mapping theorem** — neither in Mathlib. That's general complex analysis, so it belongs upstream as a proper area (RMT as the summit) rather than buried in my project.

Writing it up, the boundaries fell exactly on your work:
- **L0** (local-mapping engine) **consumes `ContourIntegration` (#35)** — residues, winding numbers, the global/homological Cauchy theorem — rather than re-deriving them.
- The **modular/elliptic uniformization** (`λ`-covering, `j`-invariant, Picard) is **not** claimed here; it belongs in **`ModularForms` (#36)**, which consumes this entry's **L4 (Schwarz reflection) + L5 (Carathéodory boundary correspondence)**. `HeegaardFloer` (merged) also consumes L4 reflection for its CR boundary conditions.

So the unique content — **Montel/normal families, RMT, Schwarz–Pick, reflection, Carathéodory** (layers L0–L6) — is the conformal spine currently missing *between* #35 and #36.

`Targets.lean` states representative milestones as `sorry`-goals and **builds green against the pinned Mathlib** (verified locally). The entry follows the roadmap conventions (generality bar pinned, Mathlib vocabulary, nothing optional).

**Two questions:**
1. Does the scoping look right — in particular the "L0 consumes #35" and "#36 consumes L4+L5" boundaries, vs. how you've set up #35/#36?
2. Is a sibling `ConformalMapping` entry welcome as its own roadmap?