### PR TITLE
ci: move app token action to Node 24

### DIFF
--- a/.github/workflows/sync-roadmap-dropdowns.yml
+++ b/.github/workflows/sync-roadmap-dropdowns.yml
@@ -37,7 +37,7 @@ jobs:
       # not be able to change what executes.
       - name: Mint app token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.SYNC_BOT_APP_ID }}
           private-key: ${{ secrets.SYNC_BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Updates actions/create-github-app-token from v1 to v3.2.0, pinned by full commit SHA. The workflow already uses the current hyphenated inputs and does not configure a proxy, so the v2 and v3 removals do not affect it. The new release uses the Node 24 action runtime.\n\nValidation: workflow YAML parsed and git diff checks passed.