### PR TITLE
doc: reword the Prop-placeholder advice in plain language

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ reviewers, can act on it without guessing.
   definitive, and `Suggested.lean` is read as suggested forms, never as an exhaustive checklist —
   open each `Suggested.lean` with the standard note saying so. Use `sorry` honestly: a condition you
   cannot yet even *state* (its Mathlib API doesn't exist) is still a `sorry`, never a field of type
-  `Prop` — a `Prop` field is satisfied by any proposition, so `True` silently empties every instance.
+  `Prop` — a `Prop` field can be satisfied by any proposition, so an instance can fill it with `True`
+  and the condition asserts nothing.
 
 - **Pin conventions.** It's essential that you decide conventions ahead of time, or implementors
   will make bad decisions.


### PR DESCRIPTION
This PR rewords one sentence in the roadmap-writing guide added in #59. "so `True` silently empties every instance" misused "empty" — you cannot empty an instance. Replace it with a plain statement: a `Prop` field can be satisfied by any proposition, so an instance can fill it with `True` and the condition asserts nothing.

🤖 Prepared with Claude Code