### PR TITLE
ci: finish Node 24 token action migration

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Mint App token (pull-requests + contents write)
         id: token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/grant-triage.yml
+++ b/.github/workflows/grant-triage.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Mint App token (organization Members write)
         id: token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/label-intentions.yml
+++ b/.github/workflows/label-intentions.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Mint App token (issues write)
         id: token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ vars.CLAIM_BOT_APP_ID }}
           private-key: ${{ secrets.CLAIM_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ permissions:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@f735789ac2b5185f6650f46e91a074fefdee6d68
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@f73dcd7b92d0b191e44c22ffe1959873f9f24f01
     with:
-      progress_ref: f735789ac2b5185f6650f46e91a074fefdee6d68
+      progress_ref: f73dcd7b92d0b191e44c22ffe1959873f9f24f01
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -127,10 +127,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@f735789ac2b5185f6650f46e91a074fefdee6d68
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@f73dcd7b92d0b191e44c22ffe1959873f9f24f01
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: f735789ac2b5185f6650f46e91a074fefdee6d68
+      progress_ref: f73dcd7b92d0b191e44c22ffe1959873f9f24f01
       # There is deliberately no author allowlist. Anyone may publish a progress report, including
       # from a fork: what bounds this is the shape of the diff (two generated files, one roadmap,
       # append-only log, window ending in published history), not who sent it. See

--- a/.github/workflows/promote-reviewers.yml
+++ b/.github/workflows/promote-reviewers.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Mint App token (organization Members write)
         id: token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Moves every remaining Roadmap create-github-app-token use to the exact warning-free Node 24 v3.0.0 commit. All callers supply App IDs, so this preserves their existing credential semantics and avoids both the Node 20 warning and the v3.1+ client-ID migration warning.\n\nAlso repins both TauCetiProgress reusable workflows and their progress_ref inputs to f73dcd7, which carries the same correction in its merge workflow.\n\nValidation: all workflow YAML parsed; git diff checks passed; TauCetiProgress full tests and CI passed.