### PR TITLE
chore: add Exchangeability to the issue-template roadmap dropdowns

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-intention.yml
+++ b/.github/ISSUE_TEMPLATE/1-intention.yml
@@ -20,6 +20,7 @@ body:
       options:
         - CombinatorialHeegaardFloer
         - EffectiveBounds
+        - Exchangeability
         - GeometricTopology
         - HeegaardFloer
         - JacobianChallenge

--- a/.github/ISSUE_TEMPLATE/2-roadmap-issue.yml
+++ b/.github/ISSUE_TEMPLATE/2-roadmap-issue.yml
@@ -16,6 +16,7 @@ body:
       options:
         - CombinatorialHeegaardFloer
         - EffectiveBounds
+        - Exchangeability
         - GeometricTopology
         - HeegaardFloer
         - JacobianChallenge


### PR DESCRIPTION
The **Exchangeability and de Finetti** roadmap merged (now item 11 in the root README, with its own
`TauCetiRoadmap/Exchangeability/` directory), but the **Roadmap area** dropdown in two issue
templates still lists only the 10 earlier roadmaps — so a contributor can't pick it when filing an
**Intention** (to claim work) or a **Roadmap issue**. That field is `required`, so it's a hard block.

This adds `Exchangeability` to both dropdowns, alphabetically after `EffectiveBounds`:

- `.github/ISSUE_TEMPLATE/1-intention.yml`
- `.github/ISSUE_TEMPLATE/2-roadmap-issue.yml`

No other roadmap is missing (the other 10 entries match the other 10 directories; `DenseGraphLimits`
isn't on `main` yet). `3-meta.yml`'s dropdown is a *Topic* list, not roadmap areas, so it's left
alone. No Lean change, so the `build` check is unaffected.

Routing note: `/.github/` is owned by `@FormalFrontier/humans` per `CODEOWNERS`, so this needs a
humans-team review rather than auto-merge on a `roadmap-reviewers` approval.
