### PR TITLE
chore: bump TauCetiProgress to f735789

### DIFF
--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ permissions:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@620030c7f7e89a340bcb0bca2b5dc5689bb8a955
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@f735789ac2b5185f6650f46e91a074fefdee6d68
     with:
-      progress_ref: 620030c7f7e89a340bcb0bca2b5dc5689bb8a955
+      progress_ref: f735789ac2b5185f6650f46e91a074fefdee6d68
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -127,10 +127,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@620030c7f7e89a340bcb0bca2b5dc5689bb8a955
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@f735789ac2b5185f6650f46e91a074fefdee6d68
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: 620030c7f7e89a340bcb0bca2b5dc5689bb8a955
+      progress_ref: f735789ac2b5185f6650f46e91a074fefdee6d68
       # There is deliberately no author allowlist. Anyone may publish a progress report, including
       # from a fork: what bounds this is the shape of the diff (two generated files, one roadmap,
       # append-only log, window ending in published history), not who sent it. See


### PR DESCRIPTION
Pin the reusable progress merge and announcement workflows to TauCetiProgress f735789, which removes stale tracked build artifacts and guarantees the installed package contains the current eight-hour cadence, theorem-first prompts, and STATUS announcement links.

Both workflow files parse successfully and all four immutable pins match.