### PR TITLE
refactor(Exchangeability): separate mixed IID from conditional IID

### DIFF
--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -354,6 +354,8 @@ Consume Mathlib's product/cylinder infrastructure — `generateFrom_pi`, `isPiSy
 `Measure.pi_eq`, `Measure.pi_pi` — and build only the de Finetti-facing adapters over it:
 
 * measurability of `ω ↦ Measure.pi fun _ : Fin m => ν ω` (the random product kernel);
+* measurability of the joint kernel `ω ↦ δ_{ν ω} ⊗ (ν ω)^{⊗m}`, which the conditional common
+  ending needs for `Measure.bind_apply` and extensionality on the joint space;
 * the AE-measurable version needed for `Measure.bind_apply`;
 * rectangle evaluation and equality-from-rectangles specialized to those random product
   measures (that rectangles form a π-system and generate the product σ-algebra is Mathlib's
@@ -666,12 +668,19 @@ The directing-measure theorem should expose a real API, not just an existence pr
   2005, Thm 1.1), the sharp form from which the mixture identity follows by integrating out;
 * **a.e.** uniqueness of `ν` **among directing measures**, i.e. among witnesses of
   `ConditionallyIIDWith` (`conditionallyIID_ae_unique`: equality of probability measures a.e.
-  under the base law, tested against a determining class — not pointwise). Mere mixing
+  under the base law, tested against a determining class — not pointwise). Pin its hypotheses:
+  `[IsProbabilityMeasure μ] [StandardBorelSpace α] [Nonempty α]`, measurable `X`, and two
+  explicit `ConditionallyIIDWith μ X ν` / `ConditionallyIIDWith μ X ν'` hypotheses, concluding
+  `ν =ᵐ[μ] ν'`. Mere mixing
   representatives (witnesses of `MixedIIDWith`) are **not** a.e. unique when the mixing law is
   nondegenerate — an independent copy of `ν` is one — so no witness-level a.e.-equality
   theorem may conclude `ν = ν'` from `MixedIIDWith` alone; the mixture-side uniqueness is of
   the mixing law `μ.map ν` (`mixedIID_mixingLaw_unique`, which does quantify over mixture
-  witnesses);
+  witnesses: two `MixedIIDWith` hypotheses, measurable `X`, concluding `μ.map ν = μ.map ν'`).
+  The `[IsProbabilityMeasure μ]` hypothesis on `mixedIID_mixingLaw_unique` is load-bearing,
+  not decorative: for infinite base measures, distinct mixing measures can give identical
+  `∞`-valued finite-dimensional mixtures, so mixing-law uniqueness fails at the hypothesis-light
+  generality of the definitions;
 * the finite-dimensional factorization identity;
 * the empirical-measure form: `(1/n) Σ_{i<n} δ_{Xᵢ}(ω) ⇒ ν(ω)` weakly in `P(α)`, tested
   against bounded continuous functions (a milestone in its own right, bringing in the weak

--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -12,7 +12,7 @@ The first summit is the de Finetti–Ryll-Nardzewski theorem for sequences on a 
 Borel space:
 
 ```text
-contractable ↔ exchangeable ↔ conditionally i.i.d.
+contractable ↔ exchangeable ↔ representable as a mixture of i.i.d. laws
 ```
 
 It has three classical proof routes: reverse martingales, L² contractability bounds, and
@@ -54,7 +54,7 @@ with `α` a standard Borel space, prove the de Finetti–Ryll-Nardzewski equival
 --     {μ : Measure Ω} [IsProbabilityMeasure μ]
 --     (X : ℕ → Ω → α)
 --     (hX_meas : ∀ i, Measurable (X i)) :
---     Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X
+--     Contractable μ X ↔ Exchangeable μ X ∧ IsIIDMixture μ X
 --
 -- theorem deFinetti
 --     {Ω : Type*} [MeasurableSpace Ω]
@@ -63,7 +63,7 @@ with `α` a standard Borel space, prove the de Finetti–Ryll-Nardzewski equival
 --     (X : ℕ → Ω → α)
 --     (hX_meas : ∀ i, Measurable (X i))
 --     (hX_exch : Exchangeable μ X) :
---     ConditionallyIID μ X
+--     IsIIDMixture μ X
 ```
 
 The standard-Borel hypothesis is on the value space `α`, where the directing measure and
@@ -91,7 +91,7 @@ output. The spine is:
 2. exchangeability, full exchangeability, spreadability/contractability, and the bridges
    between the process-level and path-law formulations;
 3. product kernels and mixtures of finite product measures;
-4. conditional independence and conditionally i.i.d. APIs;
+4. measurable mixtures of i.i.d. product laws;
 5. process-relative tail σ-algebras and path-space shifts;
 6. reverse martingales for arbitrary decreasing filtrations;
 7. Koopman operators and invariant σ-algebras for arbitrary measure-preserving maps.
@@ -108,14 +108,20 @@ The basic definitions should be as hypothesis-light as possible:
 * `Exchangeable μ X`: invariance of finite-dimensional laws under permutations of `Fin n`.
 * `FullyExchangeable μ X`: invariance of the path law under all permutations of `ℕ`.
 * `Contractable μ X`: invariance under strictly increasing finite subsequences.
-* `ConditionallyIID μ X`: existence of a measurable random probability measure whose
+* `IsIIDMixture μ X`: existence of a measurable random probability measure whose
   finite product kernels give the finite-dimensional laws. Pin the directing-measure API
   before stating it: either `ν : Ω → ProbabilityMeasure α` (with Mathlib's
   `ProbabilityMeasure.pi`, and `ProbabilityMeasure.toMeasure_pi` / `ProbabilityMeasure.pi_pi`
   for the bridge to `Measure.pi` and rectangle evaluation), or a raw `ν : Ω → Measure α`
   together with an explicit `∀ ω, IsProbabilityMeasure (ν ω)` hypothesis. A
-  `ConditionallyIIDWith μ X ν` relation plus an existential wrapper keeps the directing
+  `IsIIDMixtureWith μ X ν` relation plus an existential wrapper keeps the directing
   measure nameable in proofs.
+
+This is a representation property of the **unconditional finite-dimensional laws**. Do not call
+it `ConditionallyIID`: that standard phrase normally asserts conditional independence relative to
+a σ-algebra or random element, using conditional laws or almost-sure conditional-expectation
+identities. The mixture equation above is the conclusion of integrating out such conditional
+structure, not a definition of conditional independence on the original probability space.
 
 The standard-Borel hypotheses belong in the directing-measure construction and final
 de Finetti theorem, not in every elementary definition. Similarly, L² assumptions belong
@@ -163,7 +169,7 @@ The missing pieces are:
 * the `pathLaw` / `Fin n`-prefix wrappers over Mathlib's projective-limit uniqueness
   (`IsProjectiveLimit.unique`, from `Mathlib.MeasureTheory.Constructions.Projective`);
 * product-kernel measurability for random finite product measures;
-* the common de Finetti ending turning a directing-measure bridge into `ConditionallyIID`;
+* the common de Finetti ending turning a directing-measure bridge into `IsIIDMixture`;
 * process-relative tail σ-algebras and their antitone filtration structure;
 * reverse martingale convergence for conditional expectations along decreasing filtrations;
 * Koopman operators and the identification of the mean-ergodic projection with conditional
@@ -291,8 +297,8 @@ Also build the implication lattice and the alternate characterizations as named 
 * closure of each symmetry class under coordinatewise pushforward `X ↦ (f ∘ Xᵢ)`;
 * mixtures of i.i.d. laws are exchangeable, and exchangeable laws are stationary;
 * the implication lattice among `ExchangeableAt n`, `Exchangeable`, `FullyExchangeable`,
-  `Contractable`, and `ConditionallyIID`, with every easy arrow named and the hard arrow
-  `Contractable → ConditionallyIID` isolated;
+  `Contractable`, and `IsIIDMixture`, with every easy arrow named and the hard arrow
+  `Contractable → IsIIDMixture` isolated;
 * the process-level ↔ path-law bridges in both directions.
 
 State each equivalence with its hypotheses: finite ↔ full exchangeability needs a probability
@@ -305,7 +311,7 @@ only, or as a property of a process only, without bridges. Both viewpoints are u
 the process-level statements are what users want, while the path-law statements make
 π-system and shift arguments cleaner.
 
-### Layer 1: product kernels, conditional independence, and mixtures
+### Layer 1: product kernels and mixtures
 
 Suggested home:
 
@@ -327,7 +333,7 @@ Consume Mathlib's product/cylinder infrastructure — `generateFrom_pi`, `isPiSy
 Then build the common de Finetti ending:
 
 ```lean
-conditional_iid_from_directing_measure
+iidMixture_of_directingMeasure
 ```
 
 The intended bridge hypothesis is an indicator-product factorization: for every finite
@@ -427,7 +433,7 @@ Build:
 * extension from bounded measurable real observables to a countable determining class on the
   standard Borel state space;
 * the directing-measure bridge;
-* the call to `conditional_iid_from_directing_measure`.
+* the call to `iidMixture_of_directingMeasure`.
 
 Key milestones:
 
@@ -438,7 +444,7 @@ l2_bound_long_vs_tail
 weighted_sums_converge_L1
 realObservables_determine_directing_measure
 directing_measure_satisfies_requirements
-conditionallyIID_of_contractable_viaL2
+iidMixture_of_contractable_viaL2
 deFinetti_viaL2
 deFinetti_RyllNardzewski_equivalence_viaL2
 ```
@@ -569,8 +575,8 @@ Finally build the exchangeability-specific bridge:
 pathSpace_contractable_of_contractable
 measure_map_shift_eq_of_contractable
 pathSpace_shift_preserving_of_contractable
-conditionallyIID_transfer
-conditionallyIID_bind_of_contractable
+iidMixture_transfer
+iidMixture_bind_of_contractable
 deFinetti_viaKoopman
 ```
 
@@ -604,7 +610,7 @@ Build:
 Key milestones:
 
 ```lean
-conditionallyIID_of_contractable
+iidMixture_of_contractable
 deFinetti
 deFinetti_equivalence
 deFinetti_RyllNardzewski_equivalence
@@ -643,13 +649,13 @@ Expose:
 Exchangeable
 FullyExchangeable
 Contractable
-ConditionallyIID
+IsIIDMixture
 
 exchangeable_iff_fullyExchangeable
 contractable_of_exchangeable
-exchangeable_of_conditionallyIID
+exchangeable_of_iidMixture
 
-conditionallyIID_of_contractable
+iidMixture_of_contractable
 deFinetti
 deFinetti_equivalence
 deFinetti_RyllNardzewski_equivalence
@@ -659,7 +665,7 @@ deFinetti_viaKoopman
 
 deFinetti_empiricalMeasure
 deFinetti_mixture
-conditionallyIID_ae_unique
+iidMixture_ae_unique
 exchangeable_extreme_iff_iid
 ```
 
@@ -689,7 +695,7 @@ martingales, Koopman operators, product kernels — is a parallel ongoing goal.
 Discharge these alongside the layers; they check that the API describes real probability
 objects, not just the final theorem.
 
-* The law of an i.i.d. sequence is `ConditionallyIID`, `Exchangeable`, and `Contractable`.
+* The law of an i.i.d. sequence is `IsIIDMixture`, `Exchangeable`, and `Contractable`.
 * A mixture of i.i.d. `Bool`-valued laws, parameterized by a random `θ`, is exchangeable,
   with `ω ↦ κ (θ ω)` (`κ` a two-point kernel) as the directing measure. The directing
   measure is the random probability measure induced by `θ`, not `θ` itself; phrasing it via

--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -12,7 +12,7 @@ The first summit is the de Finetti–Ryll-Nardzewski theorem for sequences on a 
 Borel space:
 
 ```text
-contractable ↔ exchangeable ↔ representable as a mixture of i.i.d. laws
+contractable ↔ exchangeable ↔ conditionally i.i.d.
 ```
 
 It has three classical proof routes: reverse martingales, L² contractability bounds, and
@@ -54,7 +54,7 @@ with `α` a standard Borel space, prove the de Finetti–Ryll-Nardzewski equival
 --     {μ : Measure Ω} [IsProbabilityMeasure μ]
 --     (X : ℕ → Ω → α)
 --     (hX_meas : ∀ i, Measurable (X i)) :
---     Contractable μ X ↔ Exchangeable μ X ∧ IsIIDMixture μ X
+--     Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X
 --
 -- theorem deFinetti
 --     {Ω : Type*} [MeasurableSpace Ω]
@@ -63,7 +63,7 @@ with `α` a standard Borel space, prove the de Finetti–Ryll-Nardzewski equival
 --     (X : ℕ → Ω → α)
 --     (hX_meas : ∀ i, Measurable (X i))
 --     (hX_exch : Exchangeable μ X) :
---     IsIIDMixture μ X
+--     ConditionallyIID μ X
 ```
 
 The standard-Borel hypothesis is on the value space `α`, where the directing measure and
@@ -91,7 +91,8 @@ output. The spine is:
 2. exchangeability, full exchangeability, spreadability/contractability, and the bridges
    between the process-level and path-law formulations;
 3. product kernels and mixtures of finite product measures;
-4. measurable mixtures of i.i.d. product laws;
+4. measurable mixtures of i.i.d. product laws, and the genuine conditionally-i.i.d. upgrade
+   (the joint-law disintegration given the directing measure);
 5. process-relative tail σ-algebras and path-space shifts;
 6. reverse martingales for arbitrary decreasing filtrations;
 7. Koopman operators and invariant σ-algebras for arbitrary measure-preserving maps.
@@ -108,20 +109,47 @@ The basic definitions should be as hypothesis-light as possible:
 * `Exchangeable μ X`: invariance of finite-dimensional laws under permutations of `Fin n`.
 * `FullyExchangeable μ X`: invariance of the path law under all permutations of `ℕ`.
 * `Contractable μ X`: invariance under strictly increasing finite subsequences.
-* `IsIIDMixture μ X`: existence of a measurable random probability measure whose
-  finite product kernels give the finite-dimensional laws. Pin the directing-measure API
+* `MixedIID μ X` (Kallenberg's terminology for the unconditional identity): existence of a
+  measurable random probability measure whose
+  finite product kernels give the finite-dimensional laws. Pin the random-measure API
   before stating it: either `ν : Ω → ProbabilityMeasure α` (with Mathlib's
   `ProbabilityMeasure.pi`, and `ProbabilityMeasure.toMeasure_pi` / `ProbabilityMeasure.pi_pi`
   for the bridge to `Measure.pi` and rectangle evaluation), or a raw `ν : Ω → Measure α`
-  together with an explicit `∀ ω, IsProbabilityMeasure (ν ω)` hypothesis. A
-  `IsIIDMixtureWith μ X ν` relation plus an existential wrapper keeps the directing
-  measure nameable in proofs.
+  together with an explicit `∀ ω, IsProbabilityMeasure (ν ω)` hypothesis. The
+  `MixedIIDWith μ X ν` relation plus the existential wrapper keeps the mixing
+  representative nameable in proofs.
 
 This is a representation property of the **unconditional finite-dimensional laws**. Do not call
 it `ConditionallyIID`: that standard phrase normally asserts conditional independence relative to
 a σ-algebra or random element, using conditional laws or almost-sure conditional-expectation
 identities. The mixture equation above is the conclusion of integrating out such conditional
 structure, not a definition of conditional independence on the original probability space.
+
+The genuine conditional notion is the **summit predicate**, a separate, stronger target:
+
+* `ConditionallyIIDWith μ X ν`: the **joint-law disintegration**
+  `Law(ν, block) = ∫ δ_{ν(ω)} ⊗ (ν(ω))^{⊗m} dμ(ω)` — conditionally on `ν`, every finite
+  distinct block is i.i.d. `ν` (Kallenberg 2005, §1.1 eq. (2); stated as a joint-law identity,
+  so the definition needs no conditional expectations — Thm 1.1 there is the equivalence with
+  exchangeability), with `ConditionallyIID` its existential wrapper.
+
+It strictly strengthens the mixture identity **at a fixed `ν`**: the mixture relation
+constrains only the block's marginal law, so for a **nondegenerate mixing law**, on a rich
+enough space an **independent copy** of a directing measure also witnesses `MixedIIDWith`
+while the process is not conditionally i.i.d. given it. Terminology follows: a `ν` witnessing
+only the mixture identity is a **mixing representative**; **directing measure** is reserved
+for the conditional predicate's witness. Uniqueness splits the same way: no witness-level
+a.e.-equality theorem may conclude `ν = ν'` from `MixedIIDWith` alone — what is unique on the
+mixture side is the **mixing law** `μ.map ν` (`mixedIID_mixingLaw_unique`), while a.e.
+uniqueness of the witness itself holds on the conditional side
+(`conditionallyIID_ae_unique`, Layer 6). The easy arrow is
+`ConditionallyIIDWith μ X ν → MixedIIDWith μ X ν` with its existential corollary
+`mixedIID_of_conditionallyIID`; the hard converse is de Finetti's upgrade to the canonical
+tail-measurable directing measure (`conditionallyIID_of_exchangeable`, Layer 6), and the
+summit theorems conclude `ConditionallyIID`, never merely `MixedIID`. Sequencing note:
+TauCeti's landed API currently uses the name `ConditionallyIID` for the *mixture* shape, so
+the code rename (to `MixedIID` / `MixedIIDWith`) must land **before** the conditional
+predicate is implemented under this name.
 
 The standard-Borel hypotheses belong in the directing-measure construction and final
 de Finetti theorem, not in every elementary definition. Similarly, L² assumptions belong
@@ -169,7 +197,8 @@ The missing pieces are:
 * the `pathLaw` / `Fin n`-prefix wrappers over Mathlib's projective-limit uniqueness
   (`IsProjectiveLimit.unique`, from `Mathlib.MeasureTheory.Constructions.Projective`);
 * product-kernel measurability for random finite product measures;
-* the common de Finetti ending turning a directing-measure bridge into `IsIIDMixture`;
+* the common de Finetti endings turning a mixing-representative bridge into `MixedIIDWith` and
+  its joint-rectangle strengthening into `ConditionallyIIDWith`;
 * process-relative tail σ-algebras and their antitone filtration structure;
 * reverse martingale convergence for conditional expectations along decreasing filtrations;
 * Koopman operators and the identification of the mean-ergodic projection with conditional
@@ -297,8 +326,8 @@ Also build the implication lattice and the alternate characterizations as named 
 * closure of each symmetry class under coordinatewise pushforward `X ↦ (f ∘ Xᵢ)`;
 * mixtures of i.i.d. laws are exchangeable, and exchangeable laws are stationary;
 * the implication lattice among `ExchangeableAt n`, `Exchangeable`, `FullyExchangeable`,
-  `Contractable`, and `IsIIDMixture`, with every easy arrow named and the hard arrow
-  `Contractable → IsIIDMixture` isolated;
+  `Contractable`, `MixedIID`, and `ConditionallyIID`, with every easy arrow named and the hard
+  arrow `Contractable → ConditionallyIID` isolated;
 * the process-level ↔ path-law bridges in both directions.
 
 State each equivalence with its hypotheses: finite ↔ full exchangeability needs a probability
@@ -330,15 +359,20 @@ Consume Mathlib's product/cylinder infrastructure — `generateFrom_pi`, `isPiSy
   measures (that rectangles form a π-system and generate the product σ-algebra is Mathlib's
   `isPiSystem_pi` / `generateFrom_pi`).
 
-Then build the common de Finetti ending:
+Then build the common de Finetti endings:
 
 ```lean
-iidMixture_of_directingMeasure
+mixedIID_of_mixingRepresentative
+conditionallyIID_of_jointRectangles
 ```
 
-The intended bridge hypothesis is an indicator-product factorization: for every finite
-injective selection `k : Fin m → ℕ` and measurable rectangle `B`, the law of
-`(X (k i))ᵢ` equals the mixture of product measures induced by `ν`.
+The intended bridge hypothesis of the first is an indicator-product factorization: for every
+finite injective selection `k : Fin m → ℕ` and measurable rectangle `B`, the law of
+`(X (k i))ᵢ` equals the mixture of product measures induced by `ν`. The second is its
+**joint-rectangle strengthening** — agreement of the joint law of `(ν, block)` with the
+disintegration `δ_ν ⊗ ν^{⊗m}` on rectangles `S ×ˢ B` (measurable `S` in the `ν` coordinate) —
+which upgrades to `ConditionallyIIDWith` by the same π-system argument and is what each proof
+route calls to reach the conditional summit.
 
 This layer is shared by the L² and Koopman routes, and also useful for the martingale
 route's final finite-product step.
@@ -433,7 +467,8 @@ Build:
 * extension from bounded measurable real observables to a countable determining class on the
   standard Borel state space;
 * the directing-measure bridge;
-* the call to `iidMixture_of_directingMeasure`.
+* the calls to the common endings — `mixedIID_of_mixingRepresentative` and the joint-rectangle
+  `conditionallyIID_of_jointRectangles` for the conditional summit.
 
 Key milestones:
 
@@ -444,7 +479,7 @@ l2_bound_long_vs_tail
 weighted_sums_converge_L1
 realObservables_determine_directing_measure
 directing_measure_satisfies_requirements
-iidMixture_of_contractable_viaL2
+conditionallyIID_of_contractable_viaL2
 deFinetti_viaL2
 deFinetti_RyllNardzewski_equivalence_viaL2
 ```
@@ -575,8 +610,8 @@ Finally build the exchangeability-specific bridge:
 pathSpace_contractable_of_contractable
 measure_map_shift_eq_of_contractable
 pathSpace_shift_preserving_of_contractable
-iidMixture_transfer
-iidMixture_bind_of_contractable
+conditionallyIID_transfer
+conditionallyIID_bind_of_contractable
 deFinetti_viaKoopman
 ```
 
@@ -610,17 +645,33 @@ Build:
 Key milestones:
 
 ```lean
-iidMixture_of_contractable
+conditionallyIID_of_contractable
+conditionallyIID_of_exchangeable
 deFinetti
 deFinetti_equivalence
 deFinetti_RyllNardzewski_equivalence
+mixedIID_of_contractable
 ```
+
+`conditionallyIID_of_contractable` is the actual hard route theorem; `deFinetti` and the
+Ryll-Nardzewski equivalence conclude `ConditionallyIID`, and the mixture forms
+(`mixedIID_of_contractable`, `deFinetti_mixture`) are retained as integrated-out corollaries,
+never as the summit.
 
 The directing-measure theorem should expose a real API, not just an existence proof:
 
 * construction of the directing measure `ν`;
-* **a.e.** uniqueness of `ν` (equality of probability measures a.e. under the base law, tested
-  against a determining class — not pointwise);
+* the **conditional upgrade** `conditionallyIID_of_exchangeable`: the constructed `ν` satisfies
+  `ConditionallyIIDWith μ X ν` — conditionally on `ν` the process is i.i.d. `ν` (Kallenberg
+  2005, Thm 1.1), the sharp form from which the mixture identity follows by integrating out;
+* **a.e.** uniqueness of `ν` **among directing measures**, i.e. among witnesses of
+  `ConditionallyIIDWith` (`conditionallyIID_ae_unique`: equality of probability measures a.e.
+  under the base law, tested against a determining class — not pointwise). Mere mixing
+  representatives (witnesses of `MixedIIDWith`) are **not** a.e. unique when the mixing law is
+  nondegenerate — an independent copy of `ν` is one — so no witness-level a.e.-equality
+  theorem may conclude `ν = ν'` from `MixedIIDWith` alone; the mixture-side uniqueness is of
+  the mixing law `μ.map ν` (`mixedIID_mixingLaw_unique`, which does quantify over mixture
+  witnesses);
 * the finite-dimensional factorization identity;
 * the empirical-measure form: `(1/n) Σ_{i<n} δ_{Xᵢ}(ω) ⇒ ν(ω)` weakly in `P(α)`, tested
   against bounded continuous functions (a milestone in its own right, bringing in the weak
@@ -649,23 +700,31 @@ Expose:
 Exchangeable
 FullyExchangeable
 Contractable
-IsIIDMixture
+MixedIIDWith
+MixedIID
+ConditionallyIIDWith
+ConditionallyIID
 
 exchangeable_iff_fullyExchangeable
 contractable_of_exchangeable
-exchangeable_of_iidMixture
+exchangeable_of_mixedIID
+mixedIIDWith_of_conditionallyIIDWith
+mixedIID_of_conditionallyIID
 
-iidMixture_of_contractable
+conditionallyIID_of_contractable
+conditionallyIID_of_exchangeable
 deFinetti
 deFinetti_equivalence
 deFinetti_RyllNardzewski_equivalence
+mixedIID_of_contractable
 
 deFinetti_viaL2
 deFinetti_viaKoopman
 
 deFinetti_empiricalMeasure
 deFinetti_mixture
-iidMixture_ae_unique
+mixedIID_mixingLaw_unique
+conditionallyIID_ae_unique
 exchangeable_extreme_iff_iid
 ```
 
@@ -695,11 +754,14 @@ martingales, Koopman operators, product kernels — is a parallel ongoing goal.
 Discharge these alongside the layers; they check that the API describes real probability
 objects, not just the final theorem.
 
-* The law of an i.i.d. sequence is `IsIIDMixture`, `Exchangeable`, and `Contractable`.
-* A mixture of i.i.d. `Bool`-valued laws, parameterized by a random `θ`, is exchangeable,
-  with `ω ↦ κ (θ ω)` (`κ` a two-point kernel) as the directing measure. The directing
-  measure is the random probability measure induced by `θ`, not `θ` itself; phrasing it via
-  the two-point kernel keeps the example independent of a mature `Bernoulli` API.
+* The law of an i.i.d. sequence is `MixedIID` — indeed `ConditionallyIID`, with the constant
+  directing measure — `Exchangeable`, and `Contractable`.
+* A `Bool`-valued sequence generated **conditionally i.i.d. given a random `θ`** (draw `θ`,
+  then flip i.i.d. `κ (θ ω)`-coins) is exchangeable, with `ω ↦ κ (θ ω)` (`κ` a two-point
+  kernel) as the directing measure — genuinely: the generating construction makes it a witness
+  of `ConditionallyIIDWith`, not merely a mixing representative. The directing measure is the
+  random probability measure induced by `θ`, not `θ` itself; phrasing it via the two-point
+  kernel keeps the example independent of a mature `Bernoulli` API.
 * Finite-dimensional prefix marginals determine a probability measure on `ℕ → α`.
 * Full exchangeability of a path law implies shift-preservation.
 * A stationary non-reversible finite-state Markov chain — for instance the deterministic

--- a/TauCetiRoadmap/Exchangeability/Suggested.lean
+++ b/TauCetiRoadmap/Exchangeability/Suggested.lean
@@ -80,11 +80,11 @@ def prefixProj (α : Type*) (n : ℕ) (x : ℕ → α) : Fin n → α := fun i =
 /-- **Layer 0, left shift** on path space. -/
 def shift (α : Type*) (x : ℕ → α) : ℕ → α := fun n => x (n + 1)
 
-/-- **Layer 0, conditionally i.i.d.** There is a measurable random probability measure
+/-- **Layer 0, i.i.d. mixture representation.** There is a measurable random probability measure
 `ν : Ω → ProbabilityMeasure α` so that every finite block of distinct coordinates is
 distributed as the `ν`-mixture of the corresponding product measure (the explicit
 finite-index factorization; `ProbabilityMeasure.pi` supplies the product). -/
-def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+def IsIIDMixture (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
   ∃ ν : Ω → ProbabilityMeasure α, Measurable ν ∧
     ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
       μ.map (fun ω => fun i : Fin m => X (k i) ω) =
@@ -115,9 +115,9 @@ example [IsProbabilityMeasure μ] (hX : ∀ i, Measurable (X i)) :
 example (hX : ∀ i, Measurable (X i)) (h : Exchangeable μ X) : Contractable μ X := by
   sorry
 
-/-- **Layer 0 bridge, conditionally i.i.d. ⇒ exchangeable.** Permutation invariance of the
+/-- **Layer 0 bridge, i.i.d. mixture ⇒ exchangeable.** Permutation invariance of the
 finite product measures; will later move to the product-kernel layer once that lands. -/
-example (hX : ∀ i, Measurable (X i)) (h : ConditionallyIID μ X) : Exchangeable μ X := by
+example (hX : ∀ i, Measurable (X i)) (h : IsIIDMixture μ X) : Exchangeable μ X := by
   sorry
 
 /-- **Layer 0 bridge, full exchangeability ⇒ shift-preservation** of the path law (the link
@@ -142,7 +142,7 @@ example (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) (m : ℕ) :
 
 /-- **Layer 1, the common de Finetti ending.** A measurable random probability measure whose
 mixtures match the finite-dimensional laws on measurable rectangles is a directing measure:
-rectangle agreement upgrades to the full `ConditionallyIID` factorization by the π-system
+rectangle agreement upgrades to the full `IsIIDMixture` factorization by the π-system
 argument. Shared by the L², Koopman, and martingale routes. -/
 example [IsProbabilityMeasure μ] (hX : ∀ i, Measurable (X i))
     (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν)
@@ -151,7 +151,7 @@ example [IsProbabilityMeasure μ] (hX : ∀ i, Measurable (X i))
         μ.map (fun ω => fun i : Fin m => X (k i) ω) (Set.univ.pi B) =
           μ.bind (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure)
             (Set.univ.pi B)) :
-    ConditionallyIID μ X := by
+    IsIIDMixture μ X := by
   sorry
 
 /-! ## Layer 2: process tails, path-space σ-algebras, and Hewitt–Savage -/
@@ -225,18 +225,18 @@ theorem should be the reverse-martingale route.
 -/
 
 /-- **Layer 6 summit, de Finetti's theorem** on a standard Borel state space: an
-exchangeable sequence is conditionally i.i.d. -/
+exchangeable sequence has an i.i.d. mixture representation. -/
 example [IsProbabilityMeasure μ] [StandardBorelSpace α] [Nonempty α]
     (hX : ∀ i, Measurable (X i)) (h_exch : Exchangeable μ X) :
-    ConditionallyIID μ X := by
+    IsIIDMixture μ X := by
   sorry
 
 /-- **Layer 6 summit, the de Finetti–Ryll-Nardzewski equivalence**:
-`contractable ↔ exchangeable ↔ conditionally i.i.d.` for sequences on a standard Borel
+`contractable ↔ exchangeable ↔ i.i.d. mixture` for sequences on a standard Borel
 state space. -/
 example [IsProbabilityMeasure μ] [StandardBorelSpace α] [Nonempty α]
     (hX : ∀ i, Measurable (X i)) :
-    Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X := by
+    Contractable μ X ↔ Exchangeable μ X ∧ IsIIDMixture μ X := by
   sorry
 
 end TauCetiRoadmap.Exchangeability

--- a/TauCetiRoadmap/Exchangeability/Suggested.lean
+++ b/TauCetiRoadmap/Exchangeability/Suggested.lean
@@ -80,15 +80,44 @@ def prefixProj (α : Type*) (n : ℕ) (x : ℕ → α) : Fin n → α := fun i =
 /-- **Layer 0, left shift** on path space. -/
 def shift (α : Type*) (x : ℕ → α) : ℕ → α := fun n => x (n + 1)
 
-/-- **Layer 0, i.i.d. mixture representation.** There is a measurable random probability measure
-`ν : Ω → ProbabilityMeasure α` so that every finite block of distinct coordinates is
-distributed as the `ν`-mixture of the corresponding product measure (the explicit
-finite-index factorization; `ProbabilityMeasure.pi` supplies the product). -/
-def IsIIDMixture (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
-  ∃ ν : Ω → ProbabilityMeasure α, Measurable ν ∧
+/-- **Layer 0, mixed i.i.d. with a fixed mixing representative.** Every finite block of
+distinct coordinates is distributed as the `μ`-mixture of `ν`'s finite products (the explicit
+finite-index factorization; `ProbabilityMeasure.pi` supplies the product). An **unconditional**
+identity: it constrains only each block's marginal law, never the joint law of `(ν, X)` — the
+genuine conditional strengthening is `ConditionallyIIDWith` below, and `ν` here is a **mixing
+representative**, not a directing measure. -/
+def MixedIIDWith (μ : Measure Ω) (X : ℕ → Ω → α) (ν : Ω → ProbabilityMeasure α) : Prop :=
+  Measurable ν ∧
     ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
       μ.map (fun ω => fun i : Fin m => X (k i) ω) =
         μ.bind (fun ω => (ProbabilityMeasure.pi (fun _ : Fin m => ν ω)).toMeasure)
+
+/-- **Layer 0, mixed i.i.d.** (Kallenberg's terminology): some measurable random probability
+measure mixes to the finite-dimensional laws — the existential wrapper over `MixedIIDWith`. -/
+def MixedIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∃ ν : Ω → ProbabilityMeasure α, MixedIIDWith μ X ν
+
+/-- **Layer 0, conditionally i.i.d. given `ν` — the genuine conditional notion.** The **joint**
+law of the random measure and each finite distinct block disintegrates as `δ_ν ⊗ ν^{⊗m}`:
+conditionally on `ν`, the block is i.i.d. `ν` (Kallenberg, *Probabilistic Symmetries and
+Invariance Principles* (2005), §1.1 eq. (2) — stated as a joint-law identity, so no conditional
+expectations are needed to define it; Thm 1.1 there is the equivalence with exchangeability).
+Strictly stronger **at fixed `ν`** than `MixedIIDWith`, which constrains only the block's
+marginal law: for a nondegenerate mixing law, on a rich enough space an independent copy of a
+directing measure witnesses the mixture identity while the process is not conditionally i.i.d.
+given it. The term **directing measure** is reserved for a `ν` witnessing this predicate —
+witness-level a.e. uniqueness lives here, never on the mixture side. -/
+def ConditionallyIIDWith (μ : Measure Ω) (X : ℕ → Ω → α)
+    (ν : Ω → ProbabilityMeasure α) : Prop :=
+  Measurable ν ∧
+    ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
+        μ.bind fun ω =>
+          (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure
+
+/-- **Layer 0, conditionally i.i.d.** — the existential wrapper over `ConditionallyIIDWith`. -/
+def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+  ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν
 
 /-- **Layer 0, finite-marginal uniqueness.** Two measures on path space, with `μ` finite,
 agreeing on every finite-dimensional prefix marginal are equal (`ν`'s finiteness is forced by
@@ -115,9 +144,23 @@ example [IsProbabilityMeasure μ] (hX : ∀ i, Measurable (X i)) :
 example (hX : ∀ i, Measurable (X i)) (h : Exchangeable μ X) : Contractable μ X := by
   sorry
 
-/-- **Layer 0 bridge, i.i.d. mixture ⇒ exchangeable.** Permutation invariance of the
+/-- **Layer 0 bridge, mixed i.i.d. ⇒ exchangeable.** Permutation invariance of the
 finite product measures; will later move to the product-kernel layer once that lands. -/
-example (hX : ∀ i, Measurable (X i)) (h : IsIIDMixture μ X) : Exchangeable μ X := by
+example (hX : ∀ i, Measurable (X i)) (h : MixedIID μ X) : Exchangeable μ X := by
+  sorry
+
+/-- **Layer 0 bridge, conditionally i.i.d. ⇒ mixed i.i.d., at a fixed witness**
+(`mixedIIDWith_of_conditionallyIIDWith`). Project the joint identity to the block coordinate
+(integrate `ν` out) — the theorem matching the fixed-`ν` discussion. The converse **at a fixed
+`ν`** is false for a nondegenerate mixing law (the independent-copy counterexample); the
+existential converse is de Finetti's upgrade `conditionallyIID_of_exchangeable` (Layer 6),
+which produces the canonical directing measure. -/
+example (hX : ∀ i, Measurable (X i)) {ν : Ω → ProbabilityMeasure α}
+    (h : ConditionallyIIDWith μ X ν) : MixedIIDWith μ X ν := by
+  sorry
+
+/-- **Layer 0 bridge, the existential corollary** (`mixedIID_of_conditionallyIID`). -/
+example (hX : ∀ i, Measurable (X i)) (h : ConditionallyIID μ X) : MixedIID μ X := by
   sorry
 
 /-- **Layer 0 bridge, full exchangeability ⇒ shift-preservation** of the path law (the link
@@ -140,10 +183,11 @@ example (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) (m : ℕ) :
     Measurable fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure := by
   sorry
 
-/-- **Layer 1, the common de Finetti ending.** A measurable random probability measure whose
-mixtures match the finite-dimensional laws on measurable rectangles is a directing measure:
-rectangle agreement upgrades to the full `IsIIDMixture` factorization by the π-system
-argument. Shared by the L², Koopman, and martingale routes. -/
+/-- **Layer 1, the mixture common ending** (`mixedIID_of_mixingRepresentative`). A measurable
+random probability measure whose mixtures match the finite-dimensional laws on measurable
+rectangles is a **mixing representative**: rectangle agreement upgrades to the full
+`MixedIIDWith` factorization by the π-system argument. Shared by the L², Koopman, and
+martingale routes. -/
 example [IsProbabilityMeasure μ] (hX : ∀ i, Measurable (X i))
     (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν)
     (h : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
@@ -151,7 +195,26 @@ example [IsProbabilityMeasure μ] (hX : ∀ i, Measurable (X i))
         μ.map (fun ω => fun i : Fin m => X (k i) ω) (Set.univ.pi B) =
           μ.bind (fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure)
             (Set.univ.pi B)) :
-    IsIIDMixture μ X := by
+    MixedIIDWith μ X ν := by
+  sorry
+
+/-- **Layer 1, the conditional common ending** (`conditionallyIID_of_jointRectangles`). The
+joint-rectangle criterion: if the joint law of `(ν, block)` agrees with the disintegration
+`δ_ν ⊗ ν^{⊗m}` on rectangles `S ×ˢ univ.pi B` — measurable sets in the `ν` coordinate times
+block rectangles — then `ConditionallyIIDWith μ X ν` holds, again by the π-system argument.
+This is how each proof route's conditional-law identity upgrades to the Layer-6 summit; without
+it the conditional target would be named but unconnected to the routes. -/
+example [IsProbabilityMeasure μ] (hX : ∀ i, Measurable (X i))
+    (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν)
+    (h : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+      ∀ S : Set (ProbabilityMeasure α), MeasurableSet S →
+        ∀ B : Fin m → Set α, (∀ i, MeasurableSet (B i)) →
+          μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) (S ×ˢ Set.univ.pi B) =
+            μ.bind (fun ω =>
+                (Measure.dirac (ν ω)).prod
+                  (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure)
+              (S ×ˢ Set.univ.pi B)) :
+    ConditionallyIIDWith μ X ν := by
   sorry
 
 /-! ## Layer 2: process tails, path-space σ-algebras, and Hewitt–Savage -/
@@ -224,19 +287,32 @@ directing-measure API (Layers 3–6 in `README.md`) land in between. The unsuffi
 theorem should be the reverse-martingale route.
 -/
 
-/-- **Layer 6 summit, de Finetti's theorem** on a standard Borel state space: an
-exchangeable sequence has an i.i.d. mixture representation. -/
+/-- **Layer 6 summit, the hard route theorem** (`conditionallyIID_of_contractable`): a
+contractable sequence on a standard Borel state space is **conditionally i.i.d.** — the
+Ryll-Nardzewski strengthening of de Finetti, and the statement every proof route actually
+proves before the equivalences are assembled. -/
+example [IsProbabilityMeasure μ] [StandardBorelSpace α] [Nonempty α]
+    (hX : ∀ i, Measurable (X i)) (h_contr : Contractable μ X) :
+    ConditionallyIID μ X := by
+  sorry
+
+/-- **Layer 6 summit, de Finetti's theorem** on a standard Borel state space: an exchangeable
+sequence is **conditionally i.i.d.** — the sharp Kallenberg form (2005, Thm 1.1), concluding
+the joint-law disintegration for the canonical directing measure. The mixed-i.i.d.
+representation is the integrated-out corollary (`mixedIID_of_conditionallyIID`), never the
+summit. -/
 example [IsProbabilityMeasure μ] [StandardBorelSpace α] [Nonempty α]
     (hX : ∀ i, Measurable (X i)) (h_exch : Exchangeable μ X) :
-    IsIIDMixture μ X := by
+    ConditionallyIID μ X := by
   sorry
 
 /-- **Layer 6 summit, the de Finetti–Ryll-Nardzewski equivalence**:
-`contractable ↔ exchangeable ↔ i.i.d. mixture` for sequences on a standard Borel
-state space. -/
+`contractable ↔ exchangeable ↔ conditionally i.i.d.` for sequences on a standard Borel state
+space. The mixture form `Contractable ↔ Exchangeable ∧ MixedIID` is the integrated-out
+corollary. -/
 example [IsProbabilityMeasure μ] [StandardBorelSpace α] [Nonempty α]
     (hX : ∀ i, Measurable (X i)) :
-    Contractable μ X ↔ Exchangeable μ X ∧ IsIIDMixture μ X := by
+    Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X := by
   sorry
 
 end TauCetiRoadmap.Exchangeability

--- a/TauCetiRoadmap/Exchangeability/Suggested.lean
+++ b/TauCetiRoadmap/Exchangeability/Suggested.lean
@@ -106,7 +106,11 @@ Strictly stronger **at fixed `ν`** than `MixedIIDWith`, which constrains only t
 marginal law: for a nondegenerate mixing law, on a rich enough space an independent copy of a
 directing measure witnesses the mixture identity while the process is not conditionally i.i.d.
 given it. The term **directing measure** is reserved for a `ν` witnessing this predicate —
-witness-level a.e. uniqueness lives here, never on the mixture side. -/
+witness-level a.e. uniqueness lives here, never on the mixture side. Equivalence with
+Kallenberg's probabilistic notion is asserted under `[IsProbabilityMeasure μ]` with
+measurable coordinates (as the summit theorems supply); the definition itself stays
+hypothesis-light by design, and under `μ = 0` it degenerates as ordinary measure
+identities do. -/
 def ConditionallyIIDWith (μ : Measure Ω) (X : ℕ → Ω → α)
     (ν : Ω → ProbabilityMeasure α) : Prop :=
   Measurable ν ∧
@@ -181,6 +185,16 @@ random probability measure is measurable into `Measure (Fin m → α)`, the meas
 input `Measure.bind` needs in every mixture identity. -/
 example (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) (m : ℕ) :
     Measurable fun ω => (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure := by
+  sorry
+
+/-- **Layer 1, joint-kernel measurability.** The conditional common ending additionally needs
+measurability of `ω ↦ δ_{ν ω} ⊗ (ν ω)^{⊗m}` (for `Measure.bind_apply` and measure
+extensionality on the joint space); provable from the Giry measurable structure, measurable
+Dirac, the product-kernel adapter above, and `ProbabilityMeasure.measurable_fun_prod`, with
+no extra hypotheses. -/
+example (ν : Ω → ProbabilityMeasure α) (hν : Measurable ν) (m : ℕ) :
+    Measurable fun ω =>
+      (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure := by
   sorry
 
 /-- **Layer 1, the mixture common ending** (`mixedIID_of_mixingRepresentative`). A measurable


### PR DESCRIPTION
This PR separates the mixture identity from genuine conditional i.i.d.-ness in the Exchangeability roadmap. The predicate previously named `ConditionallyIID` asserted only an unconditional mixture identity, constraining each finite block's marginal law but never the joint law of `(ν, X)`, so it did not deliver the conditional independence its name promised. It is renamed to `MixedIID` (Kallenberg's terminology), with the fixed-witness relation `MixedIIDWith μ X ν` now pinned explicitly rather than inlined. The genuine conditional notion is reinstated as `ConditionallyIIDWith μ X ν`, the joint-law disintegration `Law(ν, block) = ∫ δ_{ν(ω)} ⊗ (ν(ω))^{⊗m} dμ(ω)` (Kallenberg 2005, §1.1 eq. (2)), stated with the same `bind`/`pi` toolkit and no conditional expectations, and it remains the Layer 6 summit: `conditionallyIID_of_contractable` is the hard route theorem, `deFinetti` and the Ryll-Nardzewski equivalence conclude `ConditionallyIID`, and the mixture forms (`mixedIID_of_contractable`, `deFinetti_mixture`) are retained as integrated-out corollaries.

The two notions are connected rather than merely both named: the fixed-witness implication `ConditionallyIIDWith μ X ν → MixedIIDWith μ X ν` and its existential corollary `mixedIID_of_conditionallyIID` are pinned, and Layer 1 gains the conditional common ending `conditionallyIID_of_jointRectangles` (the joint-rectangle criterion each proof route calls to reach the summit) beside the mixture ending `mixedIID_of_mixingRepresentative`. Uniqueness splits accordingly: witnesses of the mixture identity alone are not a.e. unique (on a rich enough space an independent copy of a directing measure is also a witness), so the mixture side pins uniqueness of the mixing law `μ.map ν` (`mixedIID_mixingLaw_unique`), while witness-level a.e. uniqueness (`conditionallyIID_ae_unique`) lives on the conditional side, quantifying over witnesses of `ConditionallyIIDWith`.

Terminology follows the split: a `ν` witnessing only the mixture identity is a *mixing representative*; *directing measure* is reserved for the conditional witness.

Sequencing note, recorded in the README: TauCeti's landed API currently uses the name `ConditionallyIID` for the mixture shape, so the code rename to `MixedIID`/`MixedIIDWith` must land before the conditional predicate is implemented under that name. Coordinates with #69, which documents the landed names and touches the same README regions.

Original diagnosis and rename by Kim Morrison; conditional reinstatement and connecting targets by Cameron Freer (Fable 5, reviewed by GPT 5.6).

🤖 Prepared with Claude Code
