### PR TITLE
OrthogonalL2Bases: add the weight↔measure isometry (both normalizations) + Targets.lean

### DIFF
--- a/TauCetiRoadmap.lean
+++ b/TauCetiRoadmap.lean
@@ -13,3 +13,4 @@ import TauCetiRoadmap.HeegaardFloer.Targets
 import TauCetiRoadmap.GeometricTopology.Targets
 import TauCetiRoadmap.Exchangeability.Targets
 import TauCetiRoadmap.ConformalMapping.Targets
+import TauCetiRoadmap.OrthogonalL2Bases.Targets

--- a/TauCetiRoadmap/OrthogonalL2Bases/README.md
+++ b/TauCetiRoadmap/OrthogonalL2Bases/README.md
@@ -29,7 +29,7 @@ The **Hermite basis of `L²(ℝ)`** is the worked anchor (**Part A**, the v1 del
 family-agnostic spine (**Part B**) is abstracted. The spine is then **exercised by a second family —
 the Chebyshev basis of `L²([-1,1])`** (**Part C**), whose orthogonality relation is already in
 Mathlib and which tests the bridge on a compact weighted measure (not the Gaussian); and it
-yields the **multidimensional Hermite basis** (**Part D**, future). Laguerre and Jacobi are a
+yields the **multidimensional Hermite basis** (**Part D**, a later milestone here). Laguerre and Jacobi are a
 *separate* future roadmap — Mathlib has neither family, so grounding them means defining the
 polynomials first.
 
@@ -58,6 +58,12 @@ L²") is this area's contribution.
 - **The basis layer is family-agnostic and scalar-generic.** Bases are stated through the
   measure-generic `HilbertBasis ι 𝕜 (Lp 𝕜 2 μ)` API over `[RCLike 𝕜]` (the real pointwise
   functions cast via `algebraMap ℝ 𝕜`); do **not** duplicate the API for `ℝ` and `ℂ` separately.
+- **Pin the domain.** The polynomial bridge (B2) and the Hermite/Chebyshev instances fix the
+  reference measure to **`μ : Measure ℝ`** — the bridge evaluates `Polynomial.eval` (needs `ℝ`), and
+  `ℝ` is where the compact-support and interval families (and the Laguerre/Jacobi-on-subsets follow-on)
+  live. The `weightL2Isometry` primitive itself is **not** specialized — it is measure-theoretic and
+  stated over an arbitrary measurable space; only the polynomial-facing layers are `ℝ`. Product/`pi`
+  bases (B3) are over generic measurable factors.
 - **Every basis milestone exports its element-level `coe_*`, not just the bundled term.** A
   `HilbertBasis` shipped only as a bundled term — without `⇑basis = explicit family` — is
   near-vacuous: bare existence of an `ℕ`- (resp. `ι×κ`-) indexed Hilbert basis is just a
@@ -104,7 +110,7 @@ L²") is this area's contribution.
 
 ## What is missing (build here)
 
-The completeness toolkit (both routes), the relation→`HilbertBasis` bridge, and the L²-product-basis
+The completeness toolkit (the moment-determinacy mechanism), the relation→`HilbertBasis` bridge, and the L²-product-basis
 lemma; plus their instances: the Hermite basis (Part A) and the Chebyshev basis (Part C), and the
 multidimensional Hermite basis (Part D). (Laguerre/Jacobi are a separate future roadmap.)
 
@@ -182,8 +188,8 @@ analytic facts (A2–A3) live under `Analysis/SpecialFunctions/…`. Names descr
   `‖f‖² = ∑' n, ‖⟪ψₙ,f⟫‖²`; both `ℝ` and `ℂ` instantiate.
 
 ### A3′ — The Gaussian Hermite basis (measure side; the enhancement's named instance)
-The `weightL2Isometry`-partner of `hermiteHilbertBasis`, on the **probability measure** rather than
-`L²(dx)` — the ONB any `L²(N(0,1))` expansion is taken against.
+The bare-polynomial ONB on the **probability measure** rather than `L²(dx)` — the ONB any `L²(N(0,1))`
+expansion is taken against.
 - **`gaussianHermiteHilbertBasis 𝕜 : HilbertBasis ℕ 𝕜 (Lp 𝕜 2 (gaussianReal 0 1))`** — the bare
   normalized `Hₙ/√(n!)`; the immediate instance of `hilbertBasisOfWeightedMeasure` (B2) with
   `μ = volume`, `w = gaussianPDFReal 0 1`, `cₙ = n!` (since `gaussianReal 0 1 = volume.withDensity
@@ -192,8 +198,19 @@ The `weightL2Isometry`-partner of `hermiteHilbertBasis`, on the **probability me
   `⇑(gaussianHermiteHilbertBasis n) =ᵐ[N(0,1)] fun x => algebraMap ℝ 𝕜 (aeval x (hermite n)/√(n!))`.
 - **`memLp_hermite_gaussianReal (n) (v : ℝ≥0)`** — variance-general `L²` membership of `Hₙ/√(n!)`
   under `gaussianReal 0 v` (the `Hₙ` of a centered Gaussian of any variance).
-- *Acceptance:* `⟨H₀,H₀⟩=⟨H₁,H₁⟩=1`, `⟨H₀,H₂⟩=0` under `N(0,1)`; it is the `mapₗᵢ`-image of
-  `hermiteHilbertBasis` under `weightL2Isometry`.
+- **Relation to the Lebesgue Hermite-function basis — note the dilation.** Applying
+  `weightL2Isometry` (multiplication by `√(gaussianPDFReal 0 1) = (2π)^{-1/4} e^{-x²/4}`) to
+  `gaussianHermiteHilbertBasis` does **not** give the A3 `hermiteHilbertBasis` *as is*: the image is
+  `x ↦ (2π)^{-1/4} Hₙ(x) e^{-x²/4} / √(n!) = 2^{-1/4} · ψₙ(x/√2)`, the **dilated** Hermite-function
+  basis, because v1's `ψₙ(x) = (n!√π)^{-1/2} Hₙ(x√2) e^{-x²/2}` is built on the rescaled argument
+  `x√2`. So the two named bases are related by `weightL2Isometry` **plus the `u = x√2` dilation**, not
+  by the isometry alone. Pin this with a target
+  `weightL2Isometry_gaussianHermiteHilbertBasis_apply` stating the image is `x ↦ 2^{-1/4} ψₙ(x/√2)`
+  (or, equivalently, a `dilation`-equivalence target relating the two). (One could instead base the
+  weighted side on `w = e^{-x²}`, `pₙ = Hₙ(·√2)`, i.e. `N(0,½)`, to make the image exactly `ψₙ`; we
+  keep the standard `N(0,1)` normalization that consumers expect and carry the dilation explicitly.)
+- *Acceptance:* `⟨H₀,H₀⟩=⟨H₁,H₁⟩=1`, `⟨H₀,H₂⟩=0` under `N(0,1)`; and the dilation relation above
+  holds (image `= 2^{-1/4} ψₙ(·/√2)`).
 
 ## Part B — The family-agnostic spine (the reusable layer)
 
@@ -247,18 +264,25 @@ but undischargeable downstream.
 
 **Both normalizations via the weight↔measure isometry (the enhancement).** Two new primitives — both
 genuine Mathlib gaps — make B2's basis available on either side without re-proof:
-- **`weightL2Isometry (μ : Measure ℝ) (w) (hwpos) (hwm) : L²(w·μ) ≃ₗᵢ[𝕜] L²(μ)`**, multiplication by
+- **`weightL2Isometry (μ : Measure α) (w) (hwpos) (hwm) : L²(w·μ) ≃ₗᵢ[𝕜] L²(μ)`**, multiplication by
   `√w` (`w·μ := μ.withDensity (ENNReal.ofReal ∘ w)`); an *equivalence* exactly because `0 < w` a.e.
-  (`‖√w·f‖²_{L²(μ)} = ∫ w|f|² = ‖f‖²_{L²(w·μ)}`).
+  (`‖√w·f‖²_{L²(μ)} = ∫ w|f|² = ‖f‖²_{L²(w·μ)}`). The isometry is purely measure-theoretic, so stated
+  over an **arbitrary** measurable `α` (only the polynomial bridge below needs `Measure ℝ`); it ships
+  the element-level `weightL2Isometry_apply` (a.e. `= √w · f`) as its anti-vacuity pin. Both this and
+  `mapₗᵢ` are general-purpose and are flagged as **upstream-Mathlib candidates**.
 - **`HilbertBasis.mapₗᵢ (b) (e : E ≃ₗᵢ F) : HilbertBasis ι 𝕜 F`** with `@[simp] mapₗᵢ_apply`
   (`ofRepr (e.symm.trans b.repr)`; Mathlib has `ofRepr` but no `≃ₗᵢ`-transport).
 
 So alongside the `√w`-envelope basis of `L²(μ)` above, the bridge also yields the **bare-polynomial
 basis of the weighted measure** `hilbertBasisOfWeightedMeasure : HilbertBasis ℕ 𝕜 (Lp 𝕜 2 (w·μ))` (the
 `pₙ/√cₙ`, with its own `coe_*` — orthogonal polynomials are *natively* an ONB of their weighted `L²`,
-so this needs no rescaling). Either basis is the `mapₗᵢ`-image of the other under `weightL2Isometry`;
-a consumer picks the normalization their space wants. (Chebyshev, Part C, lands its basis directly on
-the weighted `measureT` this way; the Gaussian instance is A3′.)
+so this needs no rescaling). The two are `mapₗᵢ`-images of each other under `weightL2Isometry` — **up
+to the rescaling-argument change of variables noted above**: for a family defined on a rescaled
+argument (Hermite's `Hₙ(x√2)`) the function-side basis carries a dilation, so the bare isometry image
+of the weighted-measure basis is the *dilated* function basis, not the un-dilated one (see A3′). A
+consumer picks the normalization their space wants. (Chebyshev, Part C, lands its basis directly on
+the weighted `measureT` this way — no dilation, since `Tₙ` is not on a rescaled argument; the Gaussian
+instance is A3′.)
 
 ### B3 — L²-product basis
 **The load-bearing milestone is completeness, not orthonormality.** Orthonormality of the products
@@ -314,9 +338,11 @@ rather than the Gaussian — so it tests the σ-finite-`μ` genericity of the br
   `integral_measureT_eq_integral_cos` + a unitary-transfer statement, not from `T_real_cos` alone)
   `chebyshevHilbertBasis` corresponds to the cosine basis under `x = cos θ`.
 
-## Part D — The multidimensional Hermite basis (future; consume B)
+## Part D — The multidimensional Hermite basis (a later milestone of this roadmap; consumes B3)
 
-*Not v1; recorded so Parts A/B are built generically enough to instantiate. Fully grounded — `B3 ∘ A`.*
+*A grounded, sequenced milestone — not "future"/optional: it consumes only B3 (which lands in this
+enhancement) and `A`/`A3′`, and its targets `piHilbertBasis` / `gaussianHermitePiBasis` are stated in
+`Targets.lean`. Sequenced after B3, but in scope here.*
 
 - **Multidimensional Hermite basis** of `L²(ℝᵈ)` — `Ψ_α(x) = ∏ᵢ ψ_{αᵢ}(xᵢ)`, `α : ι → ℕ` — the
   immediate `B3 ∘ A` instantiation: B3 over `ι` copies of the 1-D Hermite basis (A3), a

--- a/TauCetiRoadmap/OrthogonalL2Bases/README.md
+++ b/TauCetiRoadmap/OrthogonalL2Bases/README.md
@@ -14,7 +14,16 @@ This area builds that **L² Hilbert-basis layer** for orthogonal systems:
 - a **completeness** toolkit (moment determinacy / Fourier uniqueness) — the step that upgrades
   "orthogonal" to "complete orthonormal basis";
 - the **orthogonality-relation → `HilbertBasis`** bridge (the √w normalization + Parseval);
+- the **weight↔measure isometry** `L²(w·μ) ≃ₗᵢ L²(μ)` (multiplication by `√w`), so each family's
+  basis is available in **both normalizations** — the bare polynomials as an ONB of the weighted
+  measure `L²(w·μ)`, and their `√w`-envelope functions as an ONB of `L²(μ)` — from one construction;
 - the **L²-product-basis** lemma (a Hilbert basis of `L²(μ ⊗ ν)` from bases of the factors).
+
+Which normalization a consumer wants depends on the space they work over — a weighted / probability
+`L²` (orthogonal-polynomial and polynomial-chaos expansions, moment and spectral problems) or
+`L²(dx)` (eigenfunction expansions: the Hermite functions and QHO eigenstates, Sturm–Liouville / PDE,
+signal processing). The two are isometric but are different `HilbertBasis` objects on different
+spaces, so the area provides **both**, related by the isometry, rather than privileging one.
 
 The **Hermite basis of `L²(ℝ)`** is the worked anchor (**Part A**, the v1 deliverable) from which the
 family-agnostic spine (**Part B**) is abstracted. The spine is then **exercised by a second family —
@@ -88,6 +97,10 @@ L²") is this area's contribution.
 - `OrthonormalBasis.tensorProduct` — **finite-dimensional only** (the algebraic tensor of finite
   bases); there is no completed / `L²(Measure.pi)` product-basis API.
 - `integral_gaussian`; the Fourier-transform API (`Fourier.fourierIntegral`) for the determinacy proof.
+- `ProbabilityTheory.gaussianReal` (+ `gaussianReal_of_var_ne_zero`,
+  `integral_withDensity_eq_integral_smul`) for the measure-side basis (A3′). **Gaps the isometry
+  enhancement fills:** there is no transport of a `HilbertBasis` along a `≃ₗᵢ` (only `ofRepr`), and no
+  `L²(withDensity w) ≃ₗᵢ L²(μ)` change-of-measure isometry.
 
 ## What is missing (build here)
 
@@ -114,8 +127,12 @@ analytic facts (A2–A3) live under `Analysis/SpecialFunctions/…`. Names descr
   `Integrable (fun x => aeval x p * Real.exp (-(x²/2)))`.
 - The one-step weighted-pairing recursion `∫ p·H_{n+1}·w = ∫ p'·Hₙ·w` (one IBP via Rodrigues
   `(Hₙ·w)' = -(H_{n+1}·w)`); and the **generating function** `∑' n, Hₙ(x)·tⁿ/n! = e^{x·t - t²/2}`.
-- **Milestone** `integral_hermite_mul_hermite_mul_gaussian`:
+- **Milestone (Lebesgue form)** `integral_hermite_mul_hermite_mul_gaussian`:
   `∫ x, Hₘ(x)·Hₙ(x)·e^{-x²/2} = if m = n then n!·√(2π) else 0`.
+- **Milestone (Gaussian-measure form)** `integral_hermite_mul_hermite_gaussianReal`:
+  `∫ x, Hₘ(x)·Hₙ(x) ∂(gaussianReal 0 1) = if m = n then n! else 0` — the Lebesgue form above divided by
+  the `√(2π)` density (`integral_withDensity_eq_integral_smul`); the form the measure-side basis (A3,
+  below) consumes directly.
 - *Acceptance:* `H₀=1, H₁=X, H₂=X²-1`; `⟨H₀,H₀⟩=⟨H₁,H₁⟩=√(2π)`; `⟨H₀,H₂⟩=0`; gen. fn. at `t=0` is `1`.
 
 ### A2 — The Hermite functions `ψₙ : ℝ → ℝ`
@@ -163,6 +180,20 @@ analytic facts (A2–A3) live under `Analysis/SpecialFunctions/…`. Names descr
   discharges its `coe_*` obligation against this lemma.
 - *Acceptance:* Parseval for an explicit `f`; coordinates of `ψ₀` are `Finsupp.single 0 1`;
   `‖f‖² = ∑' n, ‖⟪ψₙ,f⟫‖²`; both `ℝ` and `ℂ` instantiate.
+
+### A3′ — The Gaussian Hermite basis (measure side; the enhancement's named instance)
+The `weightL2Isometry`-partner of `hermiteHilbertBasis`, on the **probability measure** rather than
+`L²(dx)` — the ONB any `L²(N(0,1))` expansion is taken against.
+- **`gaussianHermiteHilbertBasis 𝕜 : HilbertBasis ℕ 𝕜 (Lp 𝕜 2 (gaussianReal 0 1))`** — the bare
+  normalized `Hₙ/√(n!)`; the immediate instance of `hilbertBasisOfWeightedMeasure` (B2) with
+  `μ = volume`, `w = gaussianPDFReal 0 1`, `cₙ = n!` (since `gaussianReal 0 1 = volume.withDensity
+  (gaussianPDF 0 1)`, `gaussianReal_of_var_ne_zero`), the orthogonality being the A1 measure form.
+- **`coe_gaussianHermiteHilbertBasis`** —
+  `⇑(gaussianHermiteHilbertBasis n) =ᵐ[N(0,1)] fun x => algebraMap ℝ 𝕜 (aeval x (hermite n)/√(n!))`.
+- **`memLp_hermite_gaussianReal (n) (v : ℝ≥0)`** — variance-general `L²` membership of `Hₙ/√(n!)`
+  under `gaussianReal 0 v` (the `Hₙ` of a centered Gaussian of any variance).
+- *Acceptance:* `⟨H₀,H₀⟩=⟨H₁,H₁⟩=1`, `⟨H₀,H₂⟩=0` under `N(0,1)`; it is the `mapₗᵢ`-image of
+  `hermiteHilbertBasis` under `weightL2Isometry`.
 
 ## Part B — The family-agnostic spine (the reusable layer)
 
@@ -213,6 +244,21 @@ normalized family — so the Hermite (A3) and Chebyshev (Part C) instances obtai
 `coe_*` by **specialization**, not re-derivation. Free from
 `HilbertBasis.coe_mkOfOrthogonalEqBot`; required because a bundle-only bridge output is green
 but undischargeable downstream.
+
+**Both normalizations via the weight↔measure isometry (the enhancement).** Two new primitives — both
+genuine Mathlib gaps — make B2's basis available on either side without re-proof:
+- **`weightL2Isometry (μ : Measure ℝ) (w) (hwpos) (hwm) : L²(w·μ) ≃ₗᵢ[𝕜] L²(μ)`**, multiplication by
+  `√w` (`w·μ := μ.withDensity (ENNReal.ofReal ∘ w)`); an *equivalence* exactly because `0 < w` a.e.
+  (`‖√w·f‖²_{L²(μ)} = ∫ w|f|² = ‖f‖²_{L²(w·μ)}`).
+- **`HilbertBasis.mapₗᵢ (b) (e : E ≃ₗᵢ F) : HilbertBasis ι 𝕜 F`** with `@[simp] mapₗᵢ_apply`
+  (`ofRepr (e.symm.trans b.repr)`; Mathlib has `ofRepr` but no `≃ₗᵢ`-transport).
+
+So alongside the `√w`-envelope basis of `L²(μ)` above, the bridge also yields the **bare-polynomial
+basis of the weighted measure** `hilbertBasisOfWeightedMeasure : HilbertBasis ℕ 𝕜 (Lp 𝕜 2 (w·μ))` (the
+`pₙ/√cₙ`, with its own `coe_*` — orthogonal polynomials are *natively* an ONB of their weighted `L²`,
+so this needs no rescaling). Either basis is the `mapₗᵢ`-image of the other under `weightL2Isometry`;
+a consumer picks the normalization their space wants. (Chebyshev, Part C, lands its basis directly on
+the weighted `measureT` this way; the Gaussian instance is A3′.)
 
 ### B3 — L²-product basis
 **The load-bearing milestone is completeness, not orthonormality.** Orthonormality of the products
@@ -275,6 +321,10 @@ rather than the Gaussian — so it tests the σ-finite-`μ` genericity of the br
 - **Multidimensional Hermite basis** of `L²(ℝᵈ)` — `Ψ_α(x) = ∏ᵢ ψ_{αᵢ}(xᵢ)`, `α : ι → ℕ` — the
   immediate `B3 ∘ A` instantiation: B3 over `ι` copies of the 1-D Hermite basis (A3), a
   `HilbertBasis (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi (fun _ => volume)))`.
+- **Measure-side multidimensional basis** `gaussianHermitePiBasis (ι) [Fintype ι] : HilbertBasis
+  (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi (fun _ => gaussianReal 0 1)))` — `Ψ_α = ∏ᵢ Hₐᵢ/√(αᵢ!)` on `L²(γ^ι)`,
+  the `B3 ∘ A3′` instantiation (with `coe_gaussianHermitePiBasis`); the measure-side partner of the
+  basis above.
 
 **A separate future roadmap:** Laguerre and Jacobi L² bases. Unlike Chebyshev, **Mathlib has neither
 the Laguerre nor the Jacobi polynomials**, so grounding them means defining the families first —

--- a/TauCetiRoadmap/OrthogonalL2Bases/README.md
+++ b/TauCetiRoadmap/OrthogonalL2Bases/README.md
@@ -204,9 +204,9 @@ expansion is taken against.
   `x ↦ (2π)^{-1/4} Hₙ(x) e^{-x²/4} / √(n!) = 2^{-1/4} · ψₙ(x/√2)`, the **dilated** Hermite-function
   basis, because v1's `ψₙ(x) = (n!√π)^{-1/2} Hₙ(x√2) e^{-x²/2}` is built on the rescaled argument
   `x√2`. So the two named bases are related by `weightL2Isometry` **plus the `u = x√2` dilation**, not
-  by the isometry alone. Pin this with a target
-  `weightL2Isometry_gaussianHermiteHilbertBasis_apply` stating the image is `x ↦ 2^{-1/4} ψₙ(x/√2)`
-  (or, equivalently, a `dilation`-equivalence target relating the two). (One could instead base the
+  by the isometry alone. The corresponding Lean lemma
+  `weightL2Isometry_gaussianHermiteHilbertBasis_apply` (image `= 2^{-1/4} ψₙ(·/√2)`) lands together
+  with the A2 `ψₙ` object API it references. (One could instead base the
   weighted side on `w = e^{-x²}`, `pₙ = Hₙ(·√2)`, i.e. `N(0,½)`, to make the image exactly `ψₙ`; we
   keep the standard `N(0,1)` normalization that consumers expect and carry the dilation explicitly.)
 - *Acceptance:* `⟨H₀,H₀⟩=⟨H₁,H₁⟩=1`, `⟨H₀,H₂⟩=0` under `N(0,1)`; and the dilation relation above
@@ -349,8 +349,9 @@ enhancement) and `A`/`A3′`, and its targets `piHilbertBasis` / `gaussianHermit
   `HilbertBasis (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi (fun _ => volume)))`.
 - **Measure-side multidimensional basis** `gaussianHermitePiBasis (ι) [Fintype ι] : HilbertBasis
   (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi (fun _ => gaussianReal 0 1)))` — `Ψ_α = ∏ᵢ Hₐᵢ/√(αᵢ!)` on `L²(γ^ι)`,
-  the `B3 ∘ A3′` instantiation (with `coe_gaussianHermitePiBasis`); the measure-side partner of the
-  basis above.
+  the `B3 ∘ A3′` instantiation (with `coe_gaussianHermitePiBasis`); the standard Gaussian
+  measure-side analogue of the basis above — related to it by the **coordinatewise** `weightL2Isometry`
+  + `u = xᵢ√2` dilation (same caveat as A3′, per coordinate), not by the isometry alone.
 
 **A separate future roadmap:** Laguerre and Jacobi L² bases. Unlike Chebyshev, **Mathlib has neither
 the Laguerre nor the Jacobi polynomials**, so grounding them means defining the families first —

--- a/TauCetiRoadmap/OrthogonalL2Bases/Targets.lean
+++ b/TauCetiRoadmap/OrthogonalL2Bases/Targets.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib
+
+/-!
+# Targets — weighted orthogonal L² bases (`OrthogonalL2Bases`)
+
+Representative `sorry`-milestones for the `OrthogonalL2Bases` roadmap (full narrative and the
+complete API in `README.md`). These state the **weight↔measure-isometry enhancement** — the small
+addition that gives every family's basis in *both* normalizations — on top of the existing layers:
+the new primitive `weightL2Isometry : L²(w·μ) ≃ₗᵢ L²(μ)` and its `HilbertBasis` transport `mapₗᵢ`
+(Part 0); the orthogonality relation (A1, Gaussian-measure form); the bridge producing the
+weighted-measure basis with the `L²(μ)` √w-envelope basis as its `mapₗᵢ`-image (B2); the named
+Gaussian-Hermite instance (A3); and the product / `pi` bases (B3). The Hermite-function object API
+(A2), the function-side `hermiteHilbertBasis`, the completeness toolkit (B1), and the Chebyshev
+instance (Part C) are stated in full in `README.md`; this file seeds the representative core.
+
+Conventions folded in from review (a roadmap reviewer + Codex/GPT-5.4): `μ : Measure ℝ` (the bridge
+evaluates `Polynomial.eval`); `weightL2Isometry` needs only `0 < w` a.e. (no finiteness — the
+`ENNReal.ofReal` density is finite); `mapₗᵢ` body `ofRepr (e.symm.trans b.repr)` (Mathlib has no
+`≃ₗᵢ`-transport); ℕ-smul Hermite derivative; `ℤ[X]` Hermite mapped to `ℝ[X]` via `hermiteℝ`; every
+basis ships a `coe_*` / `*_apply` anti-vacuity pin. Elaborates against the pinned toolchain
+(sorry-warnings only).
+-/
+
+namespace TauCetiRoadmap.OrthogonalL2Bases
+
+open MeasureTheory ProbabilityTheory Polynomial Real
+open scoped NNReal ENNReal
+
+/-! ## Part 0 — weight ↔ measure isometry + basis transport (the unifying primitives) -/
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+
+/-- **Weight ↔ measure isometry.** For an a.e.-positive weight `w`, multiplication by `√w` is a
+linear isometric equivalence `L²(w·μ) ≃ₗᵢ L²(μ)` (`w·μ := μ.withDensity (ofReal ∘ w)`); an
+*equivalence* precisely because `w > 0` a.e. (`hwpos` load-bearing). The single primitive converting
+weight-in-measure ↔ weight-in-function; transports any Hilbert basis across (`mapₗᵢ`). -/
+noncomputable def weightL2Isometry (μ : Measure ℝ) (w : ℝ → ℝ)
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) :
+    Lp 𝕜 2 (μ.withDensity (fun x => ENNReal.ofReal (w x))) ≃ₗᵢ[𝕜] Lp 𝕜 2 μ := sorry
+
+/-- Transport a Hilbert basis along a linear isometric equivalence. Mathlib has `ofRepr` but no
+`≃ₗᵢ`-transport, so this is a needed (one-line) target. -/
+noncomputable def _root_.HilbertBasis.mapₗᵢ {ι : Type*} {E F : Type*}
+    [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+    [NormedAddCommGroup F] [InnerProductSpace 𝕜 F]
+    (b : HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) : HilbertBasis ι 𝕜 F :=
+  HilbertBasis.ofRepr (e.symm.trans b.repr)
+
+@[simp] theorem _root_.HilbertBasis.mapₗᵢ_apply {ι : Type*} {E F : Type*}
+    [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+    [NormedAddCommGroup F] [InnerProductSpace 𝕜 F]
+    (b : HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (i : ι) :
+    (b.mapₗᵢ e) i = e (b i) := sorry
+
+/-! ## Part A1 — Hermite polynomial API (the analytic input; `hermite n : ℤ[X]`) -/
+
+theorem derivative_hermite_succ (n : ℕ) :
+    derivative (hermite (n + 1)) = (n + 1) • hermite n := sorry
+
+theorem integrable_aeval_mul_gaussian (p : ℤ[X]) :
+    Integrable (fun x : ℝ => aeval x p * Real.exp (-(x ^ 2 / 2))) := sorry
+
+theorem hermite_generating_function (x t : ℝ) :
+    ∑' n : ℕ, aeval x (hermite n) * t ^ n / (n.factorial : ℝ) = Real.exp (x * t - t ^ 2 / 2) := sorry
+
+/-- **The orthogonality relation, Gaussian-measure form** — the analytic fact the Gaussian basis
+needs, stated directly against `N(0,1)` (the Lebesgue `∫ Hₘ Hₙ e^{-x²/2} dx = n!√(2π)` form is this
+times `√(2π)`). -/
+theorem integral_hermite_mul_hermite_gaussianReal (m n : ℕ) :
+    (∫ x, aeval x (hermite m) * aeval x (hermite n) ∂(gaussianReal 0 1))
+      = if m = n then (n.factorial : ℝ) else 0 := sorry
+
+/-! ## Part B1 — Completeness toolkit (moment determinacy; supplies `hcomplete`) -/
+
+theorem ae_eq_zero_of_forall_moment_eq_zero (g : ℝ → ℝ)
+    (hexp : ∀ a : ℝ, 0 ≤ a → Integrable (fun x : ℝ => Real.exp (a * |x|) * g x) volume)
+    (hmom : ∀ n : ℕ, ∫ x : ℝ, x ^ n * g x = 0) :
+    g =ᵐ[volume] 0 := sorry
+
+/-! ## Part B2 — orthogonality relation → Hilbert basis (re-keyed: weight in the MEASURE) -/
+
+section WeightedBridge
+variable (p : ℕ → Polynomial ℝ) (w : ℝ → ℝ) (c : ℕ → ℝ)
+
+/-- The bare normalized polynomial `pₙ/√cₙ` as an element of `L²(w·μ; 𝕜)` (scalar-cast). -/
+noncomputable def barePolyLp {μ : Measure ℝ}
+    (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
+      (μ.withDensity (fun x => ENNReal.ofReal (w x)))) (n : ℕ) :
+    Lp 𝕜 2 (μ.withDensity (fun x => ENNReal.ofReal (w x))) :=
+  (hmem n).toLp _
+
+/-- **Orthonormality from the orthogonality relation** `∫ pₘ pₙ w ∂μ = cₙ δ`. -/
+theorem orthonormal_barePolyLp {μ : Measure ℝ}
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hc : ∀ n, 0 < c n)
+    (horth : ∀ m n, (∫ x, (p m).eval x * (p n).eval x * w x ∂μ) = if m = n then c n else 0)
+    (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
+      (μ.withDensity (fun x => ENNReal.ofReal (w x)))) :
+    Orthonormal 𝕜 (barePolyLp (𝕜 := 𝕜) p w c hmem) := sorry
+
+/-- **Completeness target** — uses `hdeg` (the polynomials exhaust all degrees) + moment determinacy
+(B1). Produces the `ᗮ = ⊥` input the assembler consumes. -/
+theorem barePolyLp_ortho_eq_bot {μ : Measure ℝ}
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hc : ∀ n, 0 < c n)
+    (hdeg : ∀ n, (p n).natDegree = n)
+    (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
+      (μ.withDensity (fun x => ENNReal.ofReal (w x)))) :
+    (Submodule.span 𝕜 (Set.range (barePolyLp (𝕜 := 𝕜) p w c hmem)))ᗮ = ⊥ := sorry
+
+/-- **PRIMITIVE (weight in the measure).** The normalized bare polynomials are a Hilbert basis of the
+weighted measure `L²(w·μ)` — the textbook statement and the consumer's object. (`hdeg` is *not* a
+parameter here: completeness `hcomplete` is the input; degree is used only to produce it, in
+`barePolyLp_ortho_eq_bot`.) -/
+noncomputable def hilbertBasisOfWeightedMeasure {μ : Measure ℝ}
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hc : ∀ n, 0 < c n)
+    (horth : ∀ m n, (∫ x, (p m).eval x * (p n).eval x * w x ∂μ) = if m = n then c n else 0)
+    (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
+      (μ.withDensity (fun x => ENNReal.ofReal (w x))))
+    (hcomplete : (Submodule.span 𝕜 (Set.range (barePolyLp (𝕜 := 𝕜) p w c hmem)))ᗮ = ⊥) :
+    HilbertBasis ℕ 𝕜 (Lp 𝕜 2 (μ.withDensity (fun x => ENNReal.ofReal (w x)))) :=
+  HilbertBasis.mkOfOrthogonalEqBot (orthonormal_barePolyLp p w c hwpos hc horth hmem) hcomplete
+
+/-- **DERIVED (weight in the function).** The original Part-A headline — the `pₙ·√w`-type basis of
+`L²(μ)` — is now the `weightL2Isometry`-image of the weighted-measure basis. One line, no separate
+proof. -/
+noncomputable def hilbertBasisOfOrthogonalSystem {μ : Measure ℝ}
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
+    (horth : ∀ m n, (∫ x, (p m).eval x * (p n).eval x * w x ∂μ) = if m = n then c n else 0)
+    (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
+      (μ.withDensity (fun x => ENNReal.ofReal (w x))))
+    (hcomplete : (Submodule.span 𝕜 (Set.range (barePolyLp (𝕜 := 𝕜) p w c hmem)))ᗮ = ⊥) :
+    HilbertBasis ℕ 𝕜 (Lp 𝕜 2 μ) :=
+  (hilbertBasisOfWeightedMeasure p w c hwpos hc horth hmem hcomplete).mapₗᵢ
+    (weightL2Isometry μ w hwpos hwm)
+
+end WeightedBridge
+
+/-! ## Part A3 — the Gaussian Hermite basis (the named target the consumer imports) -/
+
+/-- `Hₙ` over `ℝ` (Mathlib's `hermite n` is `ℤ[X]`; map to `ℝ[X]`). -/
+noncomputable def hermiteℝ (n : ℕ) : Polynomial ℝ := (hermite n).map (Int.castRingHom ℝ)
+
+/-- **Gaussian Hermite ONB of `L²(N(0,1); 𝕜)`** — the bare normalized probabilists' Hermite
+polynomials `Hₙ/√(n!)`. RandomFields' `hermiteGaussianBasis` (at `𝕜 = ℝ`). The immediate instance of
+`hilbertBasisOfWeightedMeasure` (`μ = volume`, `w = gaussianPDFReal 0 1`, `p = hermiteℝ`,
+`cₙ = n!`), since `gaussianReal 0 1 = volume.withDensity (gaussianPDF 0 1)`
+(`gaussianReal_of_var_ne_zero`). -/
+noncomputable def gaussianHermiteHilbertBasis :
+    HilbertBasis ℕ 𝕜 (Lp 𝕜 2 (gaussianReal 0 1)) := sorry
+
+/-- The Gaussian Hermite basis is the explicit `Hₙ/√(n!)` family (the anti-vacuity pin downstream
+needs to compute chaos coordinates). -/
+theorem coe_gaussianHermiteHilbertBasis (n : ℕ) :
+    ⇑(gaussianHermiteHilbertBasis (𝕜 := 𝕜) n) =ᵐ[gaussianReal 0 1]
+      fun x => (algebraMap ℝ 𝕜) (aeval x (hermite n) / Real.sqrt (n.factorial)) := sorry
+
+/-- Variance-general `L²` membership (scalar-cast), for the Wick variables `Hₙ(W h)`. -/
+theorem memLp_hermite_gaussianReal (n : ℕ) (v : ℝ≥0) :
+    MemLp (fun x => (algebraMap ℝ 𝕜) (aeval x (hermite n) / Real.sqrt (n.factorial))) 2
+      (gaussianReal 0 v) := sorry
+
+/-! ## Part B3 — product / pi bases + the Gaussian multi-d instance -/
+
+section Product
+variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+  {μ : Measure α} {ν : Measure β} [SigmaFinite μ] [SigmaFinite ν]
+
+/-- **Product basis** — Hilbert basis of `L²(μ ⊗ ν)` from factor bases (real Mathlib gap; the
+finite-dim `OrthonormalBasis.tensorProduct` only). -/
+noncomputable def prodHilbertBasis {ι₁ ι₂ : Type*}
+    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) :
+    HilbertBasis (ι₁ × ι₂) 𝕜 (Lp 𝕜 2 (μ.prod ν)) := sorry
+
+/-- **Characterization** (anti-vacuity): the `(i,j)` vector is a.e. the product `b₁ i ⊗ b₂ j`. -/
+theorem prodHilbertBasis_apply {ι₁ ι₂ : Type*}
+    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) (i : ι₁) (j : ι₂) :
+    ⇑(prodHilbertBasis b₁ b₂ (i, j)) =ᵐ[μ.prod ν] fun q => (b₁ i) q.1 * (b₂ j) q.2 := sorry
+
+end Product
+
+noncomputable def piHilbertBasis
+    {ι : Type*} [Fintype ι] {α : ι → Type*} [∀ i, MeasurableSpace (α i)]
+    {μ : ∀ i, Measure (α i)} [∀ i, SigmaFinite (μ i)] {κ : ι → Type*}
+    (b : ∀ i, HilbertBasis (κ i) 𝕜 (Lp 𝕜 2 (μ i))) :
+    HilbertBasis (∀ i, κ i) 𝕜 (Lp 𝕜 2 (Measure.pi μ)) := sorry
+
+/-- **Multi-d Gaussian Hermite basis** of `L²(γⁿ)` — `piHilbertBasis` over the 1-D Gaussian basis;
+the Wiener-chaos multi-index basis `Ψ_α = ∏ᵢ Hₐᵢ`. RandomFields' iterated product basis. -/
+noncomputable def gaussianHermitePiBasis (ι : Type*) [Fintype ι] :
+    HilbertBasis (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi (fun _ : ι => gaussianReal 0 1))) :=
+  piHilbertBasis (fun _ => gaussianHermiteHilbertBasis)
+
+/-- Characterization of the multi-d basis (anti-vacuity): `Ψ_α(x) = ∏ᵢ Hₐᵢ(xᵢ)/√(αᵢ!)`. -/
+theorem coe_gaussianHermitePiBasis (ι : Type*) [Fintype ι] (a : ι → ℕ) :
+    ⇑(gaussianHermitePiBasis (𝕜 := 𝕜) ι a)
+      =ᵐ[Measure.pi (fun _ : ι => gaussianReal 0 1)]
+        fun x => ∏ i, (algebraMap ℝ 𝕜) (aeval (x i) (hermite (a i)) / Real.sqrt ((a i).factorial)) :=
+  sorry
+
+end TauCetiRoadmap.OrthogonalL2Bases

--- a/TauCetiRoadmap/OrthogonalL2Bases/Targets.lean
+++ b/TauCetiRoadmap/OrthogonalL2Bases/Targets.lean
@@ -34,13 +34,22 @@ open scoped NNReal ENNReal
 
 variable {𝕜 : Type*} [RCLike 𝕜]
 
-/-- **Weight ↔ measure isometry.** For an a.e.-positive weight `w`, multiplication by `√w` is a
-linear isometric equivalence `L²(w·μ) ≃ₗᵢ L²(μ)` (`w·μ := μ.withDensity (ofReal ∘ w)`); an
-*equivalence* precisely because `w > 0` a.e. (`hwpos` load-bearing). The single primitive converting
-weight-in-measure ↔ weight-in-function; transports any Hilbert basis across (`mapₗᵢ`). -/
-noncomputable def weightL2Isometry (μ : Measure ℝ) (w : ℝ → ℝ)
+/-- **Weight ↔ measure isometry.** For an a.e.-positive weight `w` on *any* measurable space,
+multiplication by `√w` is a linear isometric equivalence `L²(w·μ) ≃ₗᵢ L²(μ)`
+(`w·μ := μ.withDensity (ofReal ∘ w)`); an *equivalence* precisely because `w > 0` a.e. (`hwpos`
+load-bearing). Purely measure-theoretic, so stated over an arbitrary `MeasurableSpace` (only the
+polynomial bridge below needs `Measure ℝ`); a genuine Mathlib gap and an upstream candidate. The
+single primitive converting weight-in-measure ↔ weight-in-function; transports any Hilbert basis
+across (`mapₗᵢ`). -/
+noncomputable def weightL2Isometry {α : Type*} [MeasurableSpace α] (μ : Measure α) (w : α → ℝ)
     (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) :
     Lp 𝕜 2 (μ.withDensity (fun x => ENNReal.ofReal (w x))) ≃ₗᵢ[𝕜] Lp 𝕜 2 μ := sorry
+
+/-- Element-level characterization (anti-vacuity): the isometry is multiplication by `√w`. -/
+theorem weightL2Isometry_apply {α : Type*} [MeasurableSpace α] (μ : Measure α) (w : α → ℝ)
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ)
+    (f : Lp 𝕜 2 (μ.withDensity (fun x => ENNReal.ofReal (w x)))) :
+    weightL2Isometry (𝕜 := 𝕜) μ w hwpos hwm f =ᵐ[μ] fun x => Real.sqrt (w x) • f x := sorry
 
 /-- Transport a Hilbert basis along a linear isometric equivalence. Mathlib has `ofRepr` but no
 `≃ₗᵢ`-transport, so this is a needed (one-line) target. -/
@@ -93,19 +102,25 @@ noncomputable def barePolyLp {μ : Measure ℝ}
     Lp 𝕜 2 (μ.withDensity (fun x => ENNReal.ofReal (w x))) :=
   (hmem n).toLp _
 
-/-- **Orthonormality from the orthogonality relation** `∫ pₘ pₙ w ∂μ = cₙ δ`. -/
+/-- **Orthonormality from the orthogonality relation** `∫ pₘ pₙ w ∂μ = cₙ δ`. `hwm` is needed to
+rewrite the `∫ … w ∂μ` (Lebesgue-side) relation into the inner product over `μ.withDensity w`. -/
 theorem orthonormal_barePolyLp {μ : Measure ℝ}
-    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hc : ∀ n, 0 < c n)
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
     (horth : ∀ m n, (∫ x, (p m).eval x * (p n).eval x * w x ∂μ) = if m = n then c n else 0)
     (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
       (μ.withDensity (fun x => ENNReal.ofReal (w x)))) :
     Orthonormal 𝕜 (barePolyLp (𝕜 := 𝕜) p w c hmem) := sorry
 
-/-- **Completeness target** — uses `hdeg` (the polynomials exhaust all degrees) + moment determinacy
-(B1). Produces the `ᗮ = ⊥` input the assembler consumes. -/
+/-- **Completeness target** — grounded in moment determinacy (B1): the load-bearing hypothesis is
+`hexp`, that the weighted measure `w·μ` has every exponential moment finite (true for Gaussian decay,
+and automatic for compact support), so polynomials are dense in `L²(w·μ)`. Degree growth (`hdeg`)
+alone does **not** give completeness for an arbitrary `μ, w` — `hexp` is what makes it grounded rather
+than a leap. Produces the `ᗮ = ⊥` input the assembler consumes. -/
 theorem barePolyLp_ortho_eq_bot {μ : Measure ℝ}
-    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hc : ∀ n, 0 < c n)
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
     (hdeg : ∀ n, (p n).natDegree = n)
+    (hexp : ∀ a : ℝ, 0 ≤ a →
+      Integrable (fun x : ℝ => Real.exp (a * |x|)) (μ.withDensity (fun x => ENNReal.ofReal (w x))))
     (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
       (μ.withDensity (fun x => ENNReal.ofReal (w x)))) :
     (Submodule.span 𝕜 (Set.range (barePolyLp (𝕜 := 𝕜) p w c hmem)))ᗮ = ⊥ := sorry
@@ -115,13 +130,13 @@ weighted measure `L²(w·μ)` — the textbook statement and the consumer's obje
 parameter here: completeness `hcomplete` is the input; degree is used only to produce it, in
 `barePolyLp_ortho_eq_bot`.) -/
 noncomputable def hilbertBasisOfWeightedMeasure {μ : Measure ℝ}
-    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hc : ∀ n, 0 < c n)
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
     (horth : ∀ m n, (∫ x, (p m).eval x * (p n).eval x * w x ∂μ) = if m = n then c n else 0)
     (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
       (μ.withDensity (fun x => ENNReal.ofReal (w x))))
     (hcomplete : (Submodule.span 𝕜 (Set.range (barePolyLp (𝕜 := 𝕜) p w c hmem)))ᗮ = ⊥) :
     HilbertBasis ℕ 𝕜 (Lp 𝕜 2 (μ.withDensity (fun x => ENNReal.ofReal (w x)))) :=
-  HilbertBasis.mkOfOrthogonalEqBot (orthonormal_barePolyLp p w c hwpos hc horth hmem) hcomplete
+  HilbertBasis.mkOfOrthogonalEqBot (orthonormal_barePolyLp p w c hwpos hwm hc horth hmem) hcomplete
 
 /-- **DERIVED (weight in the function).** The original Part-A headline — the `pₙ·√w`-type basis of
 `L²(μ)` — is now the `weightL2Isometry`-image of the weighted-measure basis. One line, no separate
@@ -133,7 +148,7 @@ noncomputable def hilbertBasisOfOrthogonalSystem {μ : Measure ℝ}
       (μ.withDensity (fun x => ENNReal.ofReal (w x))))
     (hcomplete : (Submodule.span 𝕜 (Set.range (barePolyLp (𝕜 := 𝕜) p w c hmem)))ᗮ = ⊥) :
     HilbertBasis ℕ 𝕜 (Lp 𝕜 2 μ) :=
-  (hilbertBasisOfWeightedMeasure p w c hwpos hc horth hmem hcomplete).mapₗᵢ
+  (hilbertBasisOfWeightedMeasure p w c hwpos hwm hc horth hmem hcomplete).mapₗᵢ
     (weightL2Isometry μ w hwpos hwm)
 
 end WeightedBridge

--- a/TauCetiRoadmap/OrthogonalL2Bases/Targets.lean
+++ b/TauCetiRoadmap/OrthogonalL2Bases/Targets.lean
@@ -90,6 +90,18 @@ theorem ae_eq_zero_of_forall_moment_eq_zero (g : ℝ → ℝ)
     (hmom : ∀ n : ℕ, ∫ x : ℝ, x ^ n * g x = 0) :
     g =ᵐ[volume] 0 := sorry
 
+/-- **B1, measure level** — the determinacy result the *weighted-measure* bridge actually needs
+(`ae_eq_zero_of_forall_moment_eq_zero` above is the `volume`/function instance; `barePolyLp_ortho_eq_bot`
+is for an arbitrary `μ`, so it must rest on a measure-level statement). A finite measure `ν` on `ℝ`
+with every exponential moment finite is moment-determinate, so a `g ∈ L²(ν)` orthogonal to every
+monomial is a.e. `0`. (Finiteness is the `a = 0` case of `hexp`.) -/
+theorem ae_eq_zero_of_forall_moment_eq_zero_of_finite_expMoments
+    {ν : Measure ℝ} [IsFiniteMeasure ν]
+    (hexp : ∀ a : ℝ, 0 ≤ a → Integrable (fun x : ℝ => Real.exp (a * |x|)) ν)
+    {g : ℝ → 𝕜} (hg : MemLp g 2 ν)
+    (hmom : ∀ n : ℕ, ∫ x, (algebraMap ℝ 𝕜 x) ^ n * g x ∂ν = 0) :
+    g =ᵐ[ν] 0 := sorry
+
 /-! ## Part B2 — orthogonality relation → Hilbert basis (re-keyed: weight in the MEASURE) -/
 
 section WeightedBridge
@@ -111,14 +123,17 @@ theorem orthonormal_barePolyLp {μ : Measure ℝ}
       (μ.withDensity (fun x => ENNReal.ofReal (w x)))) :
     Orthonormal 𝕜 (barePolyLp (𝕜 := 𝕜) p w c hmem) := sorry
 
-/-- **Completeness target** — grounded in moment determinacy (B1): the load-bearing hypothesis is
-`hexp`, that the weighted measure `w·μ` has every exponential moment finite (true for Gaussian decay,
-and automatic for compact support), so polynomials are dense in `L²(w·μ)`. Degree growth (`hdeg`)
-alone does **not** give completeness for an arbitrary `μ, w` — `hexp` is what makes it grounded rather
-than a leap. Produces the `ᗮ = ⊥` input the assembler consumes. -/
+/-- **Completeness target** — grounded in moment determinacy
+(`ae_eq_zero_of_forall_moment_eq_zero_of_finite_expMoments`, B1 measure level, applied to `ν = w·μ`):
+the load-bearing hypothesis is `hexp`, that the weighted measure `w·μ` has every exponential moment
+finite (true for Gaussian decay, automatic for compact support), so polynomials are dense in
+`L²(w·μ)`. Degree alone does **not** give completeness for an arbitrary `μ, w` — `hexp` is what makes
+it grounded. Note `hdeg` uses `degree` (not `natDegree`): `natDegree 0 = 0` would let `p 0 = 0` slip
+through and kill the basis (e.g. `μ = δ₀`), so we require the genuine degree, forcing `p n ≠ 0`.
+Produces the `ᗮ = ⊥` input the assembler consumes. -/
 theorem barePolyLp_ortho_eq_bot {μ : Measure ℝ}
     (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
-    (hdeg : ∀ n, (p n).natDegree = n)
+    (hdeg : ∀ n, (p n).degree = (n : WithBot ℕ))
     (hexp : ∀ a : ℝ, 0 ≤ a →
       Integrable (fun x : ℝ => Real.exp (a * |x|)) (μ.withDensity (fun x => ENNReal.ofReal (w x))))
     (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
@@ -151,6 +166,27 @@ noncomputable def hilbertBasisOfOrthogonalSystem {μ : Measure ℝ}
   (hilbertBasisOfWeightedMeasure p w c hwpos hwm hc horth hmem hcomplete).mapₗᵢ
     (weightL2Isometry μ w hwpos hwm)
 
+/-- Element-level pin for the weighted-measure basis (immediate from `coe_mkOfOrthogonalEqBot`). -/
+theorem coe_hilbertBasisOfWeightedMeasure {μ : Measure ℝ}
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
+    (horth : ∀ m n, (∫ x, (p m).eval x * (p n).eval x * w x ∂μ) = if m = n then c n else 0)
+    (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
+      (μ.withDensity (fun x => ENNReal.ofReal (w x))))
+    (hcomplete : (Submodule.span 𝕜 (Set.range (barePolyLp (𝕜 := 𝕜) p w c hmem)))ᗮ = ⊥) :
+    ⇑(hilbertBasisOfWeightedMeasure p w c hwpos hwm hc horth hmem hcomplete)
+      = barePolyLp (𝕜 := 𝕜) p w c hmem := sorry
+
+/-- Element-level pin for the derived function-side basis: the `weightL2Isometry` image of the
+weighted-measure basis (from `mapₗᵢ_apply` + `coe_hilbertBasisOfWeightedMeasure`). -/
+theorem coe_hilbertBasisOfOrthogonalSystem {μ : Measure ℝ}
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
+    (horth : ∀ m n, (∫ x, (p m).eval x * (p n).eval x * w x ∂μ) = if m = n then c n else 0)
+    (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) ((p n).eval x / Real.sqrt (c n))) 2
+      (μ.withDensity (fun x => ENNReal.ofReal (w x))))
+    (hcomplete : (Submodule.span 𝕜 (Set.range (barePolyLp (𝕜 := 𝕜) p w c hmem)))ᗮ = ⊥) (n : ℕ) :
+    hilbertBasisOfOrthogonalSystem p w c hwpos hwm hc horth hmem hcomplete n
+      = weightL2Isometry μ w hwpos hwm (barePolyLp (𝕜 := 𝕜) p w c hmem n) := sorry
+
 end WeightedBridge
 
 /-! ## Part A3 — the Gaussian Hermite basis (the named target the consumer imports) -/
@@ -159,8 +195,8 @@ end WeightedBridge
 noncomputable def hermiteℝ (n : ℕ) : Polynomial ℝ := (hermite n).map (Int.castRingHom ℝ)
 
 /-- **Gaussian Hermite ONB of `L²(N(0,1); 𝕜)`** — the bare normalized probabilists' Hermite
-polynomials `Hₙ/√(n!)`. RandomFields' `hermiteGaussianBasis` (at `𝕜 = ℝ`). The immediate instance of
-`hilbertBasisOfWeightedMeasure` (`μ = volume`, `w = gaussianPDFReal 0 1`, `p = hermiteℝ`,
+polynomials `Hₙ/√(n!)`, the standard ONB any `L²(N(0,1))` expansion is taken against. The immediate
+instance of `hilbertBasisOfWeightedMeasure` (`μ = volume`, `w = gaussianPDFReal 0 1`, `p = hermiteℝ`,
 `cₙ = n!`), since `gaussianReal 0 1 = volume.withDensity (gaussianPDF 0 1)`
 (`gaussianReal_of_var_ne_zero`). -/
 noncomputable def gaussianHermiteHilbertBasis :
@@ -203,7 +239,8 @@ noncomputable def piHilbertBasis
     HilbertBasis (∀ i, κ i) 𝕜 (Lp 𝕜 2 (Measure.pi μ)) := sorry
 
 /-- **Multi-d Gaussian Hermite basis** of `L²(γⁿ)` — `piHilbertBasis` over the 1-D Gaussian basis;
-the Wiener-chaos multi-index basis `Ψ_α = ∏ᵢ Hₐᵢ`. RandomFields' iterated product basis. -/
+the multi-index Hermite basis `Ψ_α = ∏ᵢ Hₐᵢ`, the standard basis for multivariate Gaussian L² /
+chaos expansions. -/
 noncomputable def gaussianHermitePiBasis (ι : Type*) [Fintype ι] :
     HilbertBasis (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi (fun _ : ι => gaussianReal 0 1))) :=
   piHilbertBasis (fun _ => gaussianHermiteHilbertBasis)

--- a/TauCetiRoadmap/OrthogonalL2Bases/Targets.lean
+++ b/TauCetiRoadmap/OrthogonalL2Bases/Targets.lean
@@ -51,6 +51,12 @@ theorem weightL2Isometry_apply {α : Type*} [MeasurableSpace α] (μ : Measure �
     (f : Lp 𝕜 2 (μ.withDensity (fun x => ENNReal.ofReal (w x)))) :
     weightL2Isometry (𝕜 := 𝕜) μ w hwpos hwm f =ᵐ[μ] fun x => Real.sqrt (w x) • f x := sorry
 
+/-- Inverse direction (multiplication by `(√w)⁻¹`), closing the both-normalizations loop. -/
+theorem weightL2Isometry_symm_apply {α : Type*} [MeasurableSpace α] (μ : Measure α) (w : α → ℝ)
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (g : Lp 𝕜 2 μ) :
+    (weightL2Isometry (𝕜 := 𝕜) μ w hwpos hwm).symm g
+      =ᵐ[μ] fun x => (Real.sqrt (w x))⁻¹ • g x := sorry
+
 /-- Transport a Hilbert basis along a linear isometric equivalence. Mathlib has `ofRepr` but no
 `≃ₗᵢ`-transport, so this is a needed (one-line) target. -/
 noncomputable def _root_.HilbertBasis.mapₗᵢ {ι : Type*} {E F : Type*}
@@ -94,9 +100,11 @@ theorem ae_eq_zero_of_forall_moment_eq_zero (g : ℝ → ℝ)
 (`ae_eq_zero_of_forall_moment_eq_zero` above is the `volume`/function instance; `barePolyLp_ortho_eq_bot`
 is for an arbitrary `μ`, so it must rest on a measure-level statement). A finite measure `ν` on `ℝ`
 with every exponential moment finite is moment-determinate, so a `g ∈ L²(ν)` orthogonal to every
-monomial is a.e. `0`. (Finiteness is the `a = 0` case of `hexp`.) -/
+monomial is a.e. `0`. Finiteness is **not** a separate hypothesis: it is the `a = 0` case of `hexp`
+(`Integrable (fun _ => 1) ν`, i.e. `IsFiniteMeasure ν`), derived inside the proof — so the caller
+`barePolyLp_ortho_eq_bot`, which has only `hexp` for `ν = w·μ`, can apply this directly with no leap. -/
 theorem ae_eq_zero_of_forall_moment_eq_zero_of_finite_expMoments
-    {ν : Measure ℝ} [IsFiniteMeasure ν]
+    {ν : Measure ℝ}
     (hexp : ∀ a : ℝ, 0 ≤ a → Integrable (fun x : ℝ => Real.exp (a * |x|)) ν)
     {g : ℝ → 𝕜} (hg : MemLp g 2 ν)
     (hmom : ∀ n : ℕ, ∫ x, (algebraMap ℝ 𝕜 x) ^ n * g x ∂ν = 0) :


### PR DESCRIPTION
A small **additive** enhancement to the `OrthogonalL2Bases` roadmap (v1 kept intact, no API dropped), plus the `Targets.lean` promised at the #25 merge. Intention/claim: **#46**.

## What & why

One orthogonal family gives two bases depending on where the weight sits: the bare polynomials `Hₙ/√(n!)` as an ONB of the **weighted / probability** `L²` (e.g. `N(0,1)` — expansions, moment problems, chaos), or the `Hₙ·√w` functions as an ONB of **Lebesgue** `L²(dx)` (Hermite functions / QHO states, PDE, signal processing). The two are isometric — related by `weightL2Isometry : L²(w·μ) ≃ₗᵢ L²(μ)` (multiplication by `√w`) — but are different `HilbertBasis` objects on different spaces. This adds that isometry (plus the `HilbertBasis.mapₗᵢ` transport Mathlib lacks) so both normalizations come from one construction; neither is privileged.

*(Note: for a family on a rescaled argument like Hermite's `Hₙ(x√2)`, the function-side basis is the isometry image **plus a `u=x√2` dilation** — the `N(0,1)` basis maps to `2^{-1/4}·ψₙ(·/√2)`, the dilated Hermite functions, not `hermiteHilbertBasis` directly. The README states this explicitly.)*

## Additions

- **Part 0:** `weightL2Isometry` (+ `weightL2Isometry_apply`/`_symm_apply`), `HilbertBasis.mapₗᵢ` (+ `mapₗᵢ_apply`).
- **A1:** Gaussian-measure orthogonality `integral_hermite_mul_hermite_gaussianReal` alongside the Lebesgue form.
- **B1:** measure-level determinacy `ae_eq_zero_of_forall_moment_eq_zero_of_finite_expMoments`.
- **B2:** `barePolyLp`, `orthonormal_barePolyLp`, `barePolyLp_ortho_eq_bot` (grounded on the `hexp` moment-determinacy hypothesis), `hilbertBasisOfWeightedMeasure` + derived `hilbertBasisOfOrthogonalSystem`, with `coe_*` pins.
- **A3′:** `gaussianHermiteHilbertBasis` (+ `coe_*`, `memLp_hermite_gaussianReal`).
- **B3 / Part D:** product/`pi` bases + `gaussianHermitePiBasis`.

v1's Hermite-function API (A2), function-side `hermiteHilbertBasis`, the B1–B3 spine, and Chebyshev (Part C) are unchanged.

## Scope vs. #46

`Targets.lean` seeds **representative target signatures** for the core layers, which *includes* the B1 determinacy and B3 product/`pi` signatures. The **implementation** claim in intention #46 is narrower (Part 0 / A1 / B2 / A3′); the B1/B3 *signatures* here are stated so the file is self-contained, not claimed as implementation work.

## Status

Rebased on `main`; root `lake build TauCetiRoadmap` green on the pin (v4.31.0-rc1), `sorry`-warnings only (the new `Targets.lean` is wired into the root aggregator). A1 polynomial API + Lebesgue orthogonality is implemented in FormalFrontier/TauCeti#499 (held as draft). Review feedback (external 3-pass + our own Codex pass) addressed across the history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)