### PR TITLE
feat: auto-merge and announce generated progress reports

### DIFF
--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -11,22 +11,22 @@ on:
   push:
     branches: [main]
     paths:
-      - '**/PROGRESS.md'
+      # Scoped to the directories a generated report can touch. A bare `**/PROGRESS.md` also matches
+      # a file at the repository root or in any unrelated directory, so a hand-written one would
+      # trigger an announcement attempt for something that is not a report.
+      - 'TauCetiRoadmap/**/PROGRESS.md'
+      - 'Completed/**/PROGRESS.md'
   workflow_dispatch:
 
 permissions:
   contents: read
 
-concurrency:
-  group: progress-announce
-  cancel-in-progress: false
-
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@1a53c9eb7bf4ca82b658165890e1ef3b84473dfa
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@6d1f1d1d50bdfe869d254b0a93ffc5c10c64aefd
     with:
-      progress_ref: 1a53c9eb7bf4ca82b658165890e1ef3b84473dfa
+      progress_ref: 6d1f1d1d50bdfe869d254b0a93ffc5c10c64aefd
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -11,11 +11,11 @@ on:
   push:
     branches: [main]
     paths:
-      # Scoped to the directories a generated report can touch. A bare `**/PROGRESS.md` also matches
-      # a file at the repository root or in any unrelated directory, so a hand-written one would
-      # trigger an announcement attempt for something that is not a report.
-      - 'TauCetiRoadmap/**/PROGRESS.md'
-      - 'Completed/**/PROGRESS.md'
+      # Exactly where a generated report can land: one area directory under either parent. `**` would
+      # match across slashes, so a nested or root-level PROGRESS.md written by hand would trigger an
+      # announcement attempt for something the gate would never have accepted.
+      - 'TauCetiRoadmap/*/PROGRESS.md'
+      - 'Completed/*/PROGRESS.md'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ concurrency:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@d1677d3da7cda234bc56552af0102e968a961d2b
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@661c0067dddd2e22300f7196adea4d2ed2d6e537
     with:
-      progress_ref: d1677d3da7cda234bc56552af0102e968a961d2b
+      progress_ref: 661c0067dddd2e22300f7196adea4d2ed2d6e537
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ concurrency:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@fdf773d91831eecddbc7f3f98adbf6f8c80cf967
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@2f5da9af714160d5b33336081dcafc6653e1a427
     with:
-      progress_ref: fdf773d91831eecddbc7f3f98adbf6f8c80cf967
+      progress_ref: 2f5da9af714160d5b33336081dcafc6653e1a427
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ concurrency:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@fda061df028af73962aab8f58eb4c6e8b557933d
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@fdf773d91831eecddbc7f3f98adbf6f8c80cf967
     with:
-      progress_ref: fda061df028af73962aab8f58eb4c6e8b557933d
+      progress_ref: fdf773d91831eecddbc7f3f98adbf6f8c80cf967
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ concurrency:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@ad195ac4a3be2877912331a0742fcb0031c6d774
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@dd7e39ceb2efc052c008f357a24f1aa859e22a60
     with:
-      progress_ref: ad195ac4a3be2877912331a0742fcb0031c6d774
+      progress_ref: dd7e39ceb2efc052c008f357a24f1aa859e22a60
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ concurrency:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@661c0067dddd2e22300f7196adea4d2ed2d6e537
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@786bb153eacd99237cd2a51a636e13d237a78cfb
     with:
-      progress_ref: 661c0067dddd2e22300f7196adea4d2ed2d6e537
+      progress_ref: 786bb153eacd99237cd2a51a636e13d237a78cfb
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ concurrency:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@c6a2f6db1150c950fe226e42f0e64a9a20a95585
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@bcf7ac4819697217e16ba910e2c35bbcd4ff1120
     with:
-      progress_ref: c6a2f6db1150c950fe226e42f0e64a9a20a95585
+      progress_ref: bcf7ac4819697217e16ba910e2c35bbcd4ff1120
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ concurrency:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@786bb153eacd99237cd2a51a636e13d237a78cfb
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@c6a2f6db1150c950fe226e42f0e64a9a20a95585
     with:
-      progress_ref: 786bb153eacd99237cd2a51a636e13d237a78cfb
+      progress_ref: c6a2f6db1150c950fe226e42f0e64a9a20a95585
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ concurrency:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@bcf7ac4819697217e16ba910e2c35bbcd4ff1120
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@1a53c9eb7bf4ca82b658165890e1ef3b84473dfa
     with:
-      progress_ref: bcf7ac4819697217e16ba910e2c35bbcd4ff1120
+      progress_ref: 1a53c9eb7bf4ca82b658165890e1ef3b84473dfa
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ concurrency:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@2f5da9af714160d5b33336081dcafc6653e1a427
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@d1677d3da7cda234bc56552af0102e968a961d2b
     with:
-      progress_ref: 2f5da9af714160d5b33336081dcafc6653e1a427
+      progress_ref: d1677d3da7cda234bc56552af0102e968a961d2b
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ concurrency:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@dd7e39ceb2efc052c008f357a24f1aa859e22a60
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@fda061df028af73962aab8f58eb4c6e8b557933d
     with:
-      progress_ref: dd7e39ceb2efc052c008f357a24f1aa859e22a60
+      progress_ref: fda061df028af73962aab8f58eb4c6e8b557933d
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -1,0 +1,35 @@
+name: progress-announce
+
+# Announce a newly-merged progress section in Zulip (Tau Ceti > Progress logs).
+#
+# Triggered by the push to `main` rather than chained onto the merge job, so that the App token that
+# can write here and the Zulip credentials never share a job, and so a failed announcement can be
+# re-run without re-merging anything. The post is idempotent: each section carries a stable id and
+# posting searches the topic for it first.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/PROGRESS.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: progress-announce
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    # Same full SHA as progress-merge.yml uses; bump both together.
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@ad195ac4a3be2877912331a0742fcb0031c6d774
+    with:
+      progress_ref: ad195ac4a3be2877912331a0742fcb0031c6d774
+      channel: Tau Ceti
+      topic: Progress logs
+    secrets:
+      ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
+      ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+      ZULIP_SITE: ${{ secrets.ZULIP_SITE }}

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -19,8 +19,14 @@ name: progress-merge
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
-  # A progress PR usually opens before its `build` check finishes, so re-check when a check completes.
-  check_suite:
+  # A progress pull request usually opens before its `build` check finishes, so the gate has to be
+  # re-run when CI reports. This listens for the CI WORKFLOW rather than for `check_suite`: GitHub
+  # deliberately suppresses `check_suite` and `check_run` events for suites created by GitHub Actions
+  # (it would otherwise recurse), and `build` is a job in this repository's own Actions `CI`
+  # workflow. A `check_suite` trigger therefore never fires for it, and every report would sit
+  # unmerged after the first pass saw `build` still pending.
+  workflow_run:
+    workflows: [CI]
     types: [completed]
   workflow_dispatch:
     inputs:
@@ -33,9 +39,12 @@ permissions:
   contents: read
   pull-requests: read
 
-concurrency:
-  group: progress-merge
-  cancel-in-progress: false
+# No concurrency group HERE. GitHub keeps one running and one pending run per group and discards the
+# pending one when a newer event arrives, so a repository-wide group on the caller lets any pull
+# request activity evict a queued progress run. The merge itself still has to be serialised — the
+# compare-and-swap depends on `main` not moving underneath it — and the called workflow declares that
+# group itself, so serialisation happens where it is needed without letting unrelated events crowd
+# the queue.
 
 jobs:
   resolve:
@@ -52,7 +61,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           # Quoted through env rather than interpolated into the script: everything from the event
           # payload is attacker-influenced, and this job holds a token.
-          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
           case "$EVENT" in
@@ -63,7 +72,7 @@ jobs:
               echo "pr=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT" ;;
             workflow_dispatch)
               echo "pr=${{ inputs.pr }}" >> "$GITHUB_OUTPUT" ;;
-            check_suite)
+            workflow_run)
               # The open progress pull request for this head, if any.
               #
               # Asked of the commit directly, not of a list of recent pull requests. `gh pr list`
@@ -96,10 +105,10 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@1a53c9eb7bf4ca82b658165890e1ef3b84473dfa
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@6d1f1d1d50bdfe869d254b0a93ffc5c10c64aefd
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: 1a53c9eb7bf4ca82b658165890e1ef3b84473dfa
+      progress_ref: 6d1f1d1d50bdfe869d254b0a93ffc5c10c64aefd
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -74,16 +74,21 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@ad195ac4a3be2877912331a0742fcb0031c6d774
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@dd7e39ceb2efc052c008f357a24f1aa859e22a60
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: ad195ac4a3be2877912331a0742fcb0031c6d774
+      progress_ref: dd7e39ceb2efc052c008f357a24f1aa859e22a60
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.
       # This grants no privilege that account lacks -- it is already an OrganizationAdmin bypass
       # actor on this ruleset -- so the check's real job is excluding everyone else.
       allowed_user_ids: "477956"
