### PR TITLE
fix: stop roadmap pull requests colliding on the index list

### DIFF
--- a/.github/scripts/check_roadmap_areas.py
+++ b/.github/scripts/check_roadmap_areas.py
@@ -9,9 +9,20 @@ cannot be removed -- but they can be checked, and regenerated.
 
 Run with no arguments to check (exit 1 on drift); run with `--fix` to repair.
 `--fix` regenerates the two dropdowns wholesale, and heals the README list by
-filling gaps only: it appends a missing roadmap (title from that roadmap's own
-`# ` heading) and drops an orphaned line, but never rewrites an existing entry,
-so the curated order and any hand-shortened titles survive.
+filling gaps only: it inserts a missing roadmap (title from that roadmap's own
+`# ` heading) and drops an orphaned line, but never rewrites the text of an
+existing entry, so hand-shortened titles survive.
+
+The README list is an unnumbered bullet list sorted by title. Both properties
+exist to keep concurrent roadmap pull requests from colliding. When the list
+was numbered, every new roadmap claimed the next integer, so any two open pull
+requests conflicted on the same line and every merge re-broke the rest; and
+inserting mid-list renumbered the whole tail. Without numbers, and sorted, a
+new roadmap touches exactly one line at a position determined by its own
+title, so two pull requests conflict only when their titles are adjacent.
+
+The item pattern still accepts the old `N. ` form so that pull requests written
+against the numbered list keep parsing; `--fix` normalizes them to bullets.
 """
 
 from __future__ import annotations
@@ -81,9 +92,11 @@ def title_from_h1(area: str) -> str:
     return area
 
 
-# A line in the README's "## Roadmaps" list: `N. [Title](TauCetiRoadmap/X/README.md)`.
+# A line in the README's "## Roadmaps" list: `- [Title](TauCetiRoadmap/X/README.md)`.
+# The legacy `N. ` bullet is still accepted so that pull requests opened against
+# the numbered list keep parsing; `--fix` rewrites them as `- `.
 _README_ITEM = re.compile(
-    r"^\d+\.\s+\[(?P<title>.+?)\]\(TauCetiRoadmap/(?P<area>[^/]+)/README\.md\)\s*$"
+    r"^(?:-|\d+\.)\s+\[(?P<title>.+?)\]\(TauCetiRoadmap/(?P<area>[^/]+)/README\.md\)\s*$"
 )
 _README_SECTION = re.compile(r"(?ms)^(## Roadmaps\n\n)(?P<body>.*?)(\n## )")
 
@@ -104,11 +117,12 @@ def readme_entries() -> list[tuple[str, str]]:
 def rewrite_readme(text: str, canonical: list[str]) -> str:
     """Fill gaps in the README list without touching anything else.
 
