### PR TITLE
ci: move checkout to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Build only. The roadmap's Lean targets carry `sorry` on purpose (they are goals),
       # so there is no axiom audit or warning-as-error here.
       - name: Build

--- a/.github/workflows/sync-roadmap-dropdowns.yml
+++ b/.github/workflows/sync-roadmap-dropdowns.yml
@@ -42,7 +42,7 @@ jobs:
           app-id: ${{ vars.SYNC_BOT_APP_ID }}
           private-key: ${{ secrets.SYNC_BOT_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
Updates every actions/checkout use to v7.0.1, pinned by full commit SHA. This release uses the Node 24 action runtime and removes the Node 20 deprecation annotation.\n\nValidation: workflow YAML parsed and git diff checks passed.