### PR TITLE
feat: label intention issues so filing one needs no repository permissions

### DIFF
--- a/.github/workflows/intentions.yml
+++ b/.github/workflows/intentions.yml
@@ -4,7 +4,9 @@ on:
   issue_comment:
     types: [created]
   issues:
-    types: [opened, closed, reopened]
+    # `labeled` catches the intention issues that label-intentions.yml labels after the fact:
+    # they open without `intention`, so the `opened` event fails the auto-add filter below.
+    types: [opened, labeled, closed, reopened]
   pull_request_target:
     types: [opened, reopened, ready_for_review, converted_to_draft, closed]
   schedule:

--- a/.github/workflows/label-intentions.yml
+++ b/.github/workflows/label-intentions.yml
@@ -1,0 +1,54 @@
+name: label-intentions
+
+# Apply the `intention` label on the author's behalf, so filing an intention needs nothing but
+# permission to open an issue.
+#
+# `.github/ISSUE_TEMPLATE/1-intention.yml` carries `labels: ["intention"]`, but GitHub applies a
+# template's labels server-side only when the issue is submitted through the web form. Anyone
+# opening the issue through the API instead (`gh issue create --label intention`, which is what a
+# worker agent does) needs triage rights on this repository, and a contributor who has just
+# arrived does not have them: the call fails with `does not have the correct permissions to
+# execute AddLabelsToLabelable`. Labelling here means the web form and the API behave the same,
+# and nobody has to be granted repository permissions to register an intention.
+#
+# The label matters because intentions.yml sets `auto-add-labels: intention`, so an unlabelled
+# intention issue never reaches the Tau Ceti board.
+#
+# Deliberately uses the claim-bot App token rather than GITHUB_TOKEN: a label applied by
+# GITHUB_TOKEN does not trigger further workflow runs, so intentions.yml would never see the
+# resulting `labeled` event and the issue would still miss the board. Requires the App to hold
+# repository **Issues: write** (it already does; that is how it assigns and comments).
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    # The template pins `title: "[Intention]: "`, so the prefix identifies an intention issue
+    # whichever way it was filed. Web-form submissions already carry the label; skip those rather
+    # than firing a redundant `labeled` event.
+    if: >-
+      startsWith(github.event.issue.title, '[Intention]:') &&
+      !contains(github.event.issue.labels.*.name, 'intention')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint App token (issues write)
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.CLAIM_BOT_APP_ID }}
+          private-key: ${{ secrets.CLAIM_BOT_APP_PRIVATE_KEY }}
+          owner: TauCetiProject
+          repositories: TauCetiRoadmap
+          permission-issues: write
+
+      - name: Apply the intention label
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          gh issue edit "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" --add-label intention

--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ work on and claim it. This is powered by the
 
 1. **Register an intention.** Open an issue with the **Intention** template: pick the roadmap
    area and list the specific targets you mean to take (keep the scope as narrow as you can, so
-   the rest stays open for others).
+   the rest stays open for others). Filing it through the API works as well as the web form:
+   title the issue `[Intention]: ...` and the `intention` label is applied for you, so no
+   repository permissions are needed.
 2. **Claim it.** Comment `claim` on the issue. The bot assigns it to you and moves it to
    *Claimed* on the board. For a custom window, comment `claim 3 weeks` or `claim 2026-08-01`;
    bare `claim` uses the project default.


### PR DESCRIPTION
This PR applies the `intention` label from a workflow, so registering an intention needs nothing beyond permission to open an issue.

`.github/ISSUE_TEMPLATE/1-intention.yml` carries `labels: ["intention"]`, but GitHub applies a template's labels server-side only for web-form submissions. Filing the same issue through the API, which is what a worker agent does, needs triage rights on this repository, and an arriving contributor does not have them: the call fails with `does not have the correct permissions to execute AddLabelsToLabelable`. Since `intentions.yml` sets `auto-add-labels: intention`, the unlabelled issue then never reaches the Tau Ceti board, and the human has to go and click the web form themselves.

The new workflow keys off the template's `[Intention]:` title prefix and skips web-form submissions, which already carry the label. It mints a claim-bot App token rather than using `GITHUB_TOKEN` on purpose: a label applied by `GITHUB_TOKEN` does not trigger further workflow runs, so `intentions.yml` would never see the resulting `labeled` event.

Getting the issue onto the board also needs the intentions action to act on that event, which is https://github.com/leanprover-community/intentions/pull/13 (feat: auto-add issues to the board when the label arrives after opening). Until that merges and `v1` moves, the label is applied correctly but the issue still does not reach the board, so merge this second. The claim-bot App needs repository Issues: write, which it already holds, since that is how it assigns and comments.

🤖 Prepared with Claude Code

https://claude.ai/code/session_01PBw2CvzzA3nenW3MdPXzTr