-    Replace only the contiguous run of numbered list lines: keep every existing
-    entry whose directory still exists (in order, with its curated title), drop
-    an orphaned line, drop a duplicate, append any roadmap not yet listed (title
-    from its H1), and renumber. Prose before or after the list -- an intro
-    sentence, a note -- is left exactly as it is.
+    Replace only the contiguous run of list lines: keep every existing entry
+    whose directory still exists (with its curated title), drop an orphaned
+    line, drop a duplicate, add any roadmap not yet listed (title from its H1),
+    and emit the result as an unnumbered bullet list sorted by title. Prose
+    before or after the list -- an intro sentence, a note -- is left exactly as
+    it is.
     """
     m = _README_SECTION.search(text)
     if not m:
@@ -135,13 +149,16 @@ def rewrite_readme(text: str, canonical: list[str]) -> str:
         if a in present and a not in seen:
             seen.add(a)
             kept.append((a, t))
-    for area in canonical:  # canonical is sorted, so new entries append stably
+    for area in canonical:
         if area not in seen:
             seen.add(area)
             kept.append((area, title_from_h1(area)))
 
+    # Sorted by title, so a new roadmap lands at a position fixed by its own
+    # title rather than at the end, where every other new roadmap would land.
+    kept.sort(key=lambda entry: entry[1].casefold())
     lines[start : end + 1] = [
-        f"{i}. [{t}](TauCetiRoadmap/{a}/README.md)" for i, (a, t) in enumerate(kept, 1)
+        f"- [{t}](TauCetiRoadmap/{a}/README.md)" for a, t in kept
     ]
     return text[: m.start("body")] + "\n".join(lines) + text[m.end("body") :]
 
@@ -171,17 +188,18 @@ def main() -> int:
             detail.append("out of order")
         problems.append(f"{path.relative_to(ROOT)}: {', '.join(detail)}")
 
-    # The README list keeps its curated order and titles; we only fill gaps
-    # (append a missing roadmap, drop an orphaned line). Existing lines are
-    # never rewritten, so any hand-shortened title survives.
+    # The README list keeps its curated titles, but its membership, bullet form,
+    # and title order are all derived. Compare against the healed rendering so
+    # that a stray number or a misplaced line is caught, not just a missing
+    # roadmap; existing lines are never retitled, so hand-shortened titles
+    # survive.
     rm_text = README.read_text()
     listed = [a for a, _ in readme_entries()]
-    if sorted(listed) != canonical:  # multiplicity matters, so duplicates show up
+    healed = rewrite_readme(rm_text, canonical)
+    if healed != rm_text:
         if fix:
-            new = rewrite_readme(rm_text, canonical)
-            if new != rm_text:
-                README.write_text(new)
-                print(f"fixed: {README.relative_to(ROOT)}")
+            README.write_text(healed)
+            print(f"fixed: {README.relative_to(ROOT)}")
         else:
             missing = [a for a in canonical if a not in listed]
             extra = [a for a in set(listed) if a not in set(canonical)]
@@ -193,6 +211,8 @@ def main() -> int:
                 detail.append(f"links a roadmap with no directory {extra}")
             if dups:
                 detail.append(f"listed more than once {dups}")
+            if not detail:
+                detail.append("not an unnumbered list sorted by title")
             problems.append(f"README.md: {', '.join(detail)}")
 
     if problems and not fix:

--- a/README.md
+++ b/README.md
@@ -11,22 +11,22 @@ Tau Ceti is being incubated by the [Lean FRO](https://lean-lang.org/fro/) and th
 
 ## Roadmaps
 
-1. [Universal covers](TauCetiRoadmap/UniversalCovers/README.md)
-2. [The Jacobian challenge](TauCetiRoadmap/JacobianChallenge/README.md)
-3. [Reductive algebraic groups](TauCetiRoadmap/ReductiveGroups/README.md)
-4. [Partial differential equations](TauCetiRoadmap/PDE/README.md)
-5. [Combinatorial Heegaard Floer and grid homology](TauCetiRoadmap/CombinatorialHeegaardFloer/README.md)
-6. [Heegaard Floer homology, analytically](TauCetiRoadmap/HeegaardFloer/README.md)
-7. [Multiquadratic fields and genus theory](TauCetiRoadmap/Multiquadratic/README.md)
-8. [Geometric topology and the Kirby-list problems](TauCetiRoadmap/GeometricTopology/README.md)
-9. [One-parameter semigroups, completely monotone functions, and BCR Bochner](TauCetiRoadmap/OneParameterSemigroups/README.md)
-10. [Exchangeability and de Finetti](TauCetiRoadmap/Exchangeability/README.md)
-11. [Conformal mapping and the geometric theory of holomorphic functions](TauCetiRoadmap/ConformalMapping/README.md)
-12. [Weighted orthogonal L² bases: completeness, Hilbert bases, and products of orthogonal systems](TauCetiRoadmap/OrthogonalL2Bases/README.md)
-13. [Contour integration and the Hungerbühler–Wasem generalized residue theorem](TauCetiRoadmap/ContourIntegration/README.md)
-14. [Representation theory (semisimple algebras, character tables, Lie and classical groups, Schur-Weyl, Peter-Weyl)](TauCetiRoadmap/RepresentationTheory/README.md)
-15. [Modular forms — Hecke theory, newforms, and L-functions](TauCetiRoadmap/ModularForms/README.md)
-16. [Optimal transport and Wasserstein geometry](TauCetiRoadmap/OptimalTransport/README.md)
+- [Combinatorial Heegaard Floer and grid homology](TauCetiRoadmap/CombinatorialHeegaardFloer/README.md)
+- [Conformal mapping and the geometric theory of holomorphic functions](TauCetiRoadmap/ConformalMapping/README.md)
+- [Contour integration and the Hungerbühler–Wasem generalized residue theorem](TauCetiRoadmap/ContourIntegration/README.md)
+- [Exchangeability and de Finetti](TauCetiRoadmap/Exchangeability/README.md)
+- [Geometric topology and the Kirby-list problems](TauCetiRoadmap/GeometricTopology/README.md)
+- [Heegaard Floer homology, analytically](TauCetiRoadmap/HeegaardFloer/README.md)
+- [Modular forms — Hecke theory, newforms, and L-functions](TauCetiRoadmap/ModularForms/README.md)
+- [Multiquadratic fields and genus theory](TauCetiRoadmap/Multiquadratic/README.md)
+- [One-parameter semigroups, completely monotone functions, and BCR Bochner](TauCetiRoadmap/OneParameterSemigroups/README.md)
+- [Optimal transport and Wasserstein geometry](TauCetiRoadmap/OptimalTransport/README.md)
+- [Partial differential equations](TauCetiRoadmap/PDE/README.md)
+- [Reductive algebraic groups](TauCetiRoadmap/ReductiveGroups/README.md)
+- [Representation theory (semisimple algebras, character tables, Lie and classical groups, Schur-Weyl, Peter-Weyl)](TauCetiRoadmap/RepresentationTheory/README.md)
+- [The Jacobian challenge](TauCetiRoadmap/JacobianChallenge/README.md)
+- [Universal covers](TauCetiRoadmap/UniversalCovers/README.md)
+- [Weighted orthogonal L² bases: completeness, Hilbert bases, and products of orthogonal systems](TauCetiRoadmap/OrthogonalL2Bases/README.md)
 
 ## Completed roadmaps
 


### PR DESCRIPTION
This PR makes the root README's roadmap index an unnumbered list sorted by title, so that concurrent roadmap pull requests stop colliding on it.

Every roadmap pull request adds itself to that list, and while the list was numbered each of them claimed the same next integer and conflicted on the same line. Merging any one of them re-broke all the others, and inserting mid-list would have renumbered the whole tail, so sorting alone would not have helped. Nine open pull requests needed hand repair for exactly this reason, and merging #76 has just re-broken the ones that add an entry.

Without numbers and sorted by title, a new roadmap touches a single line at a position determined by its own title, so two pull requests conflict only when their titles happen to be adjacent. Adding "Adic spaces, up to the Fargues–Fontaine curve" and "Stable reduction and stable maps" to the same base now merges cleanly.

The checker compares the list against its healed rendering rather than only against its membership, so a stray number or a misplaced line is reported and `--fix` repairs it, instead of drifting unnoticed until the next roadmap lands. The item pattern still accepts the old `N. ` bullet, so the roadmap pull requests already open against the numbered list keep parsing, and `--fix` normalizes them to bullets as they land.

🤖 Prepared with Claude Code
