### PR TITLE
fix(ContourIntegration): give condition (A′) the pole orders it needs

### DIFF
--- a/TauCetiRoadmap/ContourIntegration/Suggested.lean
+++ b/TauCetiRoadmap/ContourIntegration/Suggested.lean
@@ -100,10 +100,11 @@ def IsNullHomologous (γ : ℝ → ℂ) (a b : ℝ) (Ω : Set ℂ) : Prop :=
   ∀ w ∉ Ω, windingNumber γ a b w = 0
 
 /-- HW condition **(A′)**: the cycle `γ` approaches each on-cycle singularity in `S` transversally,
-meeting it as a finite union of model sectors with a prescribed pole order (HW §3). One of the two
-regularity conditions that make the principal value exist; stated explicitly so the summit is
-honest. -/
-def ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (S : Finset ℂ) : Prop := sorry
+meeting it as a finite union of model sectors, **flat of order equal to the order of `f`'s pole
+there** (HW §3). One of the two regularity conditions that make the principal value exist; stated
+explicitly so the summit is honest. The prescribed pole orders come from `f` (read off by
+`meromorphicOrderAt`), so `f` is part of the data: the point set `S` alone cannot supply them. -/
+def ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : Finset ℂ) : Prop := sorry
 
 /-- HW condition **(B)**: the higher-order Laurent principal parts cancel under the
 sector-cancellation identity at each on-cycle singularity, so the principal value exists for poles of
@@ -223,7 +224,7 @@ theorem hungerbuhlerWasem_residueTheorem {f : ℂ → ℂ} {U : Set ℂ} (hU : I
     (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
     (hmero : ∀ s ∈ S, MeromorphicAt f s)
     (hnull : IsNullHomologous γ a b U)
-    (hA : ConditionAprime γ a b S) (hB : ConditionB γ a b f) :
+    (hA : ConditionAprime γ a b f S) (hB : ConditionB γ a b f) :
     HasCauchyPV γ a b f
       (2 * (Real.pi : ℂ) * Complex.I * (∑ s ∈ S, windingNumber γ a b s * residue f s)) :=
   sorry


### PR DESCRIPTION
### The problem: A′ is internally inconsistent

`ConditionAprime` is documented as requiring `γ` to approach each singularity
"as a finite union of model sectors **with a prescribed pole order**" — i.e. HW
condition (A): *flat of order n at a pole of order n*. But its signature is

```lean
def ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (S : Finset ℂ) : Prop := sorry
```

`S : Finset ℂ` is a bare set of **points** — it carries no orders, and there is
no `f` — so **no faithful definition can express the order-matching the
docstring (and the summit theorem) require.** The best a filler can do under
this signature is order-1 transversality, which is too weak for higher-order
poles, so `hungerbuhlerWasem_residueTheorem` (stated for general meromorphic
`f`) is unprovable from it. The definition and the theorem are inconsistent as
written.

This surfaced concretely while implementing `ConditionAprime` in TauCeti: the
correctness review [correctly] blocked an order-1 A′ as not faithful to HW (A′),
and every fix it suggested requires order data the signature can't hold.

### The fix (minimal)

Add `f` so A′ can read the pole orders (via `meromorphicOrderAt`), and thread it
through the summit's `hA`:

```lean
def ConditionAprime (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (S : Finset ℂ) : Prop := sorry
--                                          ^^^^^^^^^^^ added
...
    (hA : ConditionAprime γ a b f S) (hB : ConditionB γ a b f) :
--                              ^ added
```

This mirrors how condition (B) already couples with `f`, and is the smallest
change that lets a faithful A′ (*flat of order = pole order*) be stated — so the
general HW Thm 3.3 the roadmap already states becomes provable. No other targets
are touched. Elaborates green (`sorry` placeholders intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)