### PR TITLE
doc: align Layer 0 finite-marginal uniqueness with TauCeti #482

### DIFF
--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -136,8 +136,9 @@ roadmap.
 * **Finite-dimensional laws determine the law** (general index, finite measures):
   `ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq` and
   `identDistrib_iff_forall_finset_identDistrib`
-  (`Mathlib/Probability/Process/FiniteDimensionalLaws.lean`). Tau Ceti only adds the
-  `pathLaw` / `Fin n`-prefix wrappers, not this core fact.
+  (`Mathlib/Probability/Process/FiniteDimensionalLaws.lean`). Tau Ceti does not reprove
+  finite-dimensional-law uniqueness; its Layer 0 `pathLaw` / `Fin n`-prefix marginal-uniqueness
+  wrapper is built on Mathlib's projective-limit uniqueness (`IsProjectiveLimit.unique`).
 * **Kernels and bind:** `Kernel`, `Measure.bind`, and the Giry-style measure API needed
   for mixtures of finite product measures.
 * **Conditional expectation:** `μ[f | m]`, tower properties, `condExpL2`, and
@@ -159,8 +160,8 @@ The missing pieces are:
 
 * finite-dimensional exchangeability and full exchangeability for sequence laws;
 * contractability and the proof `Exchangeable → Contractable`;
-* the `pathLaw` / `Fin n`-prefix wrappers over Mathlib's general finite-dimensional-law
-  uniqueness (the core theorem is Mathlib's, cited above);
+* the `pathLaw` / `Fin n`-prefix wrappers over Mathlib's projective-limit uniqueness
+  (`IsProjectiveLimit.unique`, from `Mathlib.MeasureTheory.Constructions.Projective`);
 * product-kernel measurability for random finite product measures;
 * the common de Finetti ending turning a directing-measure bridge into `ConditionallyIID`;
 * process-relative tail σ-algebras and their antitone filtration structure;
@@ -254,8 +255,8 @@ Build:
 * `Contractable μ X`;
 * `pathLaw μ X`;
 * prefix projections and prefix cylinders;
-* `pathLaw` / `Fin n`-prefix wrappers over Mathlib's finite-dimensional-law uniqueness
-  (`ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq`);
+* `pathLaw` / `Fin n`-prefix wrappers over Mathlib's projective-limit uniqueness
+  (`IsProjectiveLimit.unique`);
 * finite approximation of infinite permutations;
 * extension of strictly monotone finite selections to finite permutations.
 
@@ -267,7 +268,6 @@ Key milestones:
 
 ```lean
 measure_eq_of_fin_marginals_eq
-measure_eq_of_fin_marginals_eq_prob
 exchangeable_iff_fullyExchangeable
 exists_perm_extending_strictMono
 contractable_of_exchangeable
@@ -276,9 +276,12 @@ Contractable.map_pair
 Contractable.comp
 ```
 
-Mathlib's `ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq` already proves that
-finite-dimensional laws determine the law (for any index); `measure_eq_of_fin_marginals_eq`
-and its probability variant are the `ℕ`-prefix wrappers over it, not new measure theory.
+Mathlib's projective-limit machinery (`IsProjectiveLimit.unique`, from
+`Mathlib.MeasureTheory.Constructions.Projective`) already gives uniqueness from a projective
+family of finite-dimensional marginals; `measure_eq_of_fin_marginals_eq` is the single
+`ℕ`-prefix wrapper over it, not new measure theory. It assumes only `[IsFiniteMeasure μ]` (the
+conclusion forces `ν` finite), so probability applications are covered directly through the
+`IsProbabilityMeasure → IsFiniteMeasure` instance; no separate probability wrapper is needed.
 
 Also build the implication lattice and the alternate characterizations as named API:
 

--- a/TauCetiRoadmap/Exchangeability/Targets.lean
+++ b/TauCetiRoadmap/Exchangeability/Targets.lean
@@ -96,19 +96,14 @@ def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
       μ.map (fun ω => fun i : Fin m => X (k i) ω) =
         μ.bind (fun ω => (ProbabilityMeasure.pi (fun _ : Fin m => ν ω)).toMeasure)
 
