### PR TITLE
ci: keep app ID on warning-free Node 24 action

### DIFF
--- a/.github/workflows/sync-roadmap-dropdowns.yml
+++ b/.github/workflows/sync-roadmap-dropdowns.yml
@@ -37,7 +37,9 @@ jobs:
       # not be able to change what executes.
       - name: Mint app token
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        # v3.1+ deprecates app-id in favour of a distinct client ID; this installation currently
+        # stores its app ID, so use the Node-24 v3.0 release until that credential is migrated.
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ vars.SYNC_BOT_APP_ID }}
           private-key: ${{ secrets.SYNC_BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Pins actions/create-github-app-token to v3.0.0, the newest Node 24 major release before v3.1 deprecated the app-id input. The configured SYNC_BOT_APP_ID is an App ID, not the distinct client ID required by the newer input, so this removes the warning without changing credential semantics.\n\nValidation: workflow YAML parsed and git diff checks passed. The post-merge sync run will verify the action and annotation output.