### PR TITLE
chore: auto-sync roadmap dropdowns and README from the roadmap directories

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,49 @@
+# `.github/scripts`
+
+## `check_roadmap_areas.py`
+
+The roadmap directories under `TauCetiRoadmap/` are the source of truth for the
+list of roadmaps. That list is also copied into the `area` dropdowns of the
+issue templates (`1-intention.yml`, `2-roadmap-issue.yml`) and, with prose
+titles, into the README's "Roadmaps" list. GitHub issue forms have no
+templating, so the dropdown copies cannot be removed.
+
+- `python3 .github/scripts/check_roadmap_areas.py` checks all three against the
+  directories and exits non-zero on drift (handy locally).
+- `--fix` regenerates the two dropdowns from the directory list and heals the
+  README list. The README heal fills gaps only: a missing roadmap is appended
+  with the title taken from its own `# ` heading, an orphaned line is dropped,
+  and the list is renumbered, but existing entries are left exactly as they
+  are, so a curated order or a hand-shortened title is preserved.
+
+The [`sync-roadmap-dropdowns`](../workflows/sync-roadmap-dropdowns.yml) workflow
+runs `--fix` after every merge to `main` that changes the roadmap set and
+commits the result, so contributors never update the dropdowns or remember to
+list a new roadmap themselves. If they did already write a README line (with a
+nicer title than the heading), the heal sees no gap and leaves it untouched.
+
+### One-time setup for the auto-commit
+
+The sync workflow pushes to `main`, which is protected (PR + code-owner review),
+so it authenticates as a dedicated GitHub App that is allowed to bypass that
+requirement. One-time setup by an org admin:
+
+1. **Create the app** (org Settings -> Developer settings -> GitHub Apps -> New).
+   - Webhook: uncheck *Active* (it needs none).
+   - Repository permissions: **Contents: Read and write**, nothing else
+     (Metadata: Read-only is added automatically).
+   - "Where can this app be installed": *Only on this account*.
+2. **Generate a private key** (app page -> bottom -> Generate a private key)
+   and note the numeric **App ID** near the top.
+3. **Install it** on the `FormalFrontier` org, scoped to this repo.
+4. **Store the credentials** on the repo:
+   - `gh variable set SYNC_BOT_APP_ID --body <app-id>`
+   - `gh secret set SYNC_BOT_APP_PRIVATE_KEY < path/to/key.pem`
+5. **Let it bypass the PR requirement on `main`.** Settings -> Branches ->
+   `main` -> "Require a pull request before merging" -> add the app under
+   "Allow specified actors to bypass required pull requests". Nothing else
+   changes: there is no push-actor restriction, and required status checks gate
+   PR merges, not the app's direct push.
+
+If setup is incomplete the workflow still runs and computes the fix, but the
+final `git push` fails, which is a visible signal rather than a silent miss.

