### PR TITLE
chore: bump TauCetiProgress to 620030c

### DIFF
--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ permissions:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@0da572fb3ef51afa1f9fe90492cc489a078423ce
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@b18930c7f5b19a5aa51ae49a603ec18f38452f4d
     with:
-      progress_ref: 0da572fb3ef51afa1f9fe90492cc489a078423ce
+      progress_ref: b18930c7f5b19a5aa51ae49a603ec18f38452f4d
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ permissions:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@b18930c7f5b19a5aa51ae49a603ec18f38452f4d
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@620030c7f7e89a340bcb0bca2b5dc5689bb8a955
     with:
-      progress_ref: b18930c7f5b19a5aa51ae49a603ec18f38452f4d
+      progress_ref: 620030c7f7e89a340bcb0bca2b5dc5689bb8a955
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -127,10 +127,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@0da572fb3ef51afa1f9fe90492cc489a078423ce
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@b18930c7f5b19a5aa51ae49a603ec18f38452f4d
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: 0da572fb3ef51afa1f9fe90492cc489a078423ce
+      progress_ref: b18930c7f5b19a5aa51ae49a603ec18f38452f4d
       # There is deliberately no author allowlist. Anyone may publish a progress report, including
       # from a fork: what bounds this is the shape of the diff (two generated files, one roadmap,
       # append-only log, window ending in published history), not who sent it. See

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -127,10 +127,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@b18930c7f5b19a5aa51ae49a603ec18f38452f4d
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@620030c7f7e89a340bcb0bca2b5dc5689bb8a955
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: b18930c7f5b19a5aa51ae49a603ec18f38452f4d
+      progress_ref: 620030c7f7e89a340bcb0bca2b5dc5689bb8a955
       # There is deliberately no author allowlist. Anyone may publish a progress report, including
       # from a fork: what bounds this is the shape of the diff (two generated files, one roadmap,
       # append-only log, window ending in published history), not who sent it. See

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Each roadmap directory may carry two files that are **written by machine, not by
   by the Tau Ceti commit it describes. It is updated asynchronously from the work it reports, so it
   is never authoritative about the current tip.
 - `PROGRESS.md` — an append-only log, one section per window of merged pull requests. Each new
-  section is normally announced in the **Tau Ceti > Progress logs** Zulip topic; announcing is a
-  separate step from merging, so it can fail without holding the report back.
+  section is normally announced in the **Tau Ceti > Progress logs** Zulip topic with links to both
+  the full log and current `STATUS.md`; announcing is a separate step from merging, so it can fail
+  without holding the report back.
 
 Both are produced by [TauCetiProgress](https://github.com/TauCetiProject/TauCetiProgress). A pull
 request carrying them can merge without human review, but only when an automated gate accepts it;


### PR DESCRIPTION
Bump both SHA-pinned TauCetiProgress workflows to `b18930c`, in step with the worker pin.

This enables:

- the theorem-first, Voyager-inspired STATUS format and its validator backstop;
- Zulip announcement footers linking both the full PROGRESS.md and current STATUS.md;
- correct footer paths for roadmaps under `Completed/`.

The README now documents the two announcement links.

Verification:

- both workflow YAML files parse successfully;
- all four `uses:` / `progress_ref:` pins are exactly `620030c7f7e89a340bcb0bca2b5dc5689bb8a955`;
- the prior pin is absent from both workflows.

This pin now includes the plain-English prompt refinements from TauCetiProgress #4, including the matching STATUS reference policy.