### PR TITLE
roadmap(Exchangeability): add the full-path joint disintegration as a Layer 6 API target

### DIFF
--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -678,6 +678,18 @@ The directing-measure theorem should expose a real API, not just an existence pr
   `∞`-valued finite-dimensional mixtures, so mixing-law uniqueness fails at the hypothesis-light
   generality of the definitions;
 * the finite-dimensional factorization identity;
+* the **full-path joint disintegration** associated to a `ConditionallyIIDWith` witness: for
+  `[IsFiniteMeasure μ]`, arbitrary measurable sample and state spaces, measurable coordinates
+  `X`, and `h : ConditionallyIIDWith μ X ν`,
+
+  ```lean
+  μ.map (fun ω => (ν ω, fun i => X i ω)) = iidMixtureLaw (μ.map ν) id
+  ```
+
+  This is the whole-path form of the predicate's finite selected-block identities. It retains
+  the directing measure as a coordinate and is therefore strictly stronger than the integrated
+  mixture identity for `pathLaw μ X`. It is a derived public API theorem, **not** a prerequisite
+  for the v1 summit, empirical-measure convergence, or the extreme-point theorem;
 * the empirical-measure form: `(1/n) Σ_{i<n} δ_{Xᵢ}(ω) ⇒ ν(ω)` weakly in `P(α)`, tested
   against bounded continuous functions (a milestone in its own right, bringing in the weak
   topology on `ProbabilityMeasure α`; not a prerequisite for the base directing-measure
@@ -727,6 +739,7 @@ deFinetti_viaL2
 deFinetti_viaKoopman
 
 deFinetti_empiricalMeasure
+ConditionallyIIDWith.jointPathLaw_eq_iidMixtureLaw
 deFinetti_mixture
 mixedIID_mixingLaw_unique
 conditionallyIID_ae_unique


### PR DESCRIPTION
Adds the full-path joint disintegration for `ConditionallyIIDWith` as an explicit Layer 6
target, plus its public name in Layer 7.

## Why

The theorem gives the whole-path semantic characterization of `ConditionallyIIDWith`,
connecting two public abstractions — the predicate and `iidMixtureLaw`. It is strictly
stronger than the integrated `pathLaw` mixture identity, since it retains the directing
measure as a coordinate, and it has stable, appropriately weak hypotheses (finite `μ`,
measurable coordinates). Adding it prevents future conditional path-space arguments from
each rebuilding finite-prefix extensionality.

This fits the layer's existing instruction that the directing-measure theorem expose "a real
API, not just an existence proof". This is a semantic completion of the public
conditional-representation API, not a target added merely to authorize its supporting
finite-prefix machinery.

## What this deliberately does not claim

The new bullet states outright that this is **not** a prerequisite for the v1 summit,
empirical-measure convergence, or the extreme-point theorem. TauCetiProject/TauCeti#1599 has
already landed the empirical object and fixed-set estimates without it, and the current
extreme-point route does not depend on it either. The target is authorized for its semantic
and reusable API value; the roadmap should not carry a fictional dependency claim.

## Provenance

Surfaced by TauCetiProject/TauCetiRoadmap#114 and the `scope` block on
TauCetiProject/TauCeti#1690. That block was **correct** under the roadmap as written — the
joint form appears in no layer. This PR is the roadmap decision that was missing, not a
retroactive blessing of an implemented branch; if the case above does not stand on its own,
the right outcome is to reject this and close #1690.

Roadmap: Exchangeability

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
