### PR TITLE
progress: ReductiveGroups report for 2026-08-03

### DIFF
--- a/TauCetiRoadmap/ReductiveGroups/PROGRESS.md
+++ b/TauCetiRoadmap/ReductiveGroups/PROGRESS.md
@@ -92,3 +92,38 @@ plumbing that makes the comodule API usable. One other design point is visible t
 declaration list: everything is stated over a general commutative base ring `R` rather than over a
 field, so the field-specific parts of the roadmap, geometric connectedness, smoothness, and
 anything defined after base change to `k̄`, remain untouched.
+
+<!--tauceti-progress:v1 {"from_sha":"ed837d596f81c587c5b9696efed02a869f945e7e","prs":[1505,1508,1514,1516,1518,1521,1617,1620,1626,1627,1632,1640,1644,1651,1652,1661,1664,1669,1671,1672,1674,1676,1678,1683,1689,1691,1692,1694,1696,1697,1709,1711,1729,1753,1776,1805,1809,1813,1815,1816,1817,1818,1825,1831,1833,1841,1843,1845,1853,1856,1862,1863,1869,1889,1905,1906,1910,1921,1924],"roadmap":"ReductiveGroups","to_sha":"11ef09d4d6e560655ed762ace27ef2858e9117cd"}-->
+## ReductiveGroups: 2026-07-29 to 2026-08-03 (`ed837d5` to `11ef09d`)
+
+Layer 0 reached its summit. `Spec` is now an anti-equivalence from commutative `S`-Hopf algebras
+onto affine group schemes over `Spec S`
+([`commHopfAlgCatOpEquivAffineGroupSchemeCat`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.html#TauCeti.commHopfAlgCatOpEquivAffineGroupSchemeCat),
+TauCeti#1626), the `Γ` direction coming from a Hopf-algebra structure on the global sections of an
+affine group scheme, and the functor of points was reconciled with it: it is corepresentable, full
+and faithful. So the roadmap's three views are finally interchangeable. Built on that, closed
+subgroup schemes of `Spec H` are classified by Hopf ideals under reverse inclusion
+([`hopfIdealOrderIsoClosedSubgroup`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Classification.html#TauCeti.CommHopfAlgCat.hopfIdealOrderIsoClosedSubgroup)),
+and the kernel of a morphism, cut out by the extended augmentation ideal, is the scheme-theoretic
+fibre over the identity.
+
+Comodules got their two structural theorems. Every element of a coalgebra over a field lies in a
+finite-dimensional subcoalgebra
+([`Subcoalgebra.exists_finiteDimensional_subcoalgebra_mem`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Subcoalgebra/Finite.html#TauCeti.Subcoalgebra.exists_finiteDimensional_subcoalgebra_mem)),
+and, when the coefficient coalgebra is free, every comodule is the union of its finite subcomodules.
+Finite-dimensional comodules over a commutative Hopf algebra now form a rigid symmetric monoidal
+category
+([`FGComoduleCat.instRigidCategory`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Finite/Rigid.html#TauCeti.FGComoduleCat.instRigidCategory)),
+duals twisted by the antipode. And the dictionary the roadmap wanted is in place: representations
+of the group functor on `V` are exactly comodule structures on `V`
+([`pointRepresentationEquivComodule`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Basic.html#TauCeti.HopfAlgebra.pointRepresentationEquivComodule)),
+with a matching criterion for when a linear map is colinear.
+
+Layer 2 opened: the tangent space at the identity, defined as dual-number points lying over the
+identity, is the module of derivations at the counit, and carries the convolution commutator as a
+Lie bracket
+([`Derivation.instLieAlgebra`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.html#TauCeti.Derivation.instLieAlgebra)),
+with the differential of a Hopf morphism a Lie morphism. The adjoint action is not there. The
+worked examples caught up with the scheme language: `GLₙ`, `SLₙ` as a closed subgroup of it, `𝔾ₐ`
+as affine one-space, `μ_n` as a closed subgroup of `𝔾ₘ`, and split tori, each with its
+scheme-valued points identified with the expected classical group.

--- a/TauCetiRoadmap/ReductiveGroups/STATUS.md
+++ b/TauCetiRoadmap/ReductiveGroups/STATUS.md
@@ -1,142 +1,89 @@
-<!--tauceti-status:v1 {"roadmap":"ReductiveGroups","to_sha":"ed837d596f81c587c5b9696efed02a869f945e7e","ts":"2026-07-29T20:34:58-04:00"}-->
+<!--tauceti-status:v1 {"roadmap":"ReductiveGroups","to_sha":"11ef09d4d6e560655ed762ace27ef2858e9117cd","ts":"2026-08-03T18:31:13Z"}-->
 # Status: ReductiveGroups
 
-This file documents the status of the ReductiveGroups roadmap up until `ed837d5` (2026-07-29T20:34:58-04:00). There may have been subsequent updates.
+This file documents the status of the ReductiveGroups roadmap up until `11ef09d` (2026-08-03T18:31:13Z). There may have been subsequent updates.
 
 It is generated, and its prose is not security-validated; see
 https://github.com/TauCetiProject/TauCetiProgress for what that means.
 
 ## Where this roadmap stands
 
-**Cross-cutting prerequisite: sheaves and descent.** Untouched. Nothing in the declaration list
-mentions presheaves on `CommAlgCat k`, representability, fppf sheafification, torsors, or
-faithfully flat descent.
+**At a glance.** Layer 0 is done: the anti-equivalence between commutative Hopf algebras and
+affine group schemes exists, and all three of the roadmap's views are explicitly identified with
+one another. Layer 1 has its structural theorems and its rigid tensor category but not
+faithfulness, the embedding theorem or Tannakian reconstruction; Layer 2 is begun; Layers 3 and 4
+are partly built; Layers 5 through 8 and the sheaf-and-descent lane have not started.
 
-**Layer 0: the functor of points and the three-way dictionary.** Partly done, and unevenly. The
-functor-of-points view is real: `R`-algebra homomorphisms out of a Hopf algebra form a group under
-convolution with inverse `f ∘ S`
-([`AlgHom.instGroup`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.html#TauCeti.AlgHom.instGroup)),
-abelian when the Hopf algebra is cocommutative, and this is packaged as a functor in the value
-algebra
-([`HopfAlgebra.pointsFunctor`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/PointsFunctor.html#TauCeti.HopfAlgebra.pointsFunctor)).
-Points of a tensor product are the product of the points
-([`AffineGroup.Product.pointsMulEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Product.html#TauCeti.AffineGroup.Product.pointsMulEquiv)),
-naturally in the value algebra, and the trivial group has the expected one-element functor of
-points. The other two views are not there. There is no group object in schemes anywhere in the
-declaration list, no `Spec`/`Γ` translation, no anti-equivalence `(CommHopfAlg k)ᵒᵖ ≌ AffGrpSch k`,
-and no third view by representable group functors; the two scheme-side examples in
-`Suggested.lean` are still stated with `sorry`. A base-change lane exists in the source tree
-(modules for base change of Hopf algebras, of the standard examples, and of the category of
-commutative Hopf algebras), but no new declarations landed in those modules in this window, so
-this report cannot say what they contain.
+### Named results
 
-**Layer 1: representations = comodules.** The comodule half is substantially built; the
-representation-theoretic half is not. Comodules over a coalgebra exist
-([`Comodule`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Basic.html#TauCeti.Comodule)),
-with morphisms forming an `R`-module, a preadditive category `ComoduleCat` with a zero object and
-binary products, trivial, group-like, regular, and cofree comodules, corestriction, transport
-along linear equivalences, a full subobject theory (lattice of subcomodules, inverse images,
-kernels, induced coactions, quotients with lifts and uniqueness), and the corresponding
-subcoalgebra lattice, images, group-like spans, and order embedding into subcomodules of the
-regular comodule. Over a bialgebra there is the diagonal tensor product
-([`Comodule.tensor`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/TensorProduct.html#TauCeti.Comodule.tensor)),
-and finitely generated comodules form a monoidal category
-([`FGComoduleCat.instMonoidalCategory`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.html#TauCeti.FGComoduleCat.instMonoidalCategory)).
-Missing, and these are the parts the roadmap cares about: duals, so the monoidal category is not
-rigid; the finite-dimensional subcoalgebra theorem (every element lies in a finite-dimensional
-subcoalgebra, every comodule is the union of its finite-dimensional subcomodules); the
-representation ⇆ comodule dictionary; faithfulness as a closed immersion and its equivalence with
-matrix coefficients generating `A`; the embedding theorem; Tannakian reconstruction. Matrix
-coefficients themselves exist and are now known to be multiplicative on tensor products
-([`Comodule.matrixCoefficientSubmodule_mul_le`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/TensorProduct.html#TauCeti.Comodule.matrixCoefficientSubmodule_mul_le)),
-which is a step toward the faithfulness criterion and not the criterion.
+- **The Hopf/affine-group-scheme anti-equivalence** — `Spec` is an anti-equivalence from
+  commutative `S`-Hopf algebras onto affine group schemes over `Spec S`, assembled from Mathlib's
+  `hopfSpec` and a Hopf-algebra structure on the global sections of an affine group scheme
+  ([`commHopfAlgCatOpEquivAffineGroupSchemeCat`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.html#TauCeti.commHopfAlgCatOpEquivAffineGroupSchemeCat)).
+  It closes the two `Suggested.lean` targets that were the roadmap's stated bottleneck.
+- **Classification of closed subgroup schemes** — the Hopf ideals of `H` under reverse inclusion
+  are order-isomorphic to the closed subgroup schemes of `Spec H`
+  ([`hopfIdealOrderIsoClosedSubgroup`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Classification.html#TauCeti.CommHopfAlgCat.hopfIdealOrderIsoClosedSubgroup)).
+  Kernels are the case of the extended augmentation ideal, and are the scheme-theoretic fibre over
+  the identity.
+- **The fundamental theorem of comodules** — every element of a coalgebra over a field lies in a
+  finite-dimensional subcoalgebra
+  ([`exists_finiteDimensional_subcoalgebra_mem`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Subcoalgebra/Finite.html#TauCeti.Subcoalgebra.exists_finiteDimensional_subcoalgebra_mem)),
+  with a module-finite version over a principal ideal domain, and every comodule over a free
+  coefficient coalgebra is the supremum of its finite subcomodules
+  ([`sSup_finiteSubcomodules_eq_top`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.html#TauCeti.Subcomodule.sSup_finiteSubcomodules_eq_top)).
+- **Rigidity of finite comodules** — finite-dimensional comodules over a commutative Hopf algebra
+  form a rigid symmetric monoidal category, duals carrying the antipode-twisted coaction
+  ([`FGComoduleCat.instRigidCategory`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Finite/Rigid.html#TauCeti.FGComoduleCat.instRigidCategory)).
+  This is the tensor category any Tannakian statement will be about.
+- **Diagonalizable groups are finitely generated abelian groups** — those groups, with arrows
+  reversed, are equivalent to diagonalizable group schemes
+  ([`schemeEquivalence`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.html#TauCeti.DiagonalizableGroup.schemeEquivalence)),
+  completing an anti-equivalence that previously had only its easy direction. Fullness needs the
+  base to have connected prime spectrum.
 
-**Layer 2: Lie algebra and the adjoint representation.** Untouched. No tangent space at the
-identity, no `Lie(G)`, no differential of a homomorphism, no `Ad`.
+### Notable definitions and infrastructure
 
-**Layer 3: subgroups, quotients, components.** Partly done, on the Hopf side only. Quotient
-bialgebras by two-sided coideals have their universal property
-([`Bialgebra.Quotient.liftBialgHom`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Bialgebra/Quotient.html#Bialgebra.Quotient.liftBialgHom)),
-the kernel of a surjective bialgebra morphism is a Hopf ideal and the quotient by it is
-bialgebra-equivalent to the codomain
-([`HopfIdeal.kerLiftBialgEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/HopfAlgebra/Kernel.html#TauCeti.HopfIdeal.kerLiftBialgEquiv)),
-and Hopf ideals pull back along surjections compatibly with joins and suprema
-([`HopfIdeal.comap`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Comap.html#TauCeti.HopfIdeal.comap)).
-Not there: the anti-equivalence between Hopf ideals and closed subgroup schemes, normality via the
-adjoint coaction, the fppf sheaf quotient `G/H` and any representability theorem for it, short
-exact sequences, the identity component, and the component group.
+- **The tangent space at the identity, as a Lie algebra.** Dual-number points over the identity
+  are the derivations at the counit, and the convolution commutator makes them a Lie algebra
+  ([`Derivation.instLieAlgebra`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.html#TauCeti.Derivation.instLieAlgebra)),
+  with the differential of a Hopf morphism a Lie morphism. This is `Lie(G)`; nothing is built on it.
+- **The representation ⇆ comodule dictionary.** Natural actions of the functor of points on a
+  module correspond to comodule structures
+  ([`pointRepresentationEquivComodule`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Basic.html#TauCeti.HopfAlgebra.pointRepresentationEquivComodule)),
+  so comodule results can be read as statements about representations.
+- **`GLₙ` and `SLₙ` as group schemes**, with scheme-valued points identified with the ordinary
+  matrix groups
+  ([`GeneralLinear.schemePointsMulEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.html#TauCeti.GeneralLinear.schemePointsMulEquiv)),
+  `SLₙ` a closed subgroup cut out by the determinant. `GLₙ` is what the embedding theorem targets.
 
-**Layer 4: Jordan decomposition, diagonalizable groups, tori.** The diagonalizable and torus lane
-is the furthest advanced part of the roadmap. Characters and cocharacters of `D(M)` are
-homomorphisms of group functors, they pair to an integer
-([`DiagonalizableGroup.pairing`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Cocharacter.html#TauCeti.DiagonalizableGroup.pairing)),
-the pairing is bilinear and is realized on points by a power endomorphism of `𝔾ₘ`, `μ_n` is the
-kernel of the `n`-th power endomorphism
-([`RootsOfUnityGroup.range_inclusion`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/RootsOfUnity/Kernel.html#TauCeti.RootsOfUnityGroup.range_inclusion)),
-and for a split torus of finite rank the character and cocharacter lattices pair perfectly
-([`SplitTorus.instIsPerfPair`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/SplitTorus/Cocharacter.html#TauCeti.SplitTorus.instIsPerfPair)).
-The anti-equivalence `M ↦ D(M)` between finitely generated abelian groups and diagonalizable
-groups has one direction only, the coordinate-ring functor
-[`DiagonalizableGroup.coordinateRingFunctor`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.html#TauCeti.DiagonalizableGroup.coordinateRingFunctor)
-out of the category of finitely generated commutative groups; full faithfulness and essential
-surjectivity are not proved. Non-split tori, groups of multiplicative type in general, Cartier
-duality, and Jordan decomposition are all untouched.
+### Roadmap coverage
 
-**Layer 5: solvable and unipotent groups; the unipotent radical.** Untouched. No definition of
-unipotence, no Lie–Kolchin, no unipotent radical.
-
-**Layer 6: reductive and semisimple groups.** Untouched. Neither definition of reductivity is
-stated, and neither is linear reductivity.
-
-**Layer 7: structure theory.** Untouched. No Borel or parabolic subgroups, no maximal tori inside
-a larger group, no root datum, no Weyl group, no Bruhat decomposition or BN-pairs. The perfect
-character–cocharacter pairing of Layer 4 is the input this layer will consume, and it is the only
-piece of it in place.
-
-**Layer 8: classification and existence.** Untouched, as expected at this stage.
-
-**Worked examples.** `𝔾ₐ` (with its Frobenius endomorphism), `𝔾ₘ`, `μ_n`, `αₚ`, split tori of
-arbitrary rank, the trivial group, and products of affine groups are all exercised on the functor
-of points. `GLₙ`, `SLₙ`, `PGLₙ`, `SOₙ`, and `Sp₂ₙ` do not appear anywhere in the declaration list.
-`αₚ` is doing the job the roadmap assigned it: its coordinate ring is provably non-reduced, and it
-has only the identity point over a reduced algebra, so a naive reduced-points definition of
-anything would already be visibly wrong.
-
-One standing caveat that cuts across all of the above: the whole development is stated over a
-general commutative base ring `R`, not over a field `k`. That is more general than the roadmap's
-starting hypothesis and costs nothing so far, but every geometric notion the later layers need
-(connectedness, smoothness, unipotence, reductivity) is defined after base change to `k̄` and none
-of that has been set up.
+Layer 0 is done, third view included: the points functor is corepresentable, full and faithful.
+Layer 1 has comodules, subcomodules, matrix coefficients and their subalgebra, duals, rigidity and
+the finiteness theorems, but not faithfulness as a closed immersion, its matrix-coefficient
+criterion, the embedding theorem or Tannakian reconstruction. Layer 2 has the tangent space, the
+bracket and the differential, and no adjoint action or smoothness criterion. Layer 3 has Hopf
+ideals, closed subgroup schemes, kernels and quotient Hopf algebras, but no normality, no `G/H`,
+no identity component or component group. Layer 4 has the diagonalizable anti-equivalence, `μ_n`
+inside `𝔾ₘ`, and split tori with their perfect pairing; non-split tori, multiplicative type,
+Cartier duality and Jordan decomposition are absent. Layers 5 through 8 and the sheaves-and-descent
+lane are untouched. Worked examples cover `𝔾ₐ`, `𝔾ₘ`, `μ_n`, `αₚ`, split tori, `GLₙ` and `SLₙ`;
+`PGLₙ`, `SOₙ` and `Sp₂ₙ` are absent. Everything is over a general commutative base ring, with
+field, domain or connected-spectrum hypotheses added exactly where needed.
 
 ## The frontier
 
-The nearest targets, roughly in order of how little stands between them and the current state:
-
-- **Duals of finitely generated comodules**, upgrading `FGComoduleCat` from monoidal to rigid.
-  The monoidal structure is finished, so this is the immediate next step in Layer 1 and a
-  prerequisite for anything Tannakian.
-- **The finite-dimensional subcoalgebra theorem**: every element of a coalgebra lies in a
-  finitely generated subcoalgebra, and every comodule is the union of its finitely generated
-  subcomodules. The groundwork is in place (the subcoalgebra lattice with its finiteness lemmas,
-  spans of group-like elements, subcoalgebras as subcomodules of the regular comodule), and the
-  roadmap identifies this as the real engine behind the embedding theorem.
-- **Full faithfulness and essential surjectivity of the diagonalizable coordinate-ring functor**,
-  which would close out the `M ↦ D(M)` anti-equivalence. The functor exists; the two remaining
-  properties are self-contained.
-- **The two Layer 0 scheme-side targets** in `Suggested.lean`: `Γ(G)` as a Hopf algebra for an
-  affine group scheme `G` over `Spec R`, and `Spec A` as a group object for a Hopf algebra `A`.
-  These are still `sorry`, and they are the bottleneck for a large amount of downstream work: the
-  correct definition of faithfulness (a closed immersion `G ↪ GLₙ`), scheme-theoretic kernels as
-  opposed to the kernels-on-points computed so far, the fppf quotient `G/H`, and every geometric
-  notion in Layers 3, 5, and 6. Anyone wanting to unblock the most work should start here.
-- **`GLₙ` as a worked example.** Nothing in the current development names it, and it is needed
-  both as a check on the definitions and as the target of the embedding theorem.
-- **Layer 2 in its entirety** (`Lie(G)`, differentials, the adjoint action). It is untouched, it
-  has no prerequisites that are missing, and the roadmap places it early precisely because Jordan
-  decomposition, root spaces, and the unipotent radical all wait on it.
-
-Blocked rather than merely unstarted: unipotence, the unipotent radical, reductivity, and the
-identity component all need base change to `k̄` and a geometric notion of connectedness, and the
-declaration list contains neither. Working over a general commutative ring rather than a field, as
-the current development does, will have to be revisited at that point, since these notions are
-field-specific.
+- **Faithfulness and the embedding theorem.** The pieces are close together: a `hopfSpec` morphism
+  is a closed immersion exactly when the coordinate map is surjective, the matrix-coefficient
+  subalgebra exists, and the finite subcoalgebra theorem is the engine the roadmap named. Missing
+  are the equivalence of the two definitions of faithful, and then `G ↪ GLₙ`.
+- **Tannakian reconstruction**, newly expressible now that the rigid symmetric monoidal category
+  of finite-dimensional comodules exists. Nothing attempted.
+- **The adjoint representation.** `Lie(G)` and the differential exist; `Ad : G → GL(Lie G)` does
+  not, and Jordan decomposition, root spaces and the unipotent radical all wait on it.
+- **Quotients and the identity component.** Both need the sheaf-and-descent lane, which has not
+  started; the identity component also needs base change to `k̄` and geometric connectedness.
+- **Root data.** The split torus pairing is still the only input in place: no maximal torus in a
+  larger group, no root, no Weyl group, and the intervening unipotence and reductivity layers have
+  not begun.


### PR DESCRIPTION
<!--tauceti-progress-pr:v1 {"from_sha":"ed837d596f81c587c5b9696efed02a869f945e7e","prs":[1505,1508,1514,1516,1518,1521,1617,1620,1626,1627,1632,1640,1644,1651,1652,1661,1664,1669,1671,1672,1674,1676,1678,1683,1689,1691,1692,1694,1696,1697,1709,1711,1729,1753,1776,1805,1809,1813,1815,1816,1817,1818,1825,1831,1833,1841,1843,1845,1853,1856,1862,1863,1869,1889,1905,1906,1910,1921,1924],"roadmap":"ReductiveGroups","to_sha":"11ef09d4d6e560655ed762ace27ef2858e9117cd","version":"f735789ac2b5185f6650f46e91a074fefdee6d68"}-->
This PR records progress on the ReductiveGroups roadmap for the window `ed837d5..11ef09d` of TauCeti `main`, covering 59 merged pull requests.

`STATUS.md` is rewritten as a snapshot at `11ef09d`; `PROGRESS.md` gains one appended section for the window. Both files are machine-owned and their prose is not security-validated.

Pull requests in the window: #1505, #1508, #1514, #1516, #1518, #1521, #1617, #1620, #1626, #1627, #1632, #1640, #1644, #1651, #1652, #1661, #1664, #1669, #1671, #1672, #1674, #1676, #1678, #1683, #1689, #1691, #1692, #1694, #1696, #1697, #1709, #1711, #1729, #1753, #1776, #1805, #1809, #1813, #1815, #1816, #1817, #1818, #1825, #1831, #1833, #1841, #1843, #1845, #1853, #1856, #1862, #1863, #1869, #1889, #1905, #1906, #1910, #1921, #1924

Generated by [TauCetiProgress](https://github.com/TauCetiProject/TauCetiProgress) at `f735789ac2b5185f6650f46e91a074fefdee6d68`.

🤖 Prepared with Claude Code