--- a/.github/scripts/check_roadmap_areas.py
+++ b/.github/scripts/check_roadmap_areas.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Keep the roadmap list in sync across the repo.
+
+The single source of truth is the set of directories under `TauCetiRoadmap/`
+that contain a `README.md`. That same list is copied, by hand, into the
+`area` dropdowns of two issue templates and into the README's "Roadmaps"
+list. GitHub issue forms are static YAML with no templating, so the copies
+cannot be removed -- but they can be checked, and regenerated.
+
+Run with no arguments to check (exit 1 on drift); run with `--fix` to repair.
+`--fix` regenerates the two dropdowns wholesale, and heals the README list by
+filling gaps only: it appends a missing roadmap (title from that roadmap's own
+`# ` heading) and drops an orphaned line, but never rewrites an existing entry,
+so the curated order and any hand-shortened titles survive.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+ROADMAP_DIR = ROOT / "TauCetiRoadmap"
+DROPDOWN_TEMPLATES = [
+    ROOT / ".github" / "ISSUE_TEMPLATE" / "1-intention.yml",
+    ROOT / ".github" / "ISSUE_TEMPLATE" / "2-roadmap-issue.yml",
+]
+README = ROOT / "README.md"
+
+
+def canonical_areas() -> list[str]:
+    """Roadmap directory names, sorted -- the source of truth."""
+    return sorted(
+        p.name for p in ROADMAP_DIR.iterdir() if (p / "README.md").is_file()
+    )
+
+
+# The `area` dropdown's options are the run of `        - Name` lines that
+# follow the `options:` key under `id: area`. Capture leading whitespace so a
+# rewrite preserves indentation exactly.
+_OPTIONS_BLOCK = re.compile(
+    r"(?m)^(?P<indent> *)id: area\n[\s\S]*?^ *options:\n(?P<options>(?: *- .*\n)+)"
+)
+_OPTION_LINE = re.compile(r"^ *- (?P<name>.+?) *$", re.M)
+
+
+def dropdown_areas(text: str) -> list[str]:
+    m = _OPTIONS_BLOCK.search(text)
+    if not m:
+        return []
+    return _OPTION_LINE.findall(m.group("options"))
+
+
+def rewrite_dropdown(text: str, areas: list[str]) -> str:
+    m = _OPTIONS_BLOCK.search(text)
+    if not m:
+        raise SystemExit("could not find an `id: area` dropdown to rewrite")
+    # Match the indentation already used for the option lines.
+    first = m.group("options").splitlines()[0]
+    lead = first[: len(first) - len(first.lstrip())]
+    block = "".join(f"{lead}- {a}\n" for a in areas)
+    return text[: m.start("options")] + block + text[m.end("options") :]
+
+
+def title_from_h1(area: str) -> str:
+    """A default README title for a roadmap, taken from its own `# ` heading.
+
+    Each roadmap's README opens with `# Roadmap: <title>`; strip that prefix
+    and capitalize. This reproduces the curated root-README title exactly for
+    most roadmaps, and gives a sensible starting point for the rest -- which a
+    human can still shorten by hand, since the healer never rewrites a line
+    that already exists.
+    """
+    for line in (ROADMAP_DIR / area / "README.md").read_text().splitlines():
+        if line.startswith("# "):
+            t = re.sub(r"(?i)^roadmap:\s*", "", line[2:].strip())
+            return t[:1].upper() + t[1:] if t else area
+    return area
+
+
+# A line in the README's "## Roadmaps" list: `N. [Title](TauCetiRoadmap/X/README.md)`.
+_README_ITEM = re.compile(
+    r"^\d+\.\s+\[(?P<title>.+?)\]\(TauCetiRoadmap/(?P<area>[^/]+)/README\.md\)\s*$"
+)
+_README_SECTION = re.compile(r"(?ms)^(## Roadmaps\n\n)(?P<body>.*?)(\n## )")
+
+
+def readme_entries() -> list[tuple[str, str]]:
+    """The (area, title) pairs currently linked in the README list, in order."""
+    m = _README_SECTION.search(README.read_text())
+    if not m:
+        return []
+    out = []
+    for line in m.group("body").splitlines():
+        item = _README_ITEM.match(line)
+        if item:
+            out.append((item.group("area"), item.group("title")))
+    return out
+
+
+def rewrite_readme(text: str, canonical: list[str]) -> str:
+    """Fill gaps in the README list without touching existing curated lines.
+
+    Keep every existing entry whose directory still exists, in its existing
+    order and with its existing title; append any roadmap directory not yet
+    listed (title from its H1); drop any line whose directory is gone; renumber.
+    """
+    m = _README_SECTION.search(text)
+    if not m:
+        raise SystemExit("could not find the '## Roadmaps' list in README.md")
+    present = set(canonical)
+    kept = [(a, t) for a, t in readme_entries() if a in present]
+    listed = {a for a, _ in kept}
+    for area in canonical:  # canonical is sorted, so new entries append stably
+        if area not in listed:
+            kept.append((area, title_from_h1(area)))
+    body = "".join(
+        f"{i}. [{t}](TauCetiRoadmap/{a}/README.md)\n"
+        for i, (a, t) in enumerate(kept, 1)
+    )
+    return text[: m.start("body")] + body + text[m.end("body") :]
+
+
+def main() -> int:
+    fix = "--fix" in sys.argv[1:]
+    canonical = canonical_areas()
+    problems: list[str] = []
+
+    for path in DROPDOWN_TEMPLATES:
+        text = path.read_text()
+        found = dropdown_areas(text)
+        if found == canonical:
+            continue
+        if fix:
+            path.write_text(rewrite_dropdown(text, canonical))
+            print(f"fixed: {path.relative_to(ROOT)}")
+            continue
+        missing = [a for a in canonical if a not in found]
+        extra = [a for a in found if a not in canonical]
+        detail = []
+        if missing:
+            detail.append(f"missing {missing}")
+        if extra:
+            detail.append(f"unknown {extra}")
+        if not detail:  # same set, wrong order
+            detail.append("out of order")
+        problems.append(f"{path.relative_to(ROOT)}: {', '.join(detail)}")
+
+    # The README list keeps its curated order and titles; we only fill gaps
+    # (append a missing roadmap, drop an orphaned line). Existing lines are
+    # never rewritten, so any hand-shortened title survives.
+    rm_text = README.read_text()
+    listed = [a for a, _ in readme_entries()]
+    if sorted(set(listed)) != canonical:
+        if fix:
+            new = rewrite_readme(rm_text, canonical)
+            if new != rm_text:
+                README.write_text(new)
+                print(f"fixed: {README.relative_to(ROOT)}")
+        else:
+            missing = [a for a in canonical if a not in listed]
+            extra = [a for a in listed if a not in canonical]
+            detail = []
+            if missing:
+                detail.append(f"not linked {missing}")
+            if extra:
+                detail.append(f"links a roadmap with no directory {extra}")
+            problems.append(f"README.md: {', '.join(detail)}")
+
+    if problems and not fix:
+        print("Roadmap area lists are out of sync with TauCetiRoadmap/:\n")
+        for p in problems:
+            print(f"  - {p}")
+        print(
+            "\nThe roadmap directories are the source of truth. Run\n"
+            "  python3 .github/scripts/check_roadmap_areas.py --fix\n"
+            "to regenerate the dropdowns and the README list."
+        )
+        return 1
+
+    if not fix:
+        print(f"Roadmap areas in sync ({len(canonical)} roadmaps).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/check_roadmap_areas.py
+++ b/.github/scripts/check_roadmap_areas.py
@@ -38,9 +38,11 @@ def canonical_areas() -> list[str]:
 
 # The `area` dropdown's options are the run of `        - Name` lines that
 # follow the `options:` key under `id: area`. Capture leading whitespace so a
-# rewrite preserves indentation exactly.
+# rewrite preserves indentation exactly. The `(?!^  - )` bound keeps the search
+# inside the `id: area` body item, so it can never reach across into a later
+# field's `options:` even if the templates are refactored.
 _OPTIONS_BLOCK = re.compile(
-    r"(?m)^(?P<indent> *)id: area\n[\s\S]*?^ *options:\n(?P<options>(?: *- .*\n)+)"
+    r"(?m)^(?P<indent> *)id: area\n(?:(?!^  - )[\s\S])*?^ *options:\n(?P<options>(?: *- .*\n)+)"
 )
 _OPTION_LINE = re.compile(r"^ *- (?P<name>.+?) *$", re.M)
 
@@ -100,26 +102,48 @@ def readme_entries() -> list[tuple[str, str]]:
 
 
 def rewrite_readme(text: str, canonical: list[str]) -> str:
-    """Fill gaps in the README list without touching existing curated lines.
+    """Fill gaps in the README list without touching anything else.
 
-    Keep every existing entry whose directory still exists, in its existing
-    order and with its existing title; append any roadmap directory not yet
-    listed (title from its H1); drop any line whose directory is gone; renumber.
+    Replace only the contiguous run of numbered list lines: keep every existing
+    entry whose directory still exists (in order, with its curated title), drop
+    an orphaned line, drop a duplicate, append any roadmap not yet listed (title
+    from its H1), and renumber. Prose before or after the list -- an intro
+    sentence, a note -- is left exactly as it is.
     """
     m = _README_SECTION.search(text)
     if not m:
         raise SystemExit("could not find the '## Roadmaps' list in README.md")
+    lines = m.group("body").split("\n")
+    item_idx = [i for i, ln in enumerate(lines) if _README_ITEM.match(ln)]
+    if not item_idx:
+        raise SystemExit("found no roadmap list items under '## Roadmaps'")
+    # The first contiguous block of list lines; prose may bracket it.
+    start = item_idx[0]
+    end = start
+    for i in item_idx[1:]:
+        if i == end + 1:
+            end = i
+        else:
+            break
+
     present = set(canonical)
-    kept = [(a, t) for a, t in readme_entries() if a in present]
-    listed = {a for a, _ in kept}
+    seen: set[str] = set()
+    kept: list[tuple[str, str]] = []
+    for ln in lines[start : end + 1]:
+        item = _README_ITEM.match(ln)
+        a, t = item.group("area"), item.group("title")
+        if a in present and a not in seen:
+            seen.add(a)
+            kept.append((a, t))
     for area in canonical:  # canonical is sorted, so new entries append stably
-        if area not in listed:
+        if area not in seen:
+            seen.add(area)
             kept.append((area, title_from_h1(area)))
-    body = "".join(
-        f"{i}. [{t}](TauCetiRoadmap/{a}/README.md)\n"
-        for i, (a, t) in enumerate(kept, 1)
-    )
-    return text[: m.start("body")] + body + text[m.end("body") :]
+
+    lines[start : end + 1] = [
+        f"{i}. [{t}](TauCetiRoadmap/{a}/README.md)" for i, (a, t) in enumerate(kept, 1)
+    ]
+    return text[: m.start("body")] + "\n".join(lines) + text[m.end("body") :]
 
 
 def main() -> int:
@@ -152,7 +176,7 @@ def main() -> int:
     # never rewritten, so any hand-shortened title survives.
     rm_text = README.read_text()
     listed = [a for a, _ in readme_entries()]
-    if sorted(set(listed)) != canonical:
+    if sorted(listed) != canonical:  # multiplicity matters, so duplicates show up
         if fix:
             new = rewrite_readme(rm_text, canonical)
             if new != rm_text:
@@ -160,12 +184,15 @@ def main() -> int:
                 print(f"fixed: {README.relative_to(ROOT)}")
         else:
             missing = [a for a in canonical if a not in listed]
-            extra = [a for a in listed if a not in canonical]
+            extra = [a for a in set(listed) if a not in set(canonical)]
+            dups = sorted({a for a in listed if listed.count(a) > 1})
             detail = []
             if missing:
                 detail.append(f"not linked {missing}")
             if extra:
                 detail.append(f"links a roadmap with no directory {extra}")
+            if dups:
+                detail.append(f"listed more than once {dups}")
             problems.append(f"README.md: {', '.join(detail)}")
 
     if problems and not fix:

--- a/.github/workflows/sync-roadmap-dropdowns.yml
+++ b/.github/workflows/sync-roadmap-dropdowns.yml
@@ -32,31 +32,45 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      # Actions are pinned to commit SHAs (not tags): this job runs repository
+      # code with a token that can bypass branch protection, so a moved tag must
+      # not be able to change what executes.
       - name: Mint app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ vars.SYNC_BOT_APP_ID }}
           private-key: ${{ secrets.SYNC_BOT_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Regenerate dropdowns and README list from roadmap directories
-        run: python3 .github/scripts/check_roadmap_areas.py --fix
-
-      - name: Commit if anything changed
+      - name: Sync the dropdowns and README, and push
         run: |
           set -euo pipefail
-          if git diff --quiet; then
-            echo "Dropdowns and README already match the roadmap directories; nothing to do."
-            exit 0
-          fi
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-          git add .github/ISSUE_TEMPLATE/1-intention.yml .github/ISSUE_TEMPLATE/2-roadmap-issue.yml README.md
-          # [skip ci] so this metadata-only commit doesn't trigger a build or
-          # re-trigger this workflow (which would no-op anyway).
-          git commit -m "chore: sync roadmap dropdowns and README list [skip ci]"
-          git push
+          # Regenerate against the freshest main each attempt, so a merge that
+          # races us just gets folded into the next regeneration rather than
+          # causing a non-fast-forward push or leaving drift behind.
+          for attempt in 1 2 3 4 5; do
+            git fetch --quiet origin main
+            git reset --hard --quiet origin/main
+            python3 .github/scripts/check_roadmap_areas.py --fix
+            if git diff --quiet; then
+              echo "Dropdowns and README already match the roadmap directories; nothing to do."
+              exit 0
+            fi
+            git add .github/ISSUE_TEMPLATE/1-intention.yml .github/ISSUE_TEMPLATE/2-roadmap-issue.yml README.md
+            # [skip ci] so this metadata-only commit neither runs a build nor
+            # re-triggers this workflow.
+            git commit --quiet -m "chore: sync roadmap dropdowns and README list [skip ci]"
+            if git push origin HEAD:main; then
+              echo "Pushed sync commit (attempt $attempt)."
+              exit 0
+            fi
+            echo "main moved under us; regenerating and retrying (attempt $attempt)."
+          done
+          echo "Could not push the sync after several retries." >&2
+          exit 1

--- a/.github/workflows/sync-roadmap-dropdowns.yml
+++ b/.github/workflows/sync-roadmap-dropdowns.yml
@@ -1,0 +1,62 @@
+name: Sync roadmap dropdowns
+
+# The roadmap directories under TauCetiRoadmap/ are the source of truth for the
+# list of roadmaps. The `area` dropdowns in the issue templates copy that list,
+# and GitHub issue forms have no templating, so the copy drifts whenever a
+# roadmap is added or removed. Rather than make contributors fix that by hand,
+# this regenerates the dropdowns after every merge that changes the roadmap set
+# and commits the result straight to main.
+#
+# The commit goes to a protected branch, so it runs as a dedicated GitHub App
+# that has Contents:write and is in main's "bypass required pull requests" list.
+# Its id and private key live in the SYNC_BOT_APP_ID variable and the
+# SYNC_BOT_APP_PRIVATE_KEY secret. Setup is in .github/scripts/README.md.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "TauCetiRoadmap/**"
+      - ".github/scripts/check_roadmap_areas.py"
+      - ".github/workflows/sync-roadmap-dropdowns.yml"
+  # Run on demand, e.g. to clear existing drift right after first setup.
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# Never let two syncs race to push to main; the latest state wins.
+concurrency: sync-roadmap-dropdowns
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.SYNC_BOT_APP_ID }}
+          private-key: ${{ secrets.SYNC_BOT_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Regenerate dropdowns and README list from roadmap directories
+        run: python3 .github/scripts/check_roadmap_areas.py --fix
+
+      - name: Commit if anything changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "Dropdowns and README already match the roadmap directories; nothing to do."
+            exit 0
+          fi
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git add .github/ISSUE_TEMPLATE/1-intention.yml .github/ISSUE_TEMPLATE/2-roadmap-issue.yml README.md
+          # [skip ci] so this metadata-only commit doesn't trigger a build or
+          # re-trigger this workflow (which would no-op anyway).
+          git commit -m "chore: sync roadmap dropdowns and README list [skip ci]"
+          git push


### PR DESCRIPTION
This PR makes the roadmap list maintain itself. The directories under `TauCetiRoadmap/` are the source of truth, but the same list is copied by hand into the `area` dropdowns of the two issue templates and into the README, and GitHub issue forms have no templating, so the copies drift every time a roadmap is added. That is what #39 fixes by hand, and the dropdowns on `main` are currently missing both `Exchangeability` and `OrthogonalL2Bases`.

It adds `.github/scripts/check_roadmap_areas.py`, which regenerates the two dropdowns from the directory list and gap-fills the README "Roadmaps" list, taking each missing roadmap's title from its own `# ` heading while leaving every existing entry (its order, and any hand-shortened title) untouched. A companion workflow runs the script with `--fix` after every merge to `main` that changes the roadmap set and commits the result, so contributors never update the dropdowns or remember to list a new roadmap. The commit lands on protected `main` as the dedicated `tau-ceti-roadmap-sync` GitHub App, which holds only `contents: write` and sits in the branch's bypass list; its credentials are the `SYNC_BOT_APP_ID` variable and `SYNC_BOT_APP_PRIVATE_KEY` secret, already configured. Merging this touches the script and workflow paths, so the sync runs immediately and clears the current dropdown drift; it can also be run on demand via `workflow_dispatch`.

This supersedes #39. Routing note: `/.github/` is owned by `@FormalFrontier/humans` per CODEOWNERS, so this needs a humans-team review.

🤖 Prepared with Claude Code