-/-- **Layer 0, finite-marginal uniqueness.** Two finite measures on path space agreeing on
-every finite-dimensional prefix marginal are equal. This and the probability variant below
-are roadmap-local ℕ-prefix wrappers over Mathlib's general
-`ProbabilityTheory.map_eq_iff_forall_finset_map_restrict_eq`, not new measure theory; the
-`sorry` is the thin `Fin n`-prefix ↔ finite-subset adapter. -/
-example {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ] [IsFiniteMeasure ν]
-    (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
-      μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) :
-    μ = ν := by
-  sorry
-
-/-- **Layer 0, finite-marginal uniqueness (probability version).** -/
-example {μ ν : Measure (ℕ → α)} [IsProbabilityMeasure μ] [IsProbabilityMeasure ν]
+/-- **Layer 0, finite-marginal uniqueness.** Two measures on path space, with `μ` finite,
+agreeing on every finite-dimensional prefix marginal are equal (`ν`'s finiteness is forced by
+the conclusion). This is a roadmap-local ℕ-prefix wrapper over Mathlib's projective-limit
+machinery (`IsProjectiveLimit.unique`), not new measure theory; the `sorry` is the thin
+`Fin n`-prefix ↔ finite-subset adapter. Assuming only `[IsFiniteMeasure]` covers probability
+applications too, via the `IsProbabilityMeasure → IsFiniteMeasure` instance, so no separate
+probability wrapper is needed. -/
+example {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ]
     (h : ∀ (n : ℕ) (S : Set (Fin n → α)), MeasurableSet S →
       μ.map (prefixProj α n) S = ν.map (prefixProj α n) S) :
     μ = ν := by

--- a/TauCetiRoadmap/Exchangeability/Targets.lean
+++ b/TauCetiRoadmap/Exchangeability/Targets.lean
@@ -100,7 +100,7 @@ def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
 agreeing on every finite-dimensional prefix marginal are equal (`ν`'s finiteness is forced by
 the conclusion). This is a roadmap-local ℕ-prefix wrapper over Mathlib's projective-limit
 machinery (`IsProjectiveLimit.unique`), not new measure theory; the `sorry` is the thin
-`Fin n`-prefix ↔ finite-subset adapter. Assuming only `[IsFiniteMeasure]` covers probability
+`Fin n`-prefix ↔ finite-subset adapter. Assuming only `[IsFiniteMeasure μ]` covers probability
 applications too, via the `IsProbabilityMeasure → IsFiniteMeasure` instance, so no separate
 probability wrapper is needed. -/
 example {μ ν : Measure (ℕ → α)} [IsFiniteMeasure μ]


### PR DESCRIPTION
## What

Align the Layer 0 finite-marginal uniqueness milestone in the Exchangeability roadmap with the code that landed in [TauCeti #482](https://github.com/FormalFrontier/TauCeti/pull/482) ([`adf1206`](https://github.com/FormalFrontier/TauCeti/commit/adf120608a2b18ee08de2f9c8c88a53a32b4bd75)).

[TauCeti #482](https://github.com/FormalFrontier/TauCeti/pull/482) deliberately did not add a probability-specific theorem. The landed `measure_eq_of_fin_marginals_eq` assumes only `[IsFiniteMeasure μ]` and is built on Mathlib's `IsProjectiveLimit.unique`; probability use sites are covered through the `IsProbabilityMeasure → IsFiniteMeasure` instance.

## Review context

In [TauCeti #482](https://github.com/FormalFrontier/TauCeti/pull/482), two review rubrics disagreed about the same target: the `api-design` reviewer requested a probability-named theorem (`measure_eq_of_fin_marginals_eq_prob`), while the `reuse` reviewer flagged that theorem as a redundant duplicate of the finite-measure version. [TauCeti #482](https://github.com/FormalFrontier/TauCeti/pull/482) resolved the implementation side by keeping a single general theorem that assumes only `[IsFiniteMeasure μ]`, based on `IsProjectiveLimit.unique`. The roadmap still named the `_prob` target and described the wrapper as being over a different Mathlib lemma — the same ambiguity behind that disagreement. This PR makes the roadmap state what the code now does, so future reviews do not re-request the redundant `_prob` target.

## Changes

`TauCetiRoadmap/Exchangeability/README.md`
- Drop the `measure_eq_of_fin_marginals_eq_prob` milestone from the Layer 0 list.
- Rewrite the milestone explanation to describe the single `[IsFiniteMeasure μ]` wrapper and the probability-measure coverage through the instance.
- Correct the wrapper provenance to `IsProjectiveLimit.unique` in the Layer 0 "Build" bullet and the "What is missing" bullet.
- Keep `map_eq_iff_forall_finset_map_restrict_eq` as a neutral inventory listing, but reword the trailing sentence so it no longer implies the wrapper is built over that lemma.

`TauCetiRoadmap/Exchangeability/Targets.lean`
- Relax the kept finite-marginal-uniqueness example to `[IsFiniteMeasure μ]` only, matching the landed signature.
- Delete the redundant `[IsProbabilityMeasure]` probability-version example.
- Update the docstring to cite `IsProjectiveLimit.unique`.

## Verification

- `lake build TauCetiRoadmap.Exchangeability.Targets` succeeds with only expected `sorry` warnings.
- `map_eq_iff_forall_finset_map_restrict_eq` survives only as the neutral inventory listing.
- The roadmap signature now matches `measure_eq_of_fin_marginals_eq` in merged `TauCeti/Probability/Exchangeability/FiniteMarginals.lean`.
