### PR TITLE
progress: ReductiveGroups report for 2026-07-29

### DIFF
--- a/TauCetiRoadmap/ReductiveGroups/PROGRESS.md
+++ b/TauCetiRoadmap/ReductiveGroups/PROGRESS.md
@@ -1,0 +1,94 @@
+# Progress log: ReductiveGroups
+
+An append-only record of what landed on the ReductiveGroups roadmap, one section per window of
+merged pull requests, oldest first. Generated; the prose is not security-validated.
+For a current snapshot instead, read `STATUS.md` beside this file.
+
+<!--tauceti-progress:v1 {"from_sha":"1f1d7527e4085f3ac0ffad2ac3ad69cfbebe809c","prs":[45,54,56,62,64,75,78,80,90,97,101,106,109,111,112,113,116,117,118,119,122,123,124,125,126,127,129,135,136,137,138,139,148,155,156,157,158,159,165,166,167,169,181,182,183,185,186,196,234,237,239,240,241,242,243,244,245,282,285,297,314,325,357,361,373,383,386,399,427,428,458,469,478,490,512,515,552,611,665,690,700,748,761,762,769,785,862,890,909,968,976,1024,1027,1134,1139,1146,1163,1214,1280,1321],"roadmap":"ReductiveGroups","to_sha":"ed837d596f81c587c5b9696efed02a869f945e7e"}-->
+## ReductiveGroups: 2026-06-04 to 2026-07-29 (`1f1d752` to `ed837d5`)
+
+The largest named result of this window is that the character–cocharacter pairing of a split
+torus is perfect: for a split torus of finite rank, the dot-product pairing between the character
+lattice `X*(T) = σ →₀ ℤ` and the cocharacter lattice `X_*(T)` induces isomorphisms onto both
+`ℤ`-duals (TauCeti#1134). It is available both in the coordinate model of the cocharacter lattice
+and, transported back, on the genuine lattice of homomorphisms
+`Multiplicative (σ →₀ ℤ) →* Multiplicative ℤ`
+([`SplitTorus.instIsPerfPair`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Cocharacter.html#TauCeti.SplitTorus.instIsPerfPair)
+and `instLatticePairingIsPerfPair`), with the two non-degeneracy directions proved separately.
+Underneath it is the character and cocharacter machinery for a general diagonalizable group `D(M)`
+(TauCeti#968): characters and cocharacters as homomorphisms of group functors, the integer pairing
+[`DiagonalizableGroup.pairing`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Cocharacter.html#TauCeti.DiagonalizableGroup.pairing)
+with its bilinearity, and the power endomorphisms of `𝔾ₘ`, which TauCeti#1163 identified with the
+canonical integer action on endomorphisms. The roadmap wants the perfect pairing as the input to
+root data, and that is exactly where the work stops: nothing here defines a root, a Weyl group, or
+a maximal torus sitting inside a larger group, and the perfectness statement is for the split,
+finite-rank case only.
+
+Two kernels were computed. `μ_n` is the kernel of the `n`-th power endomorphism of `𝔾ₘ`
+(TauCeti#976,
+[`RootsOfUnityGroup.range_inclusion`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Kernel.html#TauCeti.RootsOfUnityGroup.range_inclusion)),
+and `αₚ` is the kernel of the Frobenius endomorphism of `𝔾ₐ` (TauCeti#1146,
+[`AlphaP.range_inclusion`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/Kernel.html#TauCeti.AlphaP.range_inclusion)).
+The same pull request builds that Frobenius endomorphism from the observation that `xᵖ` is
+primitive in characteristic `p`, so `x ↦ xᵖ` is a bialgebra endomorphism of the coordinate ring of
+`𝔾ₐ`. Both kernel statements are about the functor of points: they are equalities of subgroups of
+`G(A)`, natural in the value algebra `A`, and not scheme-theoretic kernels, which do not exist yet.
+`αₚ` itself arrived earlier in the window (TauCeti#611) with its coordinate Hopf algebra `R[x]/(xᵖ)`,
+its points identified with the `p`-nilpotent elements of `A`, and
+[`AlphaP.coordinateRing_not_isReduced`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/Basic.html#TauCeti.AlphaP.coordinateRing_not_isReduced);
+TauCeti#1024 adds that over a reduced algebra it has only the identity point. That is the
+roadmap's designated non-smooth example behaving as intended: invisible on reduced points, and not
+trivial.
+
+Most of the window, by volume, went into comodules, which the roadmap treats as the engine of
+Layer 1. The basic structure landed at the start (TauCeti#62,
+[`Comodule`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Basic.html#TauCeti.Comodule)),
+and the rest of the window filled in what a working category needs: an `R`-module of morphisms
+(TauCeti#90), preadditivity (TauCeti#106), a zero object (TauCeti#117), binary products carrying
+the direct-sum coaction (TauCeti#240), trivial and group-like comodules (TauCeti#101), the regular
+comodule (TauCeti#122), corestriction along a coalgebra morphism (TauCeti#97), transport across a
+linear equivalence (TauCeti#109), and cofree comodules together with the universal property that
+comodule morphisms into `M ⊗[R] C` are just linear maps into `M`
+([`Comodule.Hom.cofreeEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Cofree.html#TauCeti.Comodule.Hom.cofreeEquiv),
+TauCeti#129). The subobject theory is now reasonably complete: the lattice of subcomodules
+(TauCeti#136), inverse images and kernels (TauCeti#241), the induced coaction on the subtype of a
+subcomodule (TauCeti#909), quotients with their lift and its uniqueness (TauCeti#785), and on the
+coalgebra side subcoalgebra suprema and finiteness (TauCeti#124), images (TauCeti#127), spans of
+group-like elements (TauCeti#119), and the order embedding of subcoalgebras into subcomodules of
+the regular comodule (TauCeti#138). Over a bialgebra the diagonal tensor product of comodules was
+assembled (TauCeti#890, TauCeti#1027) and then restricted to the finitely generated ones, which
+now form a monoidal category
+([`FGComoduleCat.instMonoidalCategory`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.html#TauCeti.FGComoduleCat.instMonoidalCategory),
+TauCeti#1280 and TauCeti#1321). Monoidal, not rigid: there are no duals of comodules here, and
+none of the results the roadmap actually wants from this layer, the finite-dimensional
+subcoalgebra theorem, faithfulness, the embedding theorem into `GLₙ`, or Tannakian reconstruction,
+have been attempted.
+
+The Hopf-ideal lane advanced in parallel and stayed at the Hopf-algebra level. A bialgebra
+morphism killing a two-sided coideal factors uniquely through the quotient bialgebra
+(TauCeti#237); the kernel of a surjective bialgebra morphism is a Hopf ideal, and the quotient by
+it is bialgebra-equivalent to the codomain
+([`HopfIdeal.kerLiftBialgEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/HopfAlgebra/Kernel.html#TauCeti.HopfIdeal.kerLiftBialgEquiv),
+TauCeti#185); and Hopf ideals pull back along surjections compatibly with the lattice operations
+(TauCeti#383). Around these sit the Layer 0 supports: the convolution group structure on
+`H →ₐ[R] A` with inverse `f ↦ f ∘ S`
+([`AlgHom.instGroup`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.html#TauCeti.AlgHom.instGroup),
+TauCeti#45) and its packaging as a functor in the value algebra (TauCeti#54), the points of a
+tensor product as the product of the points (TauCeti#167, made natural in TauCeti#458), the points
+of the trivial group (TauCeti#428), the Hopf-algebra structure on a symmetric algebra with
+antipode `ι x ↦ -ι x` (TauCeti#165), the monoid algebra of a product as a tensor product of
+monoid algebras (TauCeti#297), the universal property of a free abelian character group
+(TauCeti#282), restriction of scalars on `CommAlgCat` (TauCeti#762), and a coordinate-ring functor
+from finitely generated commutative groups to finite-type commutative Hopf algebras
+([`DiagonalizableGroup.coordinateRingFunctor`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.html#TauCeti.DiagonalizableGroup.coordinateRingFunctor),
+TauCeti#1214), which is one direction of the Layer 4 anti-equivalence and not yet the equivalence.
+Matrix coefficients also got their first multiplicativity statements: the coefficient submodule of
+a tensor product of comodules contains the product of the two coefficient submodules (TauCeti#1139).
+
+Proportion is worth stating plainly. Of the hundred pull requests in this window, fifty-five added
+no new declarations at all; they split modules into directories, renamed, adjusted imports, and
+consolidated. Of the rest, a large share is the routine `_apply`, `_comp`, and `_toLinearMap`
+plumbing that makes the comodule API usable. One other design point is visible throughout the
+declaration list: everything is stated over a general commutative base ring `R` rather than over a
+field, so the field-specific parts of the roadmap, geometric connectedness, smoothness, and
+anything defined after base change to `k̄`, remain untouched.

--- a/TauCetiRoadmap/ReductiveGroups/STATUS.md
+++ b/TauCetiRoadmap/ReductiveGroups/STATUS.md
@@ -1,0 +1,142 @@
+<!--tauceti-status:v1 {"roadmap":"ReductiveGroups","to_sha":"ed837d596f81c587c5b9696efed02a869f945e7e","ts":"2026-07-29T20:34:58-04:00"}-->
+# Status: ReductiveGroups
+
+This file documents the status of the ReductiveGroups roadmap up until `ed837d5` (2026-07-29T20:34:58-04:00). There may have been subsequent updates.
+
+It is generated, and its prose is not security-validated; see
+https://github.com/TauCetiProject/TauCetiProgress for what that means.
+
+## Where this roadmap stands
+
+**Cross-cutting prerequisite: sheaves and descent.** Untouched. Nothing in the declaration list
+mentions presheaves on `CommAlgCat k`, representability, fppf sheafification, torsors, or
+faithfully flat descent.
+
+**Layer 0: the functor of points and the three-way dictionary.** Partly done, and unevenly. The
+functor-of-points view is real: `R`-algebra homomorphisms out of a Hopf algebra form a group under
+convolution with inverse `f ∘ S`
+([`AlgHom.instGroup`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.html#TauCeti.AlgHom.instGroup)),
+abelian when the Hopf algebra is cocommutative, and this is packaged as a functor in the value
+algebra
+([`HopfAlgebra.pointsFunctor`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.html#TauCeti.HopfAlgebra.pointsFunctor)).
+Points of a tensor product are the product of the points
+([`AffineGroup.Product.pointsMulEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Product.html#TauCeti.AffineGroup.Product.pointsMulEquiv)),
+naturally in the value algebra, and the trivial group has the expected one-element functor of
+points. The other two views are not there. There is no group object in schemes anywhere in the
+declaration list, no `Spec`/`Γ` translation, no anti-equivalence `(CommHopfAlg k)ᵒᵖ ≌ AffGrpSch k`,
+and no third view by representable group functors; the two scheme-side examples in
+`Suggested.lean` are still stated with `sorry`. A base-change lane exists in the source tree
+(modules for base change of Hopf algebras, of the standard examples, and of the category of
+commutative Hopf algebras), but no new declarations landed in those modules in this window, so
+this report cannot say what they contain.
+
+**Layer 1: representations = comodules.** The comodule half is substantially built; the
+representation-theoretic half is not. Comodules over a coalgebra exist
+([`Comodule`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Basic.html#TauCeti.Comodule)),
+with morphisms forming an `R`-module, a preadditive category `ComoduleCat` with a zero object and
+binary products, trivial, group-like, regular, and cofree comodules, corestriction, transport
+along linear equivalences, a full subobject theory (lattice of subcomodules, inverse images,
+kernels, induced coactions, quotients with lifts and uniqueness), and the corresponding
+subcoalgebra lattice, images, group-like spans, and order embedding into subcomodules of the
+regular comodule. Over a bialgebra there is the diagonal tensor product
+([`Comodule.tensor`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.html#TauCeti.Comodule.tensor)),
+and finitely generated comodules form a monoidal category
+([`FGComoduleCat.instMonoidalCategory`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.html#TauCeti.FGComoduleCat.instMonoidalCategory)).
+Missing, and these are the parts the roadmap cares about: duals, so the monoidal category is not
+rigid; the finite-dimensional subcoalgebra theorem (every element lies in a finite-dimensional
+subcoalgebra, every comodule is the union of its finite-dimensional subcomodules); the
+representation ⇆ comodule dictionary; faithfulness as a closed immersion and its equivalence with
+matrix coefficients generating `A`; the embedding theorem; Tannakian reconstruction. Matrix
+coefficients themselves exist and are now known to be multiplicative on tensor products
+([`Comodule.matrixCoefficientSubmodule_mul_le`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/TensorProduct.html#TauCeti.Comodule.matrixCoefficientSubmodule_mul_le)),
+which is a step toward the faithfulness criterion and not the criterion.
+
+**Layer 2: Lie algebra and the adjoint representation.** Untouched. No tangent space at the
+identity, no `Lie(G)`, no differential of a homomorphism, no `Ad`.
+
+**Layer 3: subgroups, quotients, components.** Partly done, on the Hopf side only. Quotient
+bialgebras by two-sided coideals have their universal property
+([`Bialgebra.Quotient.liftBialgHom`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Bialgebra/Quotient.html#Bialgebra.Quotient.liftBialgHom)),
+the kernel of a surjective bialgebra morphism is a Hopf ideal and the quotient by it is
+bialgebra-equivalent to the codomain
+([`HopfIdeal.kerLiftBialgEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/HopfAlgebra/Kernel.html#TauCeti.HopfIdeal.kerLiftBialgEquiv)),
+and Hopf ideals pull back along surjections compatibly with joins and suprema
+([`HopfIdeal.comap`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.html#TauCeti.HopfIdeal.comap)).
+Not there: the anti-equivalence between Hopf ideals and closed subgroup schemes, normality via the
+adjoint coaction, the fppf sheaf quotient `G/H` and any representability theorem for it, short
+exact sequences, the identity component, and the component group.
+
+**Layer 4: Jordan decomposition, diagonalizable groups, tori.** The diagonalizable and torus lane
+is the furthest advanced part of the roadmap. Characters and cocharacters of `D(M)` are
+homomorphisms of group functors, they pair to an integer
+([`DiagonalizableGroup.pairing`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Cocharacter.html#TauCeti.DiagonalizableGroup.pairing)),
+the pairing is bilinear and is realized on points by a power endomorphism of `𝔾ₘ`, `μ_n` is the
+kernel of the `n`-th power endomorphism
+([`RootsOfUnityGroup.range_inclusion`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Kernel.html#TauCeti.RootsOfUnityGroup.range_inclusion)),
+and for a split torus of finite rank the character and cocharacter lattices pair perfectly
+([`SplitTorus.instIsPerfPair`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Cocharacter.html#TauCeti.SplitTorus.instIsPerfPair)).
+The anti-equivalence `M ↦ D(M)` between finitely generated abelian groups and diagonalizable
+groups has one direction only, the coordinate-ring functor
+[`DiagonalizableGroup.coordinateRingFunctor`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.html#TauCeti.DiagonalizableGroup.coordinateRingFunctor)
+out of the category of finitely generated commutative groups; full faithfulness and essential
+surjectivity are not proved. Non-split tori, groups of multiplicative type in general, Cartier
+duality, and Jordan decomposition are all untouched.
+
+**Layer 5: solvable and unipotent groups; the unipotent radical.** Untouched. No definition of
+unipotence, no Lie–Kolchin, no unipotent radical.
+
+**Layer 6: reductive and semisimple groups.** Untouched. Neither definition of reductivity is
+stated, and neither is linear reductivity.
+
+**Layer 7: structure theory.** Untouched. No Borel or parabolic subgroups, no maximal tori inside
+a larger group, no root datum, no Weyl group, no Bruhat decomposition or BN-pairs. The perfect
+character–cocharacter pairing of Layer 4 is the input this layer will consume, and it is the only
+piece of it in place.
+
+**Layer 8: classification and existence.** Untouched, as expected at this stage.
+
+**Worked examples.** `𝔾ₐ` (with its Frobenius endomorphism), `𝔾ₘ`, `μ_n`, `αₚ`, split tori of
+arbitrary rank, the trivial group, and products of affine groups are all exercised on the functor
+of points. `GLₙ`, `SLₙ`, `PGLₙ`, `SOₙ`, and `Sp₂ₙ` do not appear anywhere in the declaration list.
+`αₚ` is doing the job the roadmap assigned it: its coordinate ring is provably non-reduced, and it
+has only the identity point over a reduced algebra, so a naive reduced-points definition of
+anything would already be visibly wrong.
+
+One standing caveat that cuts across all of the above: the whole development is stated over a
+general commutative base ring `R`, not over a field `k`. That is more general than the roadmap's
+starting hypothesis and costs nothing so far, but every geometric notion the later layers need
+(connectedness, smoothness, unipotence, reductivity) is defined after base change to `k̄` and none
+of that has been set up.
+
+## The frontier
+
+The nearest targets, roughly in order of how little stands between them and the current state:
+
+- **Duals of finitely generated comodules**, upgrading `FGComoduleCat` from monoidal to rigid.
+  The monoidal structure is finished, so this is the immediate next step in Layer 1 and a
+  prerequisite for anything Tannakian.
+- **The finite-dimensional subcoalgebra theorem**: every element of a coalgebra lies in a
+  finitely generated subcoalgebra, and every comodule is the union of its finitely generated
+  subcomodules. The groundwork is in place (the subcoalgebra lattice with its finiteness lemmas,
+  spans of group-like elements, subcoalgebras as subcomodules of the regular comodule), and the
+  roadmap identifies this as the real engine behind the embedding theorem.
+- **Full faithfulness and essential surjectivity of the diagonalizable coordinate-ring functor**,
+  which would close out the `M ↦ D(M)` anti-equivalence. The functor exists; the two remaining
+  properties are self-contained.
+- **The two Layer 0 scheme-side targets** in `Suggested.lean`: `Γ(G)` as a Hopf algebra for an
+  affine group scheme `G` over `Spec R`, and `Spec A` as a group object for a Hopf algebra `A`.
+  These are still `sorry`, and they are the bottleneck for a large amount of downstream work: the
+  correct definition of faithfulness (a closed immersion `G ↪ GLₙ`), scheme-theoretic kernels as
+  opposed to the kernels-on-points computed so far, the fppf quotient `G/H`, and every geometric
+  notion in Layers 3, 5, and 6. Anyone wanting to unblock the most work should start here.
+- **`GLₙ` as a worked example.** Nothing in the current development names it, and it is needed
+  both as a check on the definitions and as the target of the embedding theorem.
+- **Layer 2 in its entirety** (`Lie(G)`, differentials, the adjoint action). It is untouched, it
+  has no prerequisites that are missing, and the roadmap places it early precisely because Jordan
+  decomposition, root spaces, and the unipotent radical all wait on it.
+
+Blocked rather than merely unstarted: unipotence, the unipotent radical, reductivity, and the
+identity component all need base change to `k̄` and a geometric notion of connectedness, and the
+declaration list contains neither. Working over a general commutative ring rather than a field, as
+the current development does, will have to be revisited at that point, since these notions are
+field-specific.


### PR DESCRIPTION
<!--tauceti-progress-pr:v1 {"from_sha":"1f1d7527e4085f3ac0ffad2ac3ad69cfbebe809c","prs":[45,54,56,62,64,75,78,80,90,97,101,106,109,111,112,113,116,117,118,119,122,123,124,125,126,127,129,135,136,137,138,139,148,155,156,157,158,159,165,166,167,169,181,182,183,185,186,196,234,237,239,240,241,242,243,244,245,282,285,297,314,325,357,361,373,383,386,399,427,428,458,469,478,490,512,515,552,611,665,690,700,748,761,762,769,785,862,890,909,968,976,1024,1027,1134,1139,1146,1163,1214,1280,1321],"roadmap":"ReductiveGroups","to_sha":"ed837d596f81c587c5b9696efed02a869f945e7e","version":"6d1f1d1d50bdfe869d254b0a93ffc5c10c64aefd"}-->
This PR records progress on the ReductiveGroups roadmap for the window `1f1d752..ed837d5` of TauCeti `main`, covering 100 merged pull requests.

`STATUS.md` is rewritten as a snapshot at `ed837d5`; `PROGRESS.md` gains one appended section for the window. Both files are machine-owned and their prose is not security-validated.

Pull requests in the window: #45, #54, #56, #62, #64, #75, #78, #80, #90, #97, #101, #106, #109, #111, #112, #113, #116, #117, #118, #119, #122, #123, #124, #125, #126, #127, #129, #135, #136, #137, #138, #139, #148, #155, #156, #157, #158, #159, #165, #166, #167, #169, #181, #182, #183, #185, #186, #196, #234, #237, #239, #240, #241, #242, #243, #244, #245, #282, #285, #297, #314, #325, #357, #361, #373, #383, #386, #399, #427, #428, #458, #469, #478, #490, #512, #515, #552, #611, #665, #690, #700, #748, #761, #762, #769, #785, #862, #890, #909, #968, #976, #1024, #1027, #1134, #1139, #1146, #1163, #1214, #1280, #1321

Generated by [TauCetiProgress](https://github.com/TauCetiProject/TauCetiProgress) at `6d1f1d1d50bdfe869d254b0a93ffc5c10c64aefd`.

🤖 Prepared with Claude Code
