### PR TITLE
chore: pin the progress workflows to 0da572f

### DIFF
--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ permissions:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@744493d446f5188f89e372b9d00b0a6d6ed87e08
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@0da572fb3ef51afa1f9fe90492cc489a078423ce
     with:
-      progress_ref: 744493d446f5188f89e372b9d00b0a6d6ed87e08
+      progress_ref: 0da572fb3ef51afa1f9fe90492cc489a078423ce
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -127,10 +127,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@744493d446f5188f89e372b9d00b0a6d6ed87e08
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@0da572fb3ef51afa1f9fe90492cc489a078423ce
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: 744493d446f5188f89e372b9d00b0a6d6ed87e08
+      progress_ref: 0da572fb3ef51afa1f9fe90492cc489a078423ce
       # There is deliberately no author allowlist. Anyone may publish a progress report, including
       # from a fork: what bounds this is the shape of the diff (two generated files, one roadmap,
       # append-only log, window ending in published history), not who sent it. See


### PR DESCRIPTION
Picks up two changes. A roadmap's first report is verified against the code
repository rather than left for a human: the collector clones it and asks git,
using the same functions the planner uses, so the two agree by construction
instead of by coincidence. And a labelled pull request that is in the
documented history but carries no pull request number in its merge subject now
refuses the bootstrap rather than letting the starting point skip past it.

The reporting cadence also drops to 8 hours, with the per-roadmap server-side
gap at 6 so it can never refuse a report the planner just considered due.

🤖 Prepared with Claude Code