### PR TITLE
doc: link Mathlib-isms a mathematician would not recognize

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ reviewers, can act on it without guessing.
   result that needs an explicit bound carries `∀ x ∈ s, ‖f x‖ ≤ C` directly in its hypotheses (as
   in `norm_cfc_le`), and uses `Bornology.IsBounded` when no constant is needed
   (`isBounded_iff_forall_norm_le'` relates the two). We do the same, and never wrap a one-line
-  bound in a new predicate.
+  bound in a new predicate. When Mathlib's name for something is itself a Mathlib-ism that a
+  mathematician would not recognize (`ModularFormClass`, say), link the Mathlib declaration the
+  first time you use it, so a reader can see what the term denotes rather than guess.
 
 - **Specify the mathematics, not your existing code.** Say what each milestone should prove,
   intrinsically, so a reviewer can judge it on its own terms. If you're porting existing work,


### PR DESCRIPTION
This PR extends the "Use Mathlib's vocabulary" roadmap rule to cover the case where Mathlib's own name for something is a Mathlib-ism that a mathematician would not recognize (`ModularFormClass`, "cusp function"), asking authors to link the Mathlib declaration on first use so a reader can see what the term denotes rather than guess.

The existing rule told authors to adopt Mathlib's vocabulary but said nothing about flagging it when that vocabulary is non-standard, which is the confusion raised in review of https://github.com/FormalFrontier/TauCetiRoadmap/pull/36 (the "class" and "cusp function" threads).

🤖 Prepared with Claude Code