### PR TITLE
fix(ContourIntegration): basepoint off the poles for the two HW summits

### DIFF
--- a/TauCetiRoadmap/ContourIntegration/README.md
+++ b/TauCetiRoadmap/ContourIntegration/README.md
@@ -179,6 +179,10 @@ expressible in `TauCeti/`, its milestones go into `Suggested.lean` (with `sorry`
   with the **generalized (non-integer) winding numbers** of Layer 1 as the weights. Subsumes
   the classical residue theorem (Layer 2, poles off `C`, integer weights) and the half-residue
   case (`S = {s}` with winding `½`: an on-cycle simple pole contributes `πi·Res_s f`).
+  The pinned form (`Suggested.lean`) takes a single closed curve, a finite `S`, and
+  `MeromorphicAt` at each singularity, with the basepoint off the poles — deliberately narrower
+  than the paper's cycle, accumulation-free `S`, and locally-straight essential singularities;
+  the docstring records each narrowing.
 - **The two regularity conditions** under which the paper-faithful form holds: condition (A′)
   (the cycle approaches each on-cycle singularity transversally / as a finite union of sectors,
   with a prescribed pole order) and condition (B) (the higher-order Laurent parts cancel by the

--- a/TauCetiRoadmap/ContourIntegration/Suggested.lean
+++ b/TauCetiRoadmap/ContourIntegration/Suggested.lean
@@ -259,12 +259,15 @@ open, `S ⊆ U` finite, `f` holomorphic on `U ∖ S` and meromorphic at each `s 
 **null-homologous** closed piecewise-`C¹` **immersion** in `U` whose singularities may lie *on* `γ`, under
 conditions (A′) and (B). Then the principal value exists and
 `PV (2πi)⁻¹ ∮_γ f = Σ_{s ∈ S} n_s(γ) · Res_s f`, with the generalized (non-integer) winding numbers
-as weights. Subsumes the classical residue theorem (poles off `γ`, integer weights) and the
+as weights. The basepoint stays off the poles (`hγa`) so every crossing is interior to the
+parameter interval — for a closed curve this is a reparametrization away, never a real
+restriction. Subsumes the classical residue theorem (poles off `γ`, integer weights) and the
 half-residue case below. -/
 theorem hungerbuhlerWasem_residueTheorem {f : ℂ → ℂ} {U : Set ℂ} (hU : IsOpen U) (S : Finset ℂ)
     (γ : ℝ → ℂ) (a b : ℝ)
     (hγ_imm : IsPwC1ImmersionOn γ a b)
-    (hSU : (S : Set ℂ) ⊆ U) (hclosed : γ a = γ b) (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
+    (hSU : (S : Set ℂ) ⊆ U) (hclosed : γ a = γ b) (hγa : γ a ∉ (S : Set ℂ))
+    (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
     (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
     (hmero : ∀ s ∈ S, MeromorphicAt f s)
     (hnull : IsNullHomologous γ a b U)
@@ -285,6 +288,7 @@ arc integrates the holomorphic part of `f` to a nonzero remainder — e.g. `γ(t
 `[0, π]`, `s = 0`, `f z = z⁻¹ + 1` has winding `½` and residue `1` but integral `πi − 2`). -/
 theorem hasCauchyPV_half_residue {f : ℂ → ℂ} {U : Set ℂ} (hU : IsOpen U) (γ : ℝ → ℂ) (a b : ℝ)
     (s : ℂ) (hγ_imm : IsPwC1ImmersionOn γ a b) (hsU : s ∈ U) (hclosed : γ a = γ b)
+    (hγa : γ a ≠ s)
     (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U) (hf : DifferentiableOn ℂ f (U \ {s}))
     (hmero : MeromorphicAt f s) (hnull : IsNullHomologous γ a b U)
     (hA : ConditionAprime γ a b f {s}) (hB : ConditionB γ a b f)

--- a/TauCetiRoadmap/ContourIntegration/Suggested.lean
+++ b/TauCetiRoadmap/ContourIntegration/Suggested.lean
@@ -53,11 +53,13 @@ cleanup opportunity. File map (relative to that project's `LeanModularForms/`):
   (`generalizedResidueTheorem'`, `residueSimplePole`, `residueAt`, `simple_poles_decomposition`).
 * Global (homological) Cauchy theorem, via Dixon's argument (Layer 3):
   `ForMathlib/DixonDef.lean`, `…/DixonDiff.lean`, `…/DixonTheorem.lean`.
-* HW generalized residue theorem (Layer 4, Thm 3.3, conditions (A′)/(B)): `Chapters/HW33.lean`,
-  `ForMathlib/HW33Clean.lean`, `ForMathlib/HungerbuhlerWasem/MultiCrossingCPV.lean`,
-  `ForMathlib/GeneralizedResidueTheory/{Residue/MultipointPV*,OnCurvePV/*,PVInfrastructure/*}`,
-  `ForMathlib/CauchyPrincipalValue.lean` (`HasCauchyPVOn'`, `pv_integral_simple_pole`, the
-  paper-faithful `HungerbuhlerWasem.residueTheorem_crossing_paper_faithful_clean`).
+* HW generalized residue theorem (Layer 4, Thm 3.3, conditions (A′)/(B)):
+  `ForMathlib/HW33Clean.lean` (`hw_3_3_clean_full_mero`),
+  `ForMathlib/HungerbuhlerWasem/MultiCrossingCPV.lean` (the paper-faithful
+  `HungerbuhlerWasem.residueTheorem_crossing_paper_faithful_clean` and the multi-crossing PV
+  engine), `ForMathlib/GeneralizedResidueTheory/{Residue/MultipointPV*,OnCurvePV/*,PVInfrastructure/*}`,
+  `ForMathlib/GeneralizedResidueTheory/Residue.lean` (`HasCauchyPVOn'`,
+  `pv_integral_simple_pole`).
 
 The fundamental-domain-specific winding machinery (`ForMathlib/*FDBoundary*`, `*CornerFTC*`,
 `*CrossingAt{Rho,I}*`, `*ExitTime*`) is **not** migrated here; it is the bridge from this engine to
@@ -262,7 +264,14 @@ conditions (A′) and (B). Then the principal value exists and
 as weights. The basepoint stays off the poles (`hγa`) so every crossing is interior to the
 parameter interval — for a closed curve this is a reparametrization away, never a real
 restriction. Subsumes the classical residue theorem (poles off `γ`, integer weights) and the
-half-residue case below. -/
+half-residue case below.
+
+Scope, relative to the printed theorem: HW state Thm 3.3 for a *cycle* and a singular set
+without accumulation points in `U`, and allow an essential singularity on the cycle where the
+cycle is locally straight (condition (A)'s second branch). This target takes a single closed
+curve, a **finite** `S`, and `MeromorphicAt` at each `s ∈ S` — the scope the
+`residue`/`meromorphicOrderAt` API expresses and the valence formula consumes. Each narrowing
+is deliberate, not an oversight; cycles are a finite-sum layer over this statement. -/
 theorem hungerbuhlerWasem_residueTheorem {f : ℂ → ℂ} {U : Set ℂ} (hU : IsOpen U) (S : Finset ℂ)
     (γ : ℝ → ℂ) (a b : ℝ)
     (hγ_imm : IsPwC1ImmersionOn γ a b)

--- a/TauCetiRoadmap/ContourIntegration/Suggested.lean
+++ b/TauCetiRoadmap/ContourIntegration/Suggested.lean
@@ -262,8 +262,10 @@ open, `S ⊆ U` finite, `f` holomorphic on `U ∖ S` and meromorphic at each `s 
 conditions (A′) and (B). Then the principal value exists and
 `PV (2πi)⁻¹ ∮_γ f = Σ_{s ∈ S} n_s(γ) · Res_s f`, with the generalized (non-integer) winding numbers
 as weights. The basepoint stays off the poles (`hγa`) so every crossing is interior to the
-parameter interval — for a closed curve this is a reparametrization away, never a real
-restriction. Subsumes the classical residue theorem (poles off `γ`, integer weights) and the
+parameter interval — for the intended nondegenerate closed immersions with finite `S` this is
+mathematically removable by cyclic reparametrization, but it remains a formalization residual
+until a reparametrization-invariance API exists (it is likewise a hypothesis of the AINTLIB
+summit). Subsumes the classical residue theorem (poles off `γ`, integer weights) and the
 half-residue case below.
 
 Scope, relative to the printed theorem: HW state Thm 3.3 for a *cycle* and a singular set


### PR DESCRIPTION
## What

Two summit-signature fixes plus the outcome of a full audit of every ContourIntegration target
against the AINTLIB formalization and the Hungerbühler–Wasem paper (arXiv:1808.00997).

**1. Basepoint off the poles (the original change).** Adds `hγa : γ a ∉ (S : Set ℂ)` to
`hungerbuhlerWasem_residueTheorem` and `hγa : γ a ≠ s` to `hasCauchyPV_half_residue`. With
`hclosed : γ a = γ b` this makes every crossing of an on-curve pole interior to the parameter
interval — for a closed curve a reparametrization away, never a real restriction. This is
**exactly** AINTLIB's own residual: its paper-faithful summit
(`residueTheorem_crossing_paper_faithful_clean`, `MultiCrossingCPV.lean:1476`) carries
`hx_notin_S : x ∉ ↑S`, consumed once (`crossings_finset_of_endpts_off`, `Crossing.lean:673`) to
force all crossings into `Ioo 0 1`. No `cyclicShift` elimination exists in AINTLIB — that name
is a docstring phantom.

**2. Scope notes (from the audit).** The summit docstring and README now record the deliberate
narrowings relative to the printed Thm 3.3, so they read as decisions rather than oversights:
single closed curve (paper: cycle), finite `S` (paper: no accumulation points in `U`),
`MeromorphicAt` at each singularity (paper's condition (A) also admits an essential singularity
where the cycle is locally straight). Each is forced or justified: `residue` via
`meromorphicOrderAt` cannot express essential-singularity residues, and the valence formula
needs only this scope.

**3. Provenance file-map fix.** The old `Chapters/HW33.lean` entry was not a valid path relative to the `LeanModularForms/` code tree the map is scoped to (a similarly named file exists under `LeanModularFormsBlueprint/Chapters/`, but it is blueprint documentation, not the proof source); the map now
cites `ForMathlib/HW33Clean.lean` (`hw_3_3_clean_full_mero`) and re-attributes `HasCauchyPVOn'`
/ `pv_integral_simple_pole` to `ForMathlib/GeneralizedResidueTheory/Residue.lean` where they
actually live.

## The audit (summary)

Checked every pinned def and every theorem target against (a) AINTLIB's sorry-free statements,
hypothesis by hypothesis, and (b) the paper's Def 2.1, Prop 2.2/2.3, conditions (A)/(A′)/(B),
and Thm 3.3:

* **Layers 0–3: all ten pinned items verified proven in TauCeti with roadmap-exact
  signatures** (model sector ×4, argument principle ×2, classical residue theorem,
  homology Cauchy theorem, plus the defs).
* **Def 2.1 fidelity**: the paper's excision is the spatial truncation `|C − z₀| > ε`;
  TauCeti's `HasCauchyPVAt`/`HasCauchyPV` integrands match it verbatim, as do AINTLIB's.
* **Summit hypothesis-by-hypothesis vs AINTLIB**: every AINTLIB hypothesis is either present,
  split (`IsNullHomologous` = image-subset + winding-zero, carried here as `hγU` + `hnull`),
  derivable (`hU_ne` follows from `hγU`), carried by the roadmap's raw-γ predicates
  (`IsPwC1ImmersionOn` + `hclosed` ↔ `ClosedPwC1Immersion`), or the now-added `hγa`.
  AINTLIB imposes **no** orientation hypothesis (its interval is hard-coded `[0,1]`), no
  breakpoint-avoidance for crossings (the "corner" theorems), and no `S.Nonempty`.
* **Conditions**: TauCeti's `ConditionB` (higher-order poles only, via
  `meromorphicOrderAt < -1`) is sharper than both AINTLIB's `SatisfiesConditionB` (which
  constrains every crossing) and the paper's (B) — correctly so, since the paper's own base
  regime (only simple poles on `C`) needs no conditions at all, and order-1 flatness is
  automatic for immersions (`FlatnessOne.lean` already discharges it).
* **One real provability gap found — on the TauCeti side, not here**: TauCeti's merged
  `ConditionAprime`/`ConditionB` quantify over `Ioo a b`/`Icc a b` and read the basepoint
  angle at `(a, b)` directly, so for `a > b` they are vacuous and the (deliberately
  orientation-robust, `hab`-free) summit targets would be unprovable against them. Fix was a
  TauCeti normalization to `min/max` form (since merged as TauCeti#952); **no roadmap change needed**,
  matching the proven, `hab`-free Layer-3 target.

`lake build TauCetiRoadmap.ContourIntegration.Suggested` ✓ (sorry-warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)