+      # `tau-ceti-roadmap-sync`, the App this repository's ruleset lists as a bypass actor. It must be
+      # this one and not `secrets.APP_ID` (the review bot, which auto-merge.yml uses): the review bot
+      # bypasses TauCeti's ruleset, not this one, so a direct merge with its token would be refused
+      # for want of a code-owner review. auto-merge.yml can use it because it only *enables* GitHub's
+      # native auto-merge and lets the ruleset gate the merge; this workflow merges directly.
+      app_id: ${{ vars.SYNC_BOT_APP_ID }}
     secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      APP_PRIVATE_KEY: ${{ secrets.SYNC_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -74,10 +74,10 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@fda061df028af73962aab8f58eb4c6e8b557933d
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@fdf773d91831eecddbc7f3f98adbf6f8c80cf967
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: fda061df028af73962aab8f58eb4c6e8b557933d
+      progress_ref: fdf773d91831eecddbc7f3f98adbf6f8c80cf967
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -66,16 +66,19 @@ jobs:
             check_suite)
               # The open progress pull request for this head, if any.
               #
-              # Restricted to pull requests whose HEAD LIVES IN THIS REPOSITORY. A fork can create a
-              # branch at the very same commit, and an unfiltered "first match wins" would let that
-              # fork's pull request shadow the legitimate one: the gate would refuse the fork (as it
-              # should) and the real report would never be considered at all.
-              pr="$(gh pr list --repo "$REPO" --state open \
-                     --json number,headRefName,headRefOid,headRepositoryOwner \
-                     --jq '[.[] | select(.headRefName | startswith("progress/"))
-                                | select(.headRefOid == env.HEAD_SHA)
-                                | select(.headRepositoryOwner.login == env.OWNER)
-                                | .number] | first // ""')"
+              # Asked of the commit directly, not of a list of recent pull requests. `gh pr list`
+              # returns only the newest 30 by default, so anyone could open 30 newer pull requests and
+              # push the legitimate report out of the window -- its build would complete and this
+              # trigger would never find it.
+              #
+              # The result is also restricted to a head IN THIS REPOSITORY. A fork can create a branch
+              # at the very same commit, and "first match wins" would let it shadow the real one: the
+              # gate would refuse the fork, correctly, and the report would never be considered.
+              pr="$(gh api --paginate "repos/$REPO/commits/$HEAD_SHA/pulls" \
+                     --jq '[.[] | select(.state == "open")
+                                | select(.head.ref | startswith("progress/"))
+                                | select(.head.repo.full_name == env.REPO)
+                                | .number] | first // ""' 2>/dev/null | head -n1)"
               echo "pr=$pr" >> "$GITHUB_OUTPUT" ;;
           esac
 
@@ -85,10 +88,10 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@661c0067dddd2e22300f7196adea4d2ed2d6e537
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@786bb153eacd99237cd2a51a636e13d237a78cfb
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: 661c0067dddd2e22300f7196adea4d2ed2d6e537
+      progress_ref: 786bb153eacd99237cd2a51a636e13d237a78cfb
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -74,10 +74,10 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@dd7e39ceb2efc052c008f357a24f1aa859e22a60
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@fda061df028af73962aab8f58eb4c6e8b557933d
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: dd7e39ceb2efc052c008f357a24f1aa859e22a60
+      progress_ref: fda061df028af73962aab8f58eb4c6e8b557933d
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -74,11 +74,19 @@ jobs:
               # The result is also restricted to a head IN THIS REPOSITORY. A fork can create a branch
               # at the very same commit, and "first match wins" would let it shadow the real one: the
               # gate would refuse the fork, correctly, and the report would never be considered.
-              pr="$(gh api --paginate "repos/$REPO/commits/$HEAD_SHA/pulls" \
-                     --jq '[.[] | select(.state == "open")
-                                | select(.head.ref | startswith("progress/"))
-                                | select(.head.repo.full_name == env.REPO)
-                                | .number] | first // ""' 2>/dev/null | head -n1)"
+              # `--slurp` so the pages arrive as ONE array and the filter runs over all of them.
+              # Without it `--jq` is applied page by page: page one emits an empty line, `head -n1`
+              # takes it, and a legitimate match on page two is discarded -- the same starvation the
+              # 30-item default allowed, just moved.
+              # `--slurp` so the pages arrive as ONE array; the filter then runs over all of them.
+              # Without it `--jq` is applied page by page: page one emits an empty line, and a
+              # legitimate match on a later page is lost -- the same starvation the 30-item default
+              # allowed, just moved. `--slurp` cannot be combined with `--jq`, hence the pipe.
+              pr="$(gh api --paginate --slurp "repos/$REPO/commits/$HEAD_SHA/pulls" \
+                    | jq -r '[.[][] | select(.state == "open")
+                                    | select(.head.ref | startswith("progress/"))
+                                    | select(.head.repo.full_name == env.REPO)
+                                    | .number] | first // ""')"
               echo "pr=$pr" >> "$GITHUB_OUTPUT" ;;
           esac
 
@@ -88,10 +96,10 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@786bb153eacd99237cd2a51a636e13d237a78cfb
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@c6a2f6db1150c950fe226e42f0e64a9a20a95585
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: 786bb153eacd99237cd2a51a636e13d237a78cfb
+      progress_ref: c6a2f6db1150c950fe226e42f0e64a9a20a95585
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -48,6 +48,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          # Quoted through env rather than interpolated into the script: everything from the event
+          # payload is attacker-influenced, and this job holds a token.
+          HEAD_SHA: ${{ github.event.check_suite.head_sha }}
         run: |
           set -euo pipefail
           case "$EVENT" in
@@ -59,12 +64,18 @@ jobs:
             workflow_dispatch)
               echo "pr=${{ inputs.pr }}" >> "$GITHUB_OUTPUT" ;;
             check_suite)
-              # Find the open progress pull request for this head, if any.
-              pr="$(gh pr list --repo "${{ github.repository }}" --state open \
-                     --json number,headRefName,headRefOid \
+              # The open progress pull request for this head, if any.
+              #
+              # Restricted to pull requests whose HEAD LIVES IN THIS REPOSITORY. A fork can create a
+              # branch at the very same commit, and an unfiltered "first match wins" would let that
+              # fork's pull request shadow the legitimate one: the gate would refuse the fork (as it
+              # should) and the real report would never be considered at all.
+              pr="$(gh pr list --repo "$REPO" --state open \
+                     --json number,headRefName,headRefOid,headRepositoryOwner \
                      --jq '[.[] | select(.headRefName | startswith("progress/"))
-                                | select(.headRefOid == "${{ github.event.check_suite.head_sha }}")
-                                | .number][0] // ""')"
+                                | select(.headRefOid == env.HEAD_SHA)
+                                | select(.headRepositoryOwner.login == env.OWNER)
+                                | .number] | first // ""')"
               echo "pr=$pr" >> "$GITHUB_OUTPUT" ;;
           esac
 
@@ -74,10 +85,10 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@d1677d3da7cda234bc56552af0102e968a961d2b
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@661c0067dddd2e22300f7196adea4d2ed2d6e537
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: d1677d3da7cda234bc56552af0102e968a961d2b
+      progress_ref: 661c0067dddd2e22300f7196adea4d2ed2d6e537
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -96,10 +96,10 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@bcf7ac4819697217e16ba910e2c35bbcd4ff1120
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@1a53c9eb7bf4ca82b658165890e1ef3b84473dfa
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: bcf7ac4819697217e16ba910e2c35bbcd4ff1120
+      progress_ref: 1a53c9eb7bf4ca82b658165890e1ef3b84473dfa
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -74,10 +74,10 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@fdf773d91831eecddbc7f3f98adbf6f8c80cf967
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@2f5da9af714160d5b33336081dcafc6653e1a427
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: fdf773d91831eecddbc7f3f98adbf6f8c80cf967
+      progress_ref: 2f5da9af714160d5b33336081dcafc6653e1a427
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -62,13 +62,30 @@ jobs:
           # Quoted through env rather than interpolated into the script: everything from the event
           # payload is attacker-influenced, and this job holds a token.
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # Through env, never interpolated into the script: both are attacker-controlled.
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
           case "$EVENT" in
             pull_request_target)
+              # Cheap prefilter, so that only a plausible report ever reaches the gate. The gate
+              # re-checks all of this and is the authority; the point here is queueing. The called
+              # workflow serialises on a single group, which permits one running and one pending run,
+              # so if every pull request in the repository were forwarded, ordinary contributor
+              # activity could keep evicting a queued report.
               if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
                 echo "draft pull request; nothing to do"; echo "pr=" >> "$GITHUB_OUTPUT"; exit 0
               fi
+              if [ "$PR_HEAD_REPO" != "$REPO" ]; then
+                echo "head is in $PR_HEAD_REPO, not $REPO; not a generated report"
+                echo "pr=" >> "$GITHUB_OUTPUT"; exit 0
+              fi
+              case "$PR_HEAD_REF" in
+                progress/*) ;;
+                *) echo "head branch $PR_HEAD_REF is not a progress branch"
+                   echo "pr=" >> "$GITHUB_OUTPUT"; exit 0 ;;
+              esac
               echo "pr=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT" ;;
             workflow_dispatch)
               echo "pr=${{ inputs.pr }}" >> "$GITHUB_OUTPUT" ;;

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -74,10 +74,10 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@2f5da9af714160d5b33336081dcafc6653e1a427
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@d1677d3da7cda234bc56552af0102e968a961d2b
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: 2f5da9af714160d5b33336081dcafc6653e1a427
+      progress_ref: d1677d3da7cda234bc56552af0102e968a961d2b
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -96,10 +96,10 @@ jobs:
     # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
     # validator code checked out inside, and a mismatch would validate with different rules than the
     # ones reviewed here.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@c6a2f6db1150c950fe226e42f0e64a9a20a95585
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@bcf7ac4819697217e16ba910e2c35bbcd4ff1120
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: c6a2f6db1150c950fe226e42f0e64a9a20a95585
+      progress_ref: bcf7ac4819697217e16ba910e2c35bbcd4ff1120
       # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
       # be renamed and the old name re-registered by someone else.
       #   477956 = kim-em, the account the worker authenticates as.

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -1,0 +1,89 @@
+name: progress-merge
+
+# Auto-merge generated progress reports (STATUS.md / PROGRESS.md) in this repository.
+#
+# All the validation, and the merge itself, live in a SHA-pinned reusable workflow in
+# TauCetiProgress -- the same discipline TauCeti uses for TauCetiReview, and for the same reason: an
+# unpinned `@main` would let an upstream change alter what is allowed to merge here without review.
+# The pin must be bumped deliberately, in step with the `progress_ref` input and with the version the
+# worker runs (see TauCetiProgress' README).
+#
+# `pull_request_target` rather than `pull_request` so the App secrets are available for the events we
+# care about. That is safe here only because the called workflow never checks out or executes pull
+# request content: it reads the PR through the API and merges. Note that `opened` fires for drafts
+# too, hence the explicit draft guard below as well as inside the called workflow.
+#
+# Anyone may open a pull request against this repository. A pull request that fails any check is
+# simply left alone for a human to review, which is the normal path for roadmap contributions.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  # A progress PR usually opens before its `build` check finishes, so re-check when a check completes.
+  check_suite:
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to consider.
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: progress-merge
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      pr: ${{ steps.pick.outputs.pr }}
+    steps:
+      - name: Decide which pull request to consider
+        id: pick
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          case "$EVENT" in
+            pull_request_target)
+              if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+                echo "draft pull request; nothing to do"; echo "pr=" >> "$GITHUB_OUTPUT"; exit 0
+              fi
+              echo "pr=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT" ;;
+            workflow_dispatch)
+              echo "pr=${{ inputs.pr }}" >> "$GITHUB_OUTPUT" ;;
+            check_suite)
+              # Find the open progress pull request for this head, if any.
+              pr="$(gh pr list --repo "${{ github.repository }}" --state open \
+                     --json number,headRefName,headRefOid \
+                     --jq '[.[] | select(.headRefName | startswith("progress/"))
+                                | select(.headRefOid == "${{ github.event.check_suite.head_sha }}")
+                                | .number][0] // ""')"
+              echo "pr=$pr" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+  gate:
+    needs: resolve
+    if: needs.resolve.outputs.pr != ''
+    # Pinned to a full TauCetiProgress SHA. `progress_ref` must be the SAME SHA: it selects the
+    # validator code checked out inside, and a mismatch would validate with different rules than the
+    # ones reviewed here.
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@ad195ac4a3be2877912331a0742fcb0031c6d774
+    with:
+      pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
+      progress_ref: ad195ac4a3be2877912331a0742fcb0031c6d774
+      # Numeric user ids permitted to author progress pull requests. Ids, never logins: a login can
+      # be renamed and the old name re-registered by someone else.
+      #   477956 = kim-em, the account the worker authenticates as.
+      # This grants no privilege that account lacks -- it is already an OrganizationAdmin bypass
+      # actor on this ruleset -- so the check's real job is excluding everyone else.
+      allowed_user_ids: "477956"
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Each roadmap directory may carry two files that are **written by machine, not by
 - `STATUS.md` — a snapshot of where that roadmap stands, rewritten whole on each update and headed
   by the Tau Ceti commit it describes. It is updated asynchronously from the work it reports, so it
   is never authoritative about the current tip.
-- `PROGRESS.md` — an append-only log, one section per window of merged pull requests. New sections
-  are announced in the **Tau Ceti > Progress logs** Zulip topic.
+- `PROGRESS.md` — an append-only log, one section per window of merged pull requests. Each new
+  section is normally announced in the **Tau Ceti > Progress logs** Zulip topic; announcing is a
+  separate step from merging, so it can fail without holding the report back.
 
 Both are produced by [TauCetiProgress](https://github.com/TauCetiProject/TauCetiProgress). A pull
 request carrying them can merge without human review, but only when an automated gate accepts it;

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Each roadmap directory may carry two files that are **written by machine, not by
 - `PROGRESS.md` — an append-only log, one section per window of merged pull requests. New sections
   are announced in the **Tau Ceti > Progress logs** Zulip topic.
 
-Both are produced by [TauCetiProgress](https://github.com/TauCetiProject/TauCetiProgress) and merge
-without human review, under a gate that checks their structure. **Their prose is not
+Both are produced by [TauCetiProgress](https://github.com/TauCetiProject/TauCetiProgress). A pull
+request carrying them can merge without human review, but only when an automated gate accepts it;
+anything the gate declines is left for a human like any other contribution. **Their prose is not
 security-validated**: the gate proves which paths changed and that the log only grew at the end, but
 it cannot prove that the summary is accurate. Read them as a machine's account of the work, and treat
 the roadmap `README.md` beside them — which humans own and review — as the authority on what the

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ Roadmaps the maintainers have declared complete (a judgment against the roadmap'
 
 - [Effective arithmetic bounds and geometry of numbers](Completed/EffectiveBounds/README.md)
 
+## Generated status files
+
+Each roadmap directory may carry two files that are **written by machine, not by hand**:
+
+- `STATUS.md` — a snapshot of where that roadmap stands, rewritten whole on each update and headed
+  by the Tau Ceti commit it describes. It is updated asynchronously from the work it reports, so it
+  is never authoritative about the current tip.
+- `PROGRESS.md` — an append-only log, one section per window of merged pull requests. New sections
+  are announced in the **Tau Ceti > Progress logs** Zulip topic.
+
+Both are produced by [TauCetiProgress](https://github.com/TauCetiProject/TauCetiProgress) and merge
+without human review, under a gate that checks their structure. **Their prose is not
+security-validated**: the gate proves which paths changed and that the log only grew at the end, but
+it cannot prove that the summary is accurate. Read them as a machine's account of the work, and treat
+the roadmap `README.md` beside them — which humans own and review — as the authority on what the
+roadmap actually asks for.
+
 ## Writing a roadmap
 
 A roadmap is a specification for material we want added to Tau Ceti, written so an AI contributor, and its


### PR DESCRIPTION
This PR lets per-roadmap STATUS.md and PROGRESS.md reports land without a
human review, and announces each new PROGRESS.md section in the Tau Ceti >
Progress logs Zulip topic.

Both workflows delegate to SHA-pinned reusable workflows in
TauCetiProgress, the same discipline TauCeti uses for TauCetiReview: an
unpinned ref would let an upstream change alter what may merge here
without review. Each pin appears twice, once as the `uses:` ref and once
as `progress_ref`, and the two must match, since the first selects the
workflow and the second selects the validator code inside it.

The gate matters because this repository's ruleset cannot scope its
code-owner requirement to a path, so the only route to an unattended merge
is the roadmap App's bypass, which bypasses status checks too. The
validation is therefore the whole gate: provenance by immutable numeric
user id and a non-fork progress/* branch, exactly the two generated files
for one roadmap, a byte-exact append that continues the log, no symlinks,
a green build on that exact commit, and a merge bound to the validated
head. It never checks out pull request content.

Announcing is a separate workflow on push, so the App token and the Zulip
key never share a job, and a lost announcement can be retried without
re-merging; posts are idempotent on a stable per-window id.

The README records that these two files are machine-owned and that their
prose is not security-validated: the gate proves their shape, not their
truth.

🤖 Prepared with Claude Code

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>