### PR TITLE
doc: README.md is the definitive roadmap, Targets.lean suggested forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,12 @@
 
 The human-controlled roadmaps for [Tau Ceti](https://github.com/TauCetiProject/TauCeti), an
 AIs-welcome Lean 4 library downstream of Mathlib. Humans steer the project from here: each
-roadmap is markdown plus Lean target signatures (with `sorry`, which is allowed in this repo
-because these are goals, not proofs). The AI-authored mathematics that discharges them lives
+roadmap is a markdown `README.md`, the definitive specification of its area, usually with
+suggested Lean target signatures in `Targets.lean` (with `sorry`, which is allowed in this
+repo because these are goals, not proofs). `Targets.lean` is never exhaustive: it pins names
+and signatures for particular milestones so contributors and reviewers converge, and a
+roadmap is finished only when the maintainers judge its `README.md` discharged, never
+because everything in its `Targets.lean` has landed. The AI-authored mathematics lives
 in the code repo; review machinery lives in
 [TauCetiReview](https://github.com/TauCetiProject/TauCetiReview).
 
@@ -74,7 +78,8 @@ reviewers, can act on it without guessing.
 
 - **Write Lean code.** It's really helpful to prototype signatures, particularly for structures,
   classes, and definitions, by writing Lean code, either embedded in markdown or in associated
-  Lean files using `sorry`.
+  Lean files using `sorry`. The prototypes are aids, not the specification: the markdown stays
+  definitive, and `Targets.lean` is read as suggested forms, never as an exhaustive checklist.
 
 - **Pin conventions.** It's essential that you decide conventions ahead of time, or implementors
   will make bad decisions.

--- a/TauCetiRoadmap.lean
+++ b/TauCetiRoadmap.lean
@@ -1,7 +1,8 @@
 -- Human-owned root of the roadmap target signatures.
 --
--- The narrative roadmaps live in the per-topic `README.md` files; the Lean
--- `Targets.lean` files state the goals (with `sorry`, which is allowed here).
+-- The per-topic `README.md` files are the definitive roadmaps. The Lean `Targets.lean`
+-- files suggest declaration forms for particular milestones (with `sorry`, which is
+-- allowed here); they are not exhaustive, and discharging one does not finish its roadmap.
 import TauCetiRoadmap.Multiquadratic.Targets
 import TauCetiRoadmap.UniversalCovers.Targets
 import TauCetiRoadmap.JacobianChallenge.Targets

--- a/TauCetiRoadmap/CombinatorialHeegaardFloer/Targets.lean
+++ b/TauCetiRoadmap/CombinatorialHeegaardFloer/Targets.lean
@@ -3,6 +3,11 @@ import Mathlib
 /-!
 # Combinatorial Heegaard Floer and grid homology: target signatures
 
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
 The narrative roadmap is in `README.md`: the combinatorial bodies of theory that are
 formalizable now — grid homology (Lane G), bigraded and filtered homological algebra
 (Lane ALG), knot-theory reconciliation (Lane K), lattice homology (Lane L), and the

--- a/TauCetiRoadmap/ConformalMapping/Targets.lean
+++ b/TauCetiRoadmap/ConformalMapping/Targets.lean
@@ -3,6 +3,11 @@ import Mathlib
 /-!
 # Conformal mapping and geometric function theory: target signatures
 
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
 The narrative roadmap (layers, proof routes, generality bar, references, downstream uses)
 is in `README.md`. Mathlib has the Cauchy foundations — open mapping
 (`Complex.AnalyticOnNhd.is_constant_or_isOpenMap`), maximum modulus (`Analysis/Complex/AbsMax`),

--- a/TauCetiRoadmap/GeometricTopology/Targets.lean
+++ b/TauCetiRoadmap/GeometricTopology/Targets.lean
@@ -3,6 +3,11 @@ import Mathlib
 /-!
 # Geometric topology and the Kirby-list problems: target signatures
 
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
 The narrative roadmap is in `README.md`: eleven layers of differential and geometric
 topology built bottom-up from current Mathlib (the manifold buildout and structure
 groups; locally flat embeddings; diffeomorphism-group topologies; knot theory; Dehn

--- a/TauCetiRoadmap/HeegaardFloer/Targets.lean
+++ b/TauCetiRoadmap/HeegaardFloer/Targets.lean
@@ -3,6 +3,11 @@ import Mathlib
 /-!
 # Heegaard Floer homology, analytically: target signatures
 
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
 The narrative roadmap is in `README.md`: the analytic tower — Morse homology
 (Lane M), the Fredholm/Sard–Smale substrate (Lane F0), the Cauchy–Riemann elliptic
 package (Lane F1), J-holomorphic curves (Lane F2), exact Lagrangian Floer homology

--- a/TauCetiRoadmap/JacobianChallenge/Targets.lean
+++ b/TauCetiRoadmap/JacobianChallenge/Targets.lean
@@ -3,6 +3,11 @@ import Mathlib
 /-!
 # Jacobian challenge (AG version): target signatures
 
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
 The narrative roadmap, the prerequisite tower (Layers A–E), and the acceptance
 criteria are in `README.md`. Almost none of the prerequisites are in Mathlib; the tower
 is built in `TauCeti/AlgebraicGeometry/`.

--- a/TauCetiRoadmap/Multiquadratic/Targets.lean
+++ b/TauCetiRoadmap/Multiquadratic/Targets.lean
@@ -3,6 +3,11 @@ import Mathlib
 /-!
 # Multiquadratic fields and genus theory: target signatures
 
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
 The narrative roadmap (the layer-by-layer build plan Layers 0–3, the worked examples, and
 the references) is in `README.md`. Mathlib has quadratic fields, Kummer theory, quadratic
 reciprocity, and the class group, but nothing on multiquadratic extensions

--- a/TauCetiRoadmap/OrthogonalL2Bases/Targets.lean
+++ b/TauCetiRoadmap/OrthogonalL2Bases/Targets.lean
@@ -7,6 +7,11 @@ import Mathlib
 /-!
 # Targets — weighted orthogonal L² bases (`OrthogonalL2Bases`)
 
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
 Representative `sorry`-milestones for the `OrthogonalL2Bases` roadmap (full narrative and the
 complete API in `README.md`). These state the **weight↔measure-isometry enhancement** — the small
 addition that gives every family's basis in *both* normalizations — on top of the existing layers:

--- a/TauCetiRoadmap/PDE/Targets.lean
+++ b/TauCetiRoadmap/PDE/Targets.lean
@@ -3,6 +3,11 @@ import Mathlib
 /-!
 # Partial differential equations: target signatures
 
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
 The narrative roadmap, the build lanes (A–F), and the acceptance criteria are in
 `README.md`. Mathlib already carries a substantial prerequisite stack: distributions and
 test functions, the Schwartz space, the Fourier transform, convolution and mollifiers,

--- a/TauCetiRoadmap/ReductiveGroups/Targets.lean
+++ b/TauCetiRoadmap/ReductiveGroups/Targets.lean
@@ -3,6 +3,11 @@ import Mathlib
 /-!
 # Reductive algebraic groups: target signatures
 
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
 The narrative roadmap (the three synchronized models, the layer-by-layer build plan
 Layers 0–7, the worked examples, and the references) is in `README.md`.
 

--- a/TauCetiRoadmap/UniversalCovers/Targets.lean
+++ b/TauCetiRoadmap/UniversalCovers/Targets.lean
@@ -3,6 +3,11 @@ import Mathlib
 /-!
 # Universal covers: target signatures
 
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
 The narrative roadmap is in `README.md`. Mathlib already has the covering-space,
 lifting, fundamental-groupoid, and homotopy-group toolkit; what is missing is the
 **universal cover construction** and the **deck transformation group**, which we port


### PR DESCRIPTION
This PR states explicitly, everywhere a contributor forms their model of what a roadmap is, that the markdown `README.md` is the definitive roadmap document and that `Targets.lean` only records suggested Lean forms for particular milestones. `Targets.lean` is never exhaustive: discharging every statement in it finishes neither a layer nor the roadmap, and completion is a maintainer judgment against the `README.md`. Autonomous workers have been observed weighting `Targets.lean` as if it were the specification, so the correction goes in every place they look: the root README's opening paragraph and its "Write Lean code" bullet, the root `TauCetiRoadmap.lean` header, and a standard paragraph at the top of each area's `Targets.lean` docstring (all areas except `EffectiveBounds`, which https://github.com/TauCetiProject/TauCetiRoadmap/pull/50 archives, and `Exchangeability`, whose header is rewritten with the same framing in a follow-up PR adding its next-layer targets).

🤖 Prepared with Claude Code
