### PR TITLE
doc: forbid `def _ : Prop := sorry` in the roadmap-writing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ reviewers, can act on it without guessing.
   Lean files using `sorry`. The prototypes are aids, not the specification: the markdown stays
   definitive, and `Suggested.lean` is read as suggested forms, never as an exhaustive checklist —
   open each `Suggested.lean` with the standard note saying so. Use `sorry` honestly: a condition you
-  cannot yet even *state* (its Mathlib API doesn't exist) is still a `sorry`, never a field of type
-  `Prop` — a `Prop` field can be satisfied by any proposition, so an instance can fill it with `True`
-  and the condition asserts nothing.
+  cannot yet even *state* (its Mathlib API doesn't exist) is still a `sorry`, never a `Prop`-typed
+  field or a `def _ : Prop := sorry`. Both assert nothing (a `Prop` field is satisfiable by `True`;
+  a `sorry` body is `sorryAx Prop`), so omit a condition you cannot state rather than name an empty one.
 
 - **Pin conventions.** It's essential that you decide conventions ahead of time, or implementors
   will make bad decisions.


### PR DESCRIPTION
This PR extends the "Write Lean code" guidance in the top-level `README.md` so the "use `sorry` honestly" rule covers a standalone `def _ : Prop := sorry`, not only a `Prop`-typed structure field. Both produce a proposition that asserts nothing — a `def _ : Prop := sorry` elaborates to `sorryAx Prop` — so any theorem taking it as a hypothesis says nothing about it. The guide now says to omit a condition you cannot yet state rather than name an empty one.

Prompted by the Layer-8 representability targets in https://github.com/TauCetiProject/TauCetiRoadmap/pull/53 (Add roadmap: Dense graph limits and graphons), where `IsIsoInvariant`, `IsMultiplicative`, and `IsNormalized` were pinned as `def … : Prop := sorry`, leaving three of the five hypotheses of the flagship representability theorem without content. The existing rule named only the `Prop`-field case, so it did not literally cover this.

🤖 Prepared with Claude Code