### PR TITLE
feat: invite pull request authors to a triage team

### DIFF
--- a/.github/workflows/grant-triage.yml
+++ b/.github/workflows/grant-triage.yml
@@ -1,0 +1,78 @@
+name: grant-triage
+
+# Give anyone who opens a pull request here triage rights, by inviting them to the
+# `roadmap-triage` team. Triage lets a contributor label and manage issues and PRs, which is what
+# a worker agent keeps tripping over: labelling anything needs triage, so a contributor who has
+# just arrived gets `does not have the correct permissions to execute AddLabelsToLabelable`.
+#
+# Opening a PR is the bar on purpose. Commenting is not: triage is repository-wide (close and
+# reopen any issue or PR, add and remove any label, assign, request review), so granting it to
+# anyone who comments would hand a repository-wide switch to any account that types anything on a
+# public repository. Adding `issue_comment` to the triggers below is a one-line change if that
+# trade is ever worth making.
+#
+# NOT AUTOMATIC, and it cannot be: `PUT /orgs/{org}/teams/{team}/memberships/{user}` adds the user
+# outright only if they are already an organization member. For everyone else it opens a pending
+# invitation they have to accept from email or their GitHub notifications. So this turns a click
+# per label into one click, once, and the contributor's first labelling attempt still fails until
+# they accept.
+#
+# Requires:
+#   - a `roadmap-triage` team in the organization, holding **Triage** on this repository
+#   - the tauceti-review-bot App to have organization **Members: write** (promote-reviewers.yml
+#     needs the same grant; repository-scoped permissions are not enough to manage team membership)
+
+on:
+  pull_request_target:
+    types: [opened]
+  # Grant to one named person on demand, for someone who needs triage before they have opened
+  # anything. Deliberately not a sweep over past authors: that would fire a burst of invitations.
+  workflow_dispatch:
+    inputs:
+      user:
+        description: GitHub login to invite to the triage team
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  grant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint App token (organization Members write)
+        id: token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: TauCetiProject
+          permission-members: write
+
+      - name: Invite the author to the triage team
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          ORG: TauCetiProject
+          TEAM: roadmap-triage
+          REPO: ${{ github.repository }}
+          USER: ${{ inputs.user || github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+
+          case "$USER" in *"[bot]") echo "· $USER is a bot; nothing to do"; exit 0 ;; esac
+
+          # Anyone already at triage or above has nothing to gain, and re-inviting them would
+          # send pointless notifications. On a public repository a stranger reads as "read".
+          have=$(gh api "/repos/$REPO/collaborators/$USER/permission" --jq '.permission' 2>/dev/null || echo none)
+          case "$have" in
+            triage|write|maintain|admin) echo "· $USER already has $have; nothing to do"; exit 0 ;;
+          esac
+
+          state=$(gh api -X PUT "/orgs/$ORG/teams/$TEAM/memberships/$USER" \
+            -f role=member --jq '.state')
+          if [ "$state" = "active" ]; then
+            echo "✓ $USER added to @$ORG/$TEAM (already an org member)"
+          else
+            echo "✓ $USER invited to @$ORG/$TEAM — triage starts once they accept the invitation"
+          fi

--- a/README.md
+++ b/README.md
@@ -112,9 +112,14 @@ approving review from a member of the `@TauCetiProject/roadmap-reviewers` team (
 for roadmap content) and the `build` check passes. Infrastructure files (the workflows, the
 Lake config, the toolchain pin) stay with the core `@TauCetiProject/humans` team.
 
-The reviewer pool grows itself: a contributor who lands two merged roadmap PRs is added to
-`roadmap-reviewers` automatically, so people who have demonstrably moved a roadmap forward can
-start approving others' roadmap work.
+Rights accrue as you contribute. Opening your first pull request gets you invited to
+`@TauCetiProject/roadmap-triage`, which carries triage on this repository: enough to label,
+assign, and manage issues and pull requests, which is what worker agents need and what a new
+contributor otherwise lacks. GitHub cannot add you to an organization without your say-so, so
+watch for the invitation and accept it; triage starts then, not when the PR opens. Landing two
+merged roadmap PRs then adds you to `roadmap-reviewers`, so the reviewer pool grows itself out
+of people who have demonstrably moved a roadmap forward and they can start approving others'
+roadmap work.
 
 ## Coordinating work: intentions and claims
 


### PR DESCRIPTION
This PR invites the author of every newly opened pull request to a `roadmap-triage` team holding triage on this repository, so contributors and their worker agents can label and manage issues and PRs without a maintainer doing it by hand.

Labelling anything needs triage, which an arriving contributor does not have, so an agent acting on their behalf fails with `does not have the correct permissions to execute AddLabelsToLabelable`. The mechanism mirrors `promote-reviewers.yml`: the same tauceti-review-bot App token with organization Members: write, the same team-membership PUT, just at a lower bar and a lower privilege.

Opening a PR is that bar rather than commenting, deliberately. Triage is repository-wide, covering close and reopen on any issue or PR, add and remove any label, assign and request review. Granting it to anyone who comments would hand that to any account that types anything on a public repository. Adding `issue_comment` to the triggers is a one-line change if the trade ever looks worth it.

Worth being clear that this is not automatic and cannot be made so. `PUT /orgs/{org}/teams/{team}/memberships/{user}` adds the user outright only when they are already an organization member; for everyone else GitHub opens a pending invitation they must accept. So it converts a click per label into one click, once, and a contributor's first labelling attempt still fails until they accept. The `workflow_dispatch` input grants to one named person on demand, for someone who needs triage before they have opened anything. It is not a sweep over past authors, which would fire a burst of invitations.

Before merging, the `roadmap-triage` team has to exist with Triage on this repository. It does not yet, and the workflow fails at the PUT until it does.

🤖 Prepared with Claude Code

https://claude.ai/code/session_01PBw2CvzzA3nenW3MdPXzTr