### PR TITLE
doc: guide roadmap authors to check in-flight Mathlib work and prefer sorry to Prop placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ reviewers, can act on it without guessing.
   target. If the roadmap needs something that doesn't exist, building it must itself be a target,
   here or in a roadmap you cite. The bigger the gap, the worse AIs do with it.
 
+- **Check what's already in motion.** Before specifying an object, search Zulip and the open Mathlib
+  PRs for it — someone may already be building the API, settling the design, or have formalized it.
+  Cite what you find, follow the direction it's taking, and flag milestones that will refactor onto
+  in-flight Mathlib work once it lands. Reinventing an API Mathlib is already building, or picking a
+  convention the community is deciding against, wastes the work.
+
 - **Use Mathlib's vocabulary.** Where Mathlib already has a way to say something, use it rather
   than a private version, both in the roadmap and in the code. A standard notion said in our own
   dialect drifts from the library it builds on and grows a redundant theory of lemmas Mathlib
@@ -80,7 +86,10 @@ reviewers, can act on it without guessing.
 - **Write Lean code.** It's really helpful to prototype signatures, particularly for structures,
   classes, and definitions, by writing Lean code, either embedded in markdown or in associated
   Lean files using `sorry`. The prototypes are aids, not the specification: the markdown stays
-  definitive, and `Suggested.lean` is read as suggested forms, never as an exhaustive checklist.
+  definitive, and `Suggested.lean` is read as suggested forms, never as an exhaustive checklist —
+  open each `Suggested.lean` with the standard note saying so. Use `sorry` honestly: a condition you
+  cannot yet even *state* (its Mathlib API doesn't exist) is still a `sorry`, never a field of type
+  `Prop` — a `Prop` field is satisfied by any proposition, so `True` silently empties every instance.
 
 - **Pin conventions.** It's essential that you decide conventions ahead of time, or implementors
   will make bad decisions.


### PR DESCRIPTION
This PR adds two pieces of standing advice to the roadmap-writing guide, distilled from a review round on the VHS roadmap where the gaps were general rather than specific to that entry.

The first is a *Check what's already in motion* principle: search Zulip and open Mathlib PRs before specifying an object, cite what you find, follow the direction the discussion is taking, and flag milestones that will refactor onto an in-flight Mathlib development once it lands. The concrete failure it guards against is reinventing an API Mathlib is already building (Deligne opposed filtrations, the `IsBaseChange` complexification model), or committing to a convention the community is deciding against.

The second folds two conventions into the *Write Lean code* bullet: open every `Suggested.lean` with the standard non-exhaustiveness note, and use `sorry` honestly — a condition you cannot yet even state is still a `sorry`, never a field of type `Prop`, because a `Prop`-typed placeholder is satisfied by any proposition and so `True` silently makes every instance vacuous.

🤖 Prepared with Claude Code