### PR TITLE
ci: run auto-merge on pull_request_target so fork PR secrets are available

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,8 +6,11 @@ name: auto-merge
 # approves and CI passes. Native auto-merge watches PR state directly, so this is unaffected by
 # the pull_request_review event-delivery issue.
 
+# Use pull_request_target (not pull_request) so the tauceti-review-bot App secrets are available
+# for PRs opened from forks — the common case for external contributors. This job never checks out
+# or runs PR code (it only calls `gh pr merge`), so pull_request_target is safe here.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, ready_for_review]
 
 permissions:


### PR DESCRIPTION
This PR switches the auto-merge workflow trigger from `pull_request` to `pull_request_target` so the tauceti-review-bot App secrets (`APP_ID`, `APP_PRIVATE_KEY`) are available for PRs opened from forks. Under `pull_request`, GitHub withholds secrets from fork-triggered runs, so `actions/create-github-app-token` failed with `Input required and not supplied: app-id` — meaning auto-merge could never run for external contributors, which are exactly the PRs it exists to help. The job never checks out or executes PR code (it only calls `gh pr merge`), so `pull_request_target` carries no added risk here.

Observed on https://github.com/TauCetiProject/TauCetiRoadmap/pull/61 (a fork PR), where the auto-merge `enable` job failed for this reason.

🤖 Prepared with Claude Code