### PR TITLE
refactor(Exchangeability): Use Mathlib shift invariants directly

### DIFF
--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -344,7 +344,6 @@ Suggested home:
 ```text
 TauCeti/Probability/Process/Tail.lean
 TauCeti/Probability/PathSpace/Shift.lean
-TauCeti/Probability/Ergodic/ShiftInvariantSigma.lean
 ```
 
 Build process-relative tails:
@@ -366,16 +365,13 @@ shift_measurable
 shift_iterate_measurable
 ```
 
-Build shift-invariant σ-algebras:
-
-```lean
-isShiftInvariant
-shiftInvariantSigma
-shiftInvariantSigma_le
-mem_shiftInvariantSigma_iff
-shiftInvariantSigma_measurable_shift_eq
-shiftInvariant_implies_shiftInvariantMeasurable
-```
+For the shift-invariant σ-algebra, consume Mathlib's
+`MeasurableSpace.invariants (shift α)` directly. Its existing API already provides the membership
+characterization, comparison with the ambient measurable space, iterate invariance, and the
+measurable-function/fixed-point correspondence. Do not introduce shift-specialized aliases such as
+`isShiftInvariant`, `shiftInvariantSigma`, `shiftInvariantSigma_le`, or
+`mem_shiftInvariantSigma_iff`; state only genuinely new path-space results that downstream proof
+routes require.
 
 ⚠ **Tail vs invariant σ-algebra.** Do not silently identify the tail σ-algebra with the
 shift-invariant σ-algebra. For one-sided sequences, the relationship runs through

--- a/TauCetiRoadmap/Exchangeability/Suggested.lean
+++ b/TauCetiRoadmap/Exchangeability/Suggested.lean
@@ -164,11 +164,6 @@ example [IsProbabilityMeasure μ] (hX : ∀ i, Measurable (X i))
 @[reducible] def tailProcess (X : ℕ → Ω → α) : MeasurableSpace Ω :=
   ⨅ n, tailFamily X n
 
-/-- **Layer 2, the shift-invariant σ-algebra** on path space. The strictly shift-invariant
-measurable sets already form a σ-algebra; `generateFrom` just packages them. -/
-@[reducible] def shiftInvariantSigma (α : Type*) [MeasurableSpace α] : MeasurableSpace (ℕ → α) :=
-  MeasurableSpace.generateFrom {s | MeasurableSet s ∧ shift α ⁻¹' s = s}
-
 /-- **Layer 2, the exchangeable (symmetric) σ-algebra** on path space: measurable sets
 invariant under every finitely supported permutation of the coordinates. -/
 @[reducible] def exchangeableSigma (α : Type*) [MeasurableSpace α] : MeasurableSpace (ℕ → α) :=
@@ -189,7 +184,8 @@ example (hX : ∀ i, Measurable (X i)) :
 /-- **Layer 2, the path-space σ-algebras are sub-σ-algebras.** (Do not silently identify
 them: for one-sided sequences the tail, shift-invariant, and exchangeable σ-algebras are
 related through invariance, almost invariance, and completions; see `README.md`.) -/
-example : shiftInvariantSigma α ≤ (inferInstance : MeasurableSpace (ℕ → α)) ∧
+example : MeasurableSpace.invariants (shift α) ≤
+      (inferInstance : MeasurableSpace (ℕ → α)) ∧
     exchangeableSigma α ≤ (inferInstance : MeasurableSpace (ℕ → α)) := by
   sorry
 


### PR DESCRIPTION
## What changed

Updates the Exchangeability roadmap to consume `MeasurableSpace.invariants (shift α)` directly and removes the requirement for a dedicated `ShiftInvariantSigma.lean` adapter module and its parallel names.

The suggested Lean target now states the needed comparison using Mathlib's invariant measurable space directly.

## Why

Mathlib already supplies the invariant-space definition, measurable-set characterization, ambient comparison, iterate API, and measurable-function/fixed-point correspondence. Requiring shift-specialized aliases created a second API without adding mathematics.

## Impact

After this roadmap change lands, TauCeti can delete the redundant shift-invariant adapter module while retaining genuinely new path-space results. The warning distinguishing tail and invariant sigma-algebras remains unchanged.

## Validation

- `lake build`
- `git diff --check`
