### PR TITLE
fix(ContourIntegration): piecewise-C¹ / immersion regularity for the raw-γ Layer 3–4 targets

### DIFF
--- a/TauCetiRoadmap/ContourIntegration/README.md
+++ b/TauCetiRoadmap/ContourIntegration/README.md
@@ -173,12 +173,12 @@ expressible in `TauCeti/`, its milestones go into `Suggested.lean` (with `sorry`
 
 ### Layer 4: the Hungerbühler–Wasem generalized residue theorem (HW Theorem 3.3)
 - **The headline.** Let `U ⊆ ℂ` be open, `S ⊆ U` finite, `f` holomorphic on `U ∖ S` and
-  meromorphic at each point of `S`, and `C` a **null-homologous** piecewise-`C¹` cycle in `U`
-  whose singularities may lie **on** `C`. Then
+  meromorphic at each point of `S`, and `C` a **null-homologous** closed piecewise-`C¹` immersion
+  in `U` whose singularities may lie **on** `C`. Then
   `PV (2πi)⁻¹ ∮_C f dz = Σ_{s ∈ S} n_s(C)·Res_s f`,
   with the **generalized (non-integer) winding numbers** of Layer 1 as the weights. Subsumes
   the classical residue theorem (Layer 2, poles off `C`, integer weights) and the half-residue
-  case (a simple pole on a smooth arc, winding `½`, contributes `πi·Res_s f`).
+  case (`S = {s}` with winding `½`: an on-cycle simple pole contributes `πi·Res_s f`).
 - **The two regularity conditions** under which the paper-faithful form holds: condition (A′)
   (the cycle approaches each on-cycle singularity transversally / as a finite union of sectors,
   with a prescribed pole order) and condition (B) (the higher-order Laurent parts cancel by the

--- a/TauCetiRoadmap/ContourIntegration/Suggested.lean
+++ b/TauCetiRoadmap/ContourIntegration/Suggested.lean
@@ -93,6 +93,19 @@ from genuine integrability** and never silently identified with it. Layer 4 cann
 it. -/
 def HasCauchyPV (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (v : ℂ) : Prop := sorry
 
+/-- **Piecewise `C¹` on the interval between `a` and `b`.** The raw-function curve-regularity
+hypothesis: `γ` is continuous on `[[a, b]]` and, off a finite breakpoint set, is `C¹` on each closed
+piece. This is the regularity that AINTLIB's bundled `PiecewiseC1Path` carries *inside its type*;
+stated on a raw `γ : ℝ → ℂ` it must be an **explicit hypothesis**, because the winding number, the
+contour integral `∫ deriv γ • f (γ ·)`, and Dixon's argument are all ill-posed for an arbitrary
+continuous `γ` (a space-filling curve has no honest derivative and can even cover `Ω`). This mirrors
+`TauCeti.Contour.IsPiecewiseC1On`; it is the hypothesis the Layer 3–4 theorems below carry. -/
+def IsPiecewiseC1On (γ : ℝ → ℂ) (a b : ℝ) : Prop :=
+  ContinuousOn γ (Set.uIcc a b) ∧
+    ∃ p : Finset ℝ, ↑p ⊆ Set.Ioo (min a b) (max a b) ∧
+      ∀ c d : ℝ, Set.Icc c d ⊆ Set.uIcc a b → Disjoint (↑p : Set ℝ) (Set.Ioo c d) →
+        ContDiffOn ℝ 1 γ (Set.Icc c d)
+
 /-- A cycle `γ` on `[a, b]` is **null-homologous** in `Ω` when its winding number about every point
 outside `Ω` vanishes (`n_w(γ) = 0` for all `w ∉ Ω`) — the hypothesis of the homology Cauchy theorem
 (Layer 3) and of HW Thm 3.3 (Layer 4). -/
@@ -203,7 +216,8 @@ is the `S = ∅` case of the general arbitrary-cycle residue theorem, which is w
 sits here rather than in Layer 2. Named for the theorem (homology Cauchy), attributed to Dixon for
 the proof. -/
 theorem homologyCauchyTheorem {f : ℂ → ℂ} {Ω : Set ℂ} (hΩ : IsOpen Ω) (γ : ℝ → ℂ) (a b : ℝ)
-    (hγ : ∀ t ∈ Set.Icc a b, γ t ∈ Ω) (hclosed : γ a = γ b)
+    (hγ_pc1 : IsPiecewiseC1On γ a b)
+    (hγ : ∀ t ∈ Set.uIcc a b, γ t ∈ Ω) (hclosed : γ a = γ b)
     (hf : DifferentiableOn ℂ f Ω)
     (hnull : IsNullHomologous γ a b Ω) :
     ∫ t in a..b, deriv γ t • f (γ t) = 0 :=
@@ -220,7 +234,8 @@ as weights. Subsumes the classical residue theorem (poles off `γ`, integer weig
 half-residue case below. -/
 theorem hungerbuhlerWasem_residueTheorem {f : ℂ → ℂ} {U : Set ℂ} (hU : IsOpen U) (S : Finset ℂ)
     (γ : ℝ → ℂ) (a b : ℝ)
-    (hSU : (S : Set ℂ) ⊆ U) (hclosed : γ a = γ b) (hγU : ∀ t ∈ Set.Icc a b, γ t ∈ U)
+    (hγ_pc1 : IsPiecewiseC1On γ a b)
+    (hSU : (S : Set ℂ) ⊆ U) (hclosed : γ a = γ b) (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
     (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
     (hmero : ∀ s ∈ S, MeromorphicAt f s)
     (hnull : IsNullHomologous γ a b U)
@@ -234,6 +249,7 @@ formula's `i`, `ρ`. A simple pole of `f` lying *on* a smooth arc `γ` (generali
 contributes `πi · Res_s f` to the principal-value contour integral: the `α = π` specialisation of
 HW Thm 3.3. -/
 theorem hasCauchyPV_half_residue {f : ℂ → ℂ} (γ : ℝ → ℂ) (a b : ℝ) (s : ℂ)
+    (hγ_pc1 : IsPiecewiseC1On γ a b)
     (hf : MeromorphicAt f s) (hwind : windingNumber γ a b s = 1 / 2) :
     HasCauchyPV γ a b f ((Real.pi : ℂ) * Complex.I * residue f s) :=
   sorry

--- a/TauCetiRoadmap/ContourIntegration/Suggested.lean
+++ b/TauCetiRoadmap/ContourIntegration/Suggested.lean
@@ -113,20 +113,27 @@ def IsPiecewiseC1On (γ : ℝ → ℂ) (a b : ℝ) : Prop :=
       ∀ c d : ℝ, Set.Icc c d ⊆ Set.uIcc a b → Disjoint (↑p : Set ℝ) (Set.Ioo c d) →
         ContDiffOn ℝ 1 γ (Set.Icc c d)
 
-/-- **Piecewise-`C¹` immersion on `[[a, b]]`.** Strengthens `IsPiecewiseC1On` by requiring the
-derivative to be **non-vanishing** off a finite set — the raw-`γ` mirror of AINTLIB's `PwC1Immersion`
-/ `ClosedPwC1Immersion` (`Λ̇|_{[aₖ,aₖ₊₁]} ≠ 0` on each piece; HW arXiv:1808.00997 p. 3). This is the
-regularity the **on-cycle** residue theorems carry: Hungerbühler–Wasem represents each on-cycle
-singularity by model sectors of a definite opening angle, which needs a well-defined non-zero tangent
-there, and AINTLIB accordingly states HW Thm 3.3 — and even condition (A′) — over an immersion
-(`ClosedPwC1Immersion` / `PwC1Immersion`), not a bare piecewise-`C¹` path. (The homology Cauchy
-theorem, whose singularities lie *off* `γ`, needs only `IsPiecewiseC1On`.) The `deriv γ t ≠ 0` clause
-uses the global `deriv`; a port may prefer the one-sided `derivWithin` at breakpoints, as AINTLIB
-does at corners. -/
+/-- **Piecewise-`C¹` immersion on `[[a, b]]`** — `IsPiecewiseC1On` strengthened, over a **common**
+breakpoint witness, by a non-vanishing tangent on every piece: on each breakpoint-free closed piece
+`[c, d]`, the curve is `C¹` and its within-piece derivative is non-zero on **all** of `[c, d]` —
+one-sided at the piece endpoints, HW's `Λ̇|_{[aₖ,aₖ₊₁]} ≠ 0` (arXiv:1808.00997, p. 3). This is the
+raw-`γ` mirror of the `derivWithin_ne_zero_pieces` field of AINTLIB's `ClosedPwC1Immersion` (whose
+closed partition includes the interval endpoints; closedness itself stays the theorems' separate
+`γ a = γ b` hypothesis), the type its HW summit is stated over; `SatisfiesConditionA'` is likewise
+typed over an immersion, since the on-cycle model-sector analysis needs a well-defined non-zero
+tangent at each on-cycle singularity. The one-sided conditions are load-bearing: merely asking
+`deriv γ ≠ 0` off a finite set would admit zero-speed turnarounds (`γ t = t ^ 2` on `[-1, 1]`,
+whose one-sided tangents both vanish at `0`) and zero-speed seams, which are not immersions.
+`derivWithin` is used because at a corner the global `deriv` is `0` by Mathlib convention, which
+would falsely contradict non-vanishing; at interior points of a piece it agrees with `deriv`.
+Implies `IsPiecewiseC1On` with the same witness (pieces with `c ≥ d` are degenerate). (The homology
+Cauchy theorem, whose singularities lie *off* `γ`, needs only `IsPiecewiseC1On`.) -/
 def IsPwC1ImmersionOn (γ : ℝ → ℂ) (a b : ℝ) : Prop :=
-  IsPiecewiseC1On γ a b ∧
+  ContinuousOn γ (Set.uIcc a b) ∧
     ∃ p : Finset ℝ, ↑p ⊆ Set.Ioo (min a b) (max a b) ∧
-      ∀ t ∈ Set.Ioo (min a b) (max a b), t ∉ p → deriv γ t ≠ 0
+      ∀ c d : ℝ, c < d → Set.Icc c d ⊆ Set.uIcc a b → Disjoint (↑p : Set ℝ) (Set.Ioo c d) →
+        ContDiffOn ℝ 1 γ (Set.Icc c d) ∧
+          ∀ t ∈ Set.Icc c d, derivWithin γ (Set.Icc c d) t ≠ 0
 
 /-- A cycle `γ` on `[a, b]` is **null-homologous** in `Ω` when its winding number about every point
 outside `Ω` vanishes (`n_w(γ) = 0` for all `w ∉ Ω`) — the hypothesis of the homology Cauchy theorem

--- a/TauCetiRoadmap/ContourIntegration/Suggested.lean
+++ b/TauCetiRoadmap/ContourIntegration/Suggested.lean
@@ -21,7 +21,8 @@ Hungerbühler–Wasem generalized residue theorem (arXiv:1808.00997, Thm 3.3) fo
 *on* the cycle, with non-integer winding-number weights. We build that in `TauCeti/Analysis/Contour/`.
 
 This file pins the roadmap's load-bearing **definitions** (`windingNumber`, `residue`,
-`HasCauchyPV`, the HW conditions, `IsNullHomologous`) and its **named milestones** as `sorry`-targets
+`HasCauchyPV`, `IsPiecewiseC1On`, `IsPwC1ImmersionOn`, the HW conditions, `IsNullHomologous`) and its
+**named milestones** as `sorry`-targets
 (`sorry` is allowed in this human-owned roadmap library — these are goals, not proofs). The
 `def`s fix the objects the roadmap is *about* so the statements below are expressible at all; the
 generalized winding number, the classical residue theorem, the homology Cauchy theorem and HW
@@ -99,13 +100,33 @@ a finite breakpoint set, is `C¹` on each closed
 piece. This is the regularity that AINTLIB's bundled `PiecewiseC1Path` carries *inside its type*;
 stated on a raw `γ : ℝ → ℂ` it must be an **explicit hypothesis**, because the winding number, the
 contour integral `∫ deriv γ • f (γ ·)`, and Dixon's argument are all ill-posed for an arbitrary
-continuous `γ` (a space-filling curve has no honest derivative and can even cover `Ω`). This mirrors
-`TauCeti.Contour.IsPiecewiseC1On`; it is the hypothesis the Layer 3–4 theorems below carry. -/
+continuous `γ`: a space-filling continuous `γ` has no honest derivative, so `∫ deriv γ • …` is not
+the contour integral at all, and Dixon's argument needs differentiability off a countable set to
+make the winding number integer-valued. (The off-curve base point Dixon picks, by contrast, exists
+already from continuity and compactness — the image of `[[a, b]]` is compact, so it cannot fill a
+nonempty open `Ω` — and is not what this regularity is for.) This mirrors
+`TauCeti.Contour.IsPiecewiseC1On`; it is the base regularity the homology Cauchy theorem (Layer 3)
+carries. The **on-cycle** residue theorems (Layer 4) need the stronger `IsPwC1ImmersionOn` below. -/
 def IsPiecewiseC1On (γ : ℝ → ℂ) (a b : ℝ) : Prop :=
   ContinuousOn γ (Set.uIcc a b) ∧
     ∃ p : Finset ℝ, ↑p ⊆ Set.Ioo (min a b) (max a b) ∧
       ∀ c d : ℝ, Set.Icc c d ⊆ Set.uIcc a b → Disjoint (↑p : Set ℝ) (Set.Ioo c d) →
         ContDiffOn ℝ 1 γ (Set.Icc c d)
+
+/-- **Piecewise-`C¹` immersion on `[[a, b]]`.** Strengthens `IsPiecewiseC1On` by requiring the
+derivative to be **non-vanishing** off a finite set — the raw-`γ` mirror of AINTLIB's `PwC1Immersion`
+/ `ClosedPwC1Immersion` (`Λ̇|_{[aₖ,aₖ₊₁]} ≠ 0` on each piece; HW arXiv:1808.00997 p. 3). This is the
+regularity the **on-cycle** residue theorems carry: Hungerbühler–Wasem represents each on-cycle
+singularity by model sectors of a definite opening angle, which needs a well-defined non-zero tangent
+there, and AINTLIB accordingly states HW Thm 3.3 — and even condition (A′) — over an immersion
+(`ClosedPwC1Immersion` / `PwC1Immersion`), not a bare piecewise-`C¹` path. (The homology Cauchy
+theorem, whose singularities lie *off* `γ`, needs only `IsPiecewiseC1On`.) The `deriv γ t ≠ 0` clause
+uses the global `deriv`; a port may prefer the one-sided `derivWithin` at breakpoints, as AINTLIB
+does at corners. -/
+def IsPwC1ImmersionOn (γ : ℝ → ℂ) (a b : ℝ) : Prop :=
+  IsPiecewiseC1On γ a b ∧
+    ∃ p : Finset ℝ, ↑p ⊆ Set.Ioo (min a b) (max a b) ∧
+      ∀ t ∈ Set.Ioo (min a b) (max a b), t ∉ p → deriv γ t ≠ 0
 
 /-- A cycle `γ` on `[a, b]` is **null-homologous** in `Ω` when its winding number about every point
 outside `Ω` vanishes (`n_w(γ) = 0` for all `w ∉ Ω`) — the hypothesis of the homology Cauchy theorem
@@ -228,14 +249,14 @@ theorem homologyCauchyTheorem {f : ℂ → ℂ} {Ω : Set ℂ} (hΩ : IsOpen Ω)
 
 /-- **Hungerbühler–Wasem generalized residue theorem** (HW Thm 3.3) — the summit. Let `U ⊆ ℂ` be
 open, `S ⊆ U` finite, `f` holomorphic on `U ∖ S` and meromorphic at each `s ∈ S`, and `γ` a
-**null-homologous** closed piecewise-`C¹` cycle in `U` whose singularities may lie *on* `γ`, under
+**null-homologous** closed piecewise-`C¹` **immersion** in `U` whose singularities may lie *on* `γ`, under
 conditions (A′) and (B). Then the principal value exists and
 `PV (2πi)⁻¹ ∮_γ f = Σ_{s ∈ S} n_s(γ) · Res_s f`, with the generalized (non-integer) winding numbers
 as weights. Subsumes the classical residue theorem (poles off `γ`, integer weights) and the
 half-residue case below. -/
 theorem hungerbuhlerWasem_residueTheorem {f : ℂ → ℂ} {U : Set ℂ} (hU : IsOpen U) (S : Finset ℂ)
     (γ : ℝ → ℂ) (a b : ℝ)
-    (hγ_pc1 : IsPiecewiseC1On γ a b)
+    (hγ_imm : IsPwC1ImmersionOn γ a b)
     (hSU : (S : Set ℂ) ⊆ U) (hclosed : γ a = γ b) (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
     (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
     (hmero : ∀ s ∈ S, MeromorphicAt f s)
@@ -245,13 +266,22 @@ theorem hungerbuhlerWasem_residueTheorem {f : ℂ → ℂ} {U : Set ℂ} (hU : I
       (2 * (Real.pi : ℂ) * Complex.I * (∑ s ∈ S, windingNumber γ a b s * residue f s)) :=
   sorry
 
-/-- **Half-residue on a smooth arc** — the on-cycle acceptance gate and the bridge to the valence
-formula's `i`, `ρ`. A simple pole of `f` lying *on* a smooth arc `γ` (generalized winding `½`)
-contributes `πi · Res_s f` to the principal-value contour integral: the `α = π` specialisation of
-HW Thm 3.3. -/
-theorem hasCauchyPV_half_residue {f : ℂ → ℂ} (γ : ℝ → ℂ) (a b : ℝ) (s : ℂ)
-    (hγ_pc1 : IsPiecewiseC1On γ a b)
-    (hf : MeromorphicAt f s) (hwind : windingNumber γ a b s = 1 / 2) :
+/-- **Half-residue: the winding-`½` on-cycle case of HW Thm 3.3** — the acceptance gate and the
+bridge to the valence formula's `i`, `ρ`. Stated as the genuine `S = {s}` specialisation of
+`hungerbuhlerWasem_residueTheorem`: a **closed, null-homologous** piecewise-`C¹` **immersion** `γ` in an
+open `U`, with `f` holomorphic on `U ∖ {s}` and meromorphic at `s`, under conditions (A′)/(B); when
+the generalized winding number about `s` is `½`, the principal value equals `πi · Res_s f` — the
+`S = {s}`, `n_s(γ) = ½` case of the HW sum `2πi · Σ n_s(γ)·Res_s f`. The closedness,
+holomorphy-off-`s`, null-homology and (A′)/(B) hypotheses are **load-bearing**, not decoration:
+without them the whole PV integral is *not* determined by `n_s(γ)` and `Res_s f` alone (a non-closed
+arc integrates the holomorphic part of `f` to a nonzero remainder — e.g. `γ(t) = e^{i t}` on
+`[0, π]`, `s = 0`, `f z = z⁻¹ + 1` has winding `½` and residue `1` but integral `πi − 2`). -/
+theorem hasCauchyPV_half_residue {f : ℂ → ℂ} {U : Set ℂ} (hU : IsOpen U) (γ : ℝ → ℂ) (a b : ℝ)
+    (s : ℂ) (hγ_imm : IsPwC1ImmersionOn γ a b) (hsU : s ∈ U) (hclosed : γ a = γ b)
+    (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U) (hf : DifferentiableOn ℂ f (U \ {s}))
+    (hmero : MeromorphicAt f s) (hnull : IsNullHomologous γ a b U)
+    (hA : ConditionAprime γ a b f {s}) (hB : ConditionB γ a b f)
+    (hwind : windingNumber γ a b s = 1 / 2) :
     HasCauchyPV γ a b f ((Real.pi : ℂ) * Complex.I * residue f s) :=
   sorry
 

--- a/TauCetiRoadmap/ContourIntegration/Suggested.lean
+++ b/TauCetiRoadmap/ContourIntegration/Suggested.lean
@@ -94,7 +94,8 @@ it. -/
 def HasCauchyPV (γ : ℝ → ℂ) (a b : ℝ) (f : ℂ → ℂ) (v : ℂ) : Prop := sorry
 
 /-- **Piecewise `C¹` on the interval between `a` and `b`.** The raw-function curve-regularity
-hypothesis: `γ` is continuous on `[[a, b]]` and, off a finite breakpoint set, is `C¹` on each closed
+hypothesis: `γ` is continuous on `[[a, b]]` (Mathlib's `Set.uIcc a b`, the interval robust to `a > b`) and, off
+a finite breakpoint set, is `C¹` on each closed
 piece. This is the regularity that AINTLIB's bundled `PiecewiseC1Path` carries *inside its type*;
 stated on a raw `γ : ℝ → ℂ` it must be an **explicit hypothesis**, because the winding number, the
 contour integral `∫ deriv γ • f (γ ·)`, and Dixon's argument are all ill-posed for an arbitrary


### PR DESCRIPTION
## What

The Layer 3–4 contour targets are stated over a raw `γ : ℝ → ℂ` but omit the curve-regularity
hypotheses their proofs actually need. This adds them, **matching the regularity each AINTLIB summit
theorem carries** (piecewise-`C¹` for the homology Cauchy theorem, a piecewise-`C¹` *immersion* for
the Hungerbühler–Wasem theorem — see Audit).

- New `def IsPiecewiseC1On (γ : ℝ → ℂ) (a b : ℝ) : Prop` — continuity on `[[a,b]]` + a finite
  breakpoint set with `C¹` pieces — mirroring the merged `TauCeti.Contour.IsPiecewiseC1On`.
- New `def IsPwC1ImmersionOn` — over a **common** finite breakpoint witness, every breakpoint-free
  closed piece `[c, d]` is `C¹` **with non-vanishing within-piece derivative on all of `[c, d]`**
  (one-sided at piece endpoints, including the interval endpoints — the closed curve's seam). This
  is the raw-`γ` mirror, field-for-field, of AINTLIB's
  `ClosedPwC1Immersion.derivWithin_ne_zero_pieces` (HW's `Λ̇|_{[aₖ,aₖ₊₁]} ≠ 0`).
- `homologyCauchyTheorem` carries `IsPiecewiseC1On`; `hungerbuhlerWasem_residueTheorem` and
  `hasCauchyPV_half_residue` carry `IsPwC1ImmersionOn`.
- Switch those targets' membership hypotheses from `Set.Icc a b` to `Set.uIcc a b` (the oriented
  interval; `Icc` silently assumes `a ≤ b`).
- Restate `hasCauchyPV_half_residue` as the genuine `S = {s}` specialisation of the HW theorem.
- Add `IsPiecewiseC1On` / `IsPwC1ImmersionOn` to the pinned-definitions list.

## Why the base regularity

The AINTLIB proofs carry regularity **inside bundled curve types**, so restating the targets over a
raw `γ` silently drops it. As written the statements are ill-posed / unprovable:

- `∫ deriv γ • f (γ ·)` uses `deriv γ`, which is junk for a non-differentiable `γ` — not the contour
  integral at all.
- Dixon's argument needs continuity, an integrable derivative, and differentiability off a countable
  set (that last is what makes the winding number integer-valued).

## Why `hasCauchyPV_half_residue` had to be restated

As first written it concluded the **whole** PV integral equals `πi · Res_s f` from only
piecewise-`C¹` + `MeromorphicAt f s` + winding `½`. That does not follow. Counterexample:
`γ(t) = e^{it}` on `[0, π]`, `s = 0`, `f(z) = z⁻¹ + 1` has winding `½` and residue `1` but integral
`πi − 2` — the arc is not closed and `f` is not required holomorphic off `s`, so the holomorphic part
contributes a nonzero remainder. It is now the `S = {s}` specialisation of
`hungerbuhlerWasem_residueTheorem`, carrying closedness, holomorphy off `s`, null-homology, and
(A′)/(B). (Reported by @cameronfreer / GPT-5.6.)

## Audit — which regularity each summit needs (verified against AINTLIB `LeanModularForms`)

- **Homology Cauchy theorem.** The Dixon summit `contourIntegral_eq_zero_of_nullHomologous_at`
  (`ForMathlib/DixonTheorem.lean`) is stated over `PiecewiseC1Path`; its singularities lie *off* `γ`,
  so `homologyCauchyTheorem` needs only `IsPiecewiseC1On`. (Some intermediate Dixon lemmas use
  `PwC1Immersion`, but the summit discharges it.)
- **HW Thm 3.3 and the half-residue.** The clean HW summit `hw_3_3_clean_full_mero` →
  `residueTheorem_crossing_paper_faithful_clean` (`ForMathlib/HW33Clean.lean`) is stated over a
  **`ClosedPwC1Immersion`**, and `SatisfiesConditionA'` is itself typed over `PwC1Immersion`
  (`ForMathlib/FlatnessConditions.lean`) — you cannot even *state* (A′) without the immersion, because
  the on-cycle model-sector analysis needs a well-defined non-zero tangent. So these targets carry
  `IsPwC1ImmersionOn`, not bare `IsPiecewiseC1On`. **This corrects two earlier revisions of this
  PR:** the first claimed AINTLIB proves HW over `PiecewiseC1Path` (that holds only for Dixon); the
  second mirrored the immersion as "`deriv γ ≠ 0` off a finite set", which is still weaker than
  AINTLIB's object — `γ(t) = t²` on `[-1, 1]` satisfies it with `p = {0}` yet has a zero-speed
  turnaround (both one-sided tangents vanish at `0`), so the summit would not apply. The predicate
  is now the within-piece one-sided condition, field-for-field with `derivWithin_ne_zero_pieces`
  (both reported by @cameronfreer). Stating HW over anything weaker would be an unproven
  *generalisation*, not a transcription of what we have.
- **Layers 0–2 are fine as-is.** The `def`s are total (junk-on-bad-input is acceptable), and the
  Layer 1–2 theorems are over `circleMap` / `circleIntegral` (smooth), so `deriv` is honest. The
  classical residue theorem (poles *off* the cycle) is Dixon-based and legitimately stays
  piecewise-`C¹`.
- No other roadmap area (`ConformalMapping`, `PDE`, …) has raw-curve/contour targets.

The file still elaborates (`sorry`-targets only). Once this merges I'll prove the corrected
`homologyCauchyTheorem` in TauCeti from the already-merged Dixon chain.
