### PR TITLE
Pin the Bourbaki numbering and an integral root datum

### DIFF
--- a/TauCetiRoadmap/RepresentationTheory/RootSystems/README.md
+++ b/TauCetiRoadmap/RepresentationTheory/RootSystems/README.md
@@ -202,7 +202,8 @@ upstream.
 `Suggested.lean` pins the load-bearing objects (`posRoots`, `inversions`,
 `inversions_ncard_mul_ofIdx`, `coxeterMatrixOfBase`, `weylCoxeterSystem`, `dominantChamber`,
 `longestElement`, `DynkinType`, `DynkinType.Valid`, `DynkinType.cartanMatrix`, `IsFiniteType`,
-`existsUnique_dynkinType`, `exists_rootPairing_of_dynkinType`) and the milestones below as
+`existsUnique_dynkinType`, `exists_rootPairing_of_dynkinType`, `DynkinType.IsLongSimpleRoot`,
+`DynkinType.numRoots`, `DynkinType.simplyConnectedRootDatum`) and the milestones below as
 `sorry`-targets, so each is claimable and the summit statements are machine-checked to be expressible
 against the pinned Mathlib.
 
@@ -353,6 +354,41 @@ topology.
   (as a `RootPairing`) to the root system of a **unique valid** `DynkinType t` - a bijection between
   isomorphism classes of such root systems and the valid Dynkin types.
 
+### Layer 6: the Bourbaki numbering and integral root data
+
+Layer 5 classifies root systems up to isomorphism, and `exists_rootPairing_of_dynkinType` realizes
+each valid type. That is not enough for a consumer that needs a *carrier*: an existence statement can
+only be turned into data by `Classical.choose`, and a development that then builds a group out of the
+chosen root system has no way to show a reviewer what its group is made of. The
+CFSG statement roadmap ([Add CFSG statement roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/pull/156)) needs exactly this, for the
+Chevalley--Demazure construction of the finite groups of Lie type, and it is not the only consumer:
+any explicit construction of a semisimple group scheme starts here.
+
+- **Pin the node numbering.** `DynkinType.cartanMatrix` is indexed by the Bourbaki labels, with
+  Bourbaki node `i` at `Fin` index `i - 1`, and `cartanMatrix t i j = ⟨α_i, α_j^∨⟩`. This is
+  currently unstated, so nothing downstream can say which node is which. Fix it as part of pinning
+  `cartanMatrix` itself: the `A_n` chain in order; the `B_n`/`C_n` double edge between the last two
+  nodes, short last in `B_n` and long last in `C_n`; the `D_n` fork at index `n - 3`; Bourbaki's
+  branch node for `E₆`, `E₇`, `E₈`; `F₄` long then short; and `G₂` short then long, giving
+  `!![2, -1; -3, 2]` as the worked example below already records. Add
+  `DynkinType.IsLongSimpleRoot` so downstream length-exchanging maps have something to refer to.
+  Zero-based `Fin` indices against one-based Bourbaki labels are the standing trap here, so state the
+  offset rather than leaving it to be inferred.
+
+- **A named datum per valid type.** `DynkinType.simplyConnectedRootDatum t ht`, a `RootDatum` over
+  `ℤ` with roots indexed by `Fin t.numRoots` and both lattices pinned to `Fin t.rank → ℤ`: the
+  cocharacter lattice with the simple coroots as its standard basis, the character lattice with the
+  fundamental weights as its standard basis, so that `⟨ω_i, α_j^∨⟩ = δ_ij` and the simple root `α_i`
+  is the `i`-th row of the Cartan matrix. The first `t.rank` root indices are the simple roots in
+  Bourbaki order, and `DynkinType.simplyConnectedBase` is the corresponding base. Acceptance is
+  `DynkinType.hasCartanType_simplyConnectedRootDatum`, which says the pinned datum realizes its own
+  type against the pinned numbering, and `DynkinType.span_coroot_simplyConnectedRootDatum`, which
+  says the form is the simply connected one. The adjoint form is `RootPairing.flip` of the dual
+  type's datum, not a second pinned definition.
+
+  `DynkinType.numRoots` is part of this: `n(n+1)` for `A n`, `2n²` for `B n` and `C n`, `2n(n-1)`
+  for `D n`, and `72, 126, 240, 48, 12` for the exceptional types.
+
 ## Worked examples (acceptance criteria)
 
 - **`Aₙ` and the symmetric group.** Fix the indexing convention once: type `A n` (for `n ≥ 1`) has
@@ -391,8 +427,11 @@ action and the length-equals-inversions identity. Layer 5 (the classification) n
 positive-definite geometry that bounds the Cartan matrices; its uniqueness half (`existsUnique_dynkinType`)
 and its realization half (`exists_rootPairing_of_dynkinType`, explicit coordinate models) are
 independent and proceed in parallel, and the final isomorphism step consumes `equivOfCartanMatrixEq`.
-The worked examples are built alongside the layer that first makes them expressible: `Aₙ` after Layer
-2, `G₂` after Layer 5.
+Layer 6 (the Bourbaki numbering and the pinned integral root data) needs only the `DynkinType`
+enumeration and its Cartan matrices, so it does not wait on either half of Layer 5, and the numbering
+convention should be fixed at the same time as `DynkinType.cartanMatrix` rather than afterwards. The
+worked examples are built alongside the layer that first makes them expressible: `Aₙ` after Layer 2,
+`G₂` after Layer 5.
 
 ## References
 

--- a/TauCetiRoadmap/RepresentationTheory/RootSystems/Suggested.lean
+++ b/TauCetiRoadmap/RepresentationTheory/RootSystems/Suggested.lean
@@ -308,7 +308,7 @@ Bourbaki node `i` sits at `Fin` index `i - 1`, and `cartanMatrix t i j = ⟨α_i
 the `A_n` chain runs `0, 1, …, n - 1` in order; `B_n` and `C_n` continue that chain with the double
 edge between `n - 2` and `n - 1`, the short simple root being the last node of `B_n` and the long
 one the last node of `C_n`; `D_n` forks at `n - 3`, with `n - 2` and `n - 1` the two fork nodes;
-`E_n` follows Bourbaki with node `1` (index `1`) the branch node off the `1-3-4-5-6` chain; `F₄` has
+`E_n` follows Bourbaki with node `2` (index `1`) the branch node off the `1-3-4-5-6` chain; `F₄` has
 `0, 1` long and `2, 3` short; and `G₂` has `0` short and `1` long, giving `!![2, -1; -3, 2]`.
 
 Anything that permutes simple roots must be stated against this numbering, and zero-based `Fin`

--- a/TauCetiRoadmap/RepresentationTheory/RootSystems/Suggested.lean
+++ b/TauCetiRoadmap/RepresentationTheory/RootSystems/Suggested.lean
@@ -296,6 +296,71 @@ theorem exists_rootPairing_of_dynkinType (t : DynkinType) (ht : t.Valid) :
       (_hirr : P.IsIrreducible),
       @HasCartanType (Fin t.rank) ℚ (Fin t.rank → ℚ) (Fin t.rank → ℚ) _ _ _ _ _ P hcrys b t := sorry
 
+/-! ## Layer 6: the Bourbaki numbering and integral root data
+
+Layer 5 classifies root systems up to isomorphism. Downstream constructions need something stronger:
+a *named* root datum over `ℤ` for each valid type, with its nodes numbered, rather than an existence
+theorem they would have to `Classical.choose` from. The Chevalley--Demazure construction consumed by
+the CFSG statement roadmap ([Add CFSG statement roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/pull/156)) is the immediate consumer. -/
+
+/-- **The Bourbaki node numbering**, pinned once. `DynkinType.cartanMatrix t` is indexed so that
+Bourbaki node `i` sits at `Fin` index `i - 1`, and `cartanMatrix t i j = ⟨α_i, α_j^∨⟩`. Concretely:
+the `A_n` chain runs `0, 1, …, n - 1` in order; `B_n` and `C_n` continue that chain with the double
+edge between `n - 2` and `n - 1`, the short simple root being the last node of `B_n` and the long
+one the last node of `C_n`; `D_n` forks at `n - 3`, with `n - 2` and `n - 1` the two fork nodes;
+`E_n` follows Bourbaki with node `1` (index `1`) the branch node off the `1-3-4-5-6` chain; `F₄` has
+`0, 1` long and `2, 3` short; and `G₂` has `0` short and `1` long, giving `!![2, -1; -3, 2]`.
+
+Anything that permutes simple roots must be stated against this numbering, and zero-based `Fin`
+indices are the trap: a diagram automorphism written as "`1 ↔ 6`" in Bourbaki labels is
+`0 ↔ 5` here. -/
+def DynkinType.IsLongSimpleRoot : (t : DynkinType) → Fin t.rank → Prop
+  | .A _, _ => True
+  | .D _, _ => True
+  | .E6, _ | .E7, _ | .E8, _ => True
+  | .B n, i => (i : ℕ) + 1 < n
+  | .C n, i => (i : ℕ) + 1 = n
+  | .F4, i => (i : ℕ) < 2
+  | .G2, i => (i : ℕ) = 1
+
+/-- The number of roots of each Dynkin type, so that the root index set of the pinned datum below can
+be `Fin t.numRoots` rather than an abstract type. -/
+def DynkinType.numRoots : DynkinType → ℕ
+  | .A n => n * (n + 1)
+  | .B n | .C n => 2 * n ^ 2
+  | .D n => 2 * n * (n - 1)
+  | .E6 => 72 | .E7 => 126 | .E8 => 240 | .F4 => 48 | .G2 => 12
+
+/-- **The pinned simply connected root datum** of a valid Dynkin type. Both lattices are
+`Fin t.rank → ℤ`: the cocharacter lattice has the simple coroots as its standard basis, and the
+character lattice has the fundamental weights as its standard basis, so `⟨ω_i, α_j^∨⟩ = δ_ij` and
+the simple root `α_i` is the `i`-th row of `DynkinType.cartanMatrix t`. Roots are indexed by
+`Fin t.numRoots`, with the first `t.rank` indices the simple roots in Bourbaki order.
+
+This is a definition, not an existence statement, and that is the point: a consumer that needs a
+carrier must be able to unfold to explicit data rather than choose one from
+`exists_rootPairing_of_dynkinType`. -/
+def DynkinType.simplyConnectedRootDatum (t : DynkinType) (_ht : t.Valid) :
+    RootDatum (Fin t.numRoots) (Fin t.rank → ℤ) (Fin t.rank → ℤ) := sorry
+
+/-- The base of the pinned datum, supported on the first `t.rank` root indices in Bourbaki order. -/
+def DynkinType.simplyConnectedBase (t : DynkinType) (ht : t.Valid) :
+    (t.simplyConnectedRootDatum ht).Base := sorry
+
+/-- The pinned datum realizes its own type, against the pinned numbering. Together with
+`DynkinType.simplyConnectedRootDatum` this replaces `exists_rootPairing_of_dynkinType` for consumers
+that need a named carrier. -/
+theorem DynkinType.hasCartanType_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
+    ∃ _hcrys : (t.simplyConnectedRootDatum ht).IsCrystallographic,
+      HasCartanType (t.simplyConnectedRootDatum ht) (t.simplyConnectedBase ht) t := sorry
+
+/-- The pinned datum is the **simply connected** form: its cocharacter lattice is spanned by the
+coroots. The adjoint form is the dual choice, with the character lattice spanned by the roots; a
+consumer that needs it takes `RootPairing.flip` of the corresponding datum rather than a second
+pinned definition. -/
+theorem DynkinType.span_coroot_simplyConnectedRootDatum (t : DynkinType) (ht : t.Valid) :
+    Submodule.span ℤ (Set.range (t.simplyConnectedRootDatum ht).coroot) = ⊤ := sorry
+
 /-! ## Worked examples (acceptance criteria) -/
 
 /-- **`Aₙ` and the symmetric group.** A root system whose Cartan matrix is of type `A n` (with


### PR DESCRIPTION
This PR adds Layer 6 to the root-systems roadmap: a named simply connected root datum over `ℤ` for each valid Dynkin type, and the node numbering its Cartan matrices are indexed by.

Layer 5 classifies root systems up to isomorphism, and `exists_rootPairing_of_dynkinType` realizes each valid type, but both are existence statements. A consumer that needs a carrier can only reach one through `Classical.choose`, and can then no longer show a reviewer what its objects are built from. `DynkinType.simplyConnectedRootDatum` pins both lattices to `Fin t.rank → ℤ`, the cocharacter lattice on the simple coroots and the character lattice on the fundamental weights, with roots indexed by `Fin t.numRoots` and the simple roots first in Bourbaki order.

The numbering is currently unstated, so nothing downstream can name a simple root or say which node a diagram automorphism moves. One-based Bourbaki labels against zero-based `Fin` indices are the standing trap here, so the offset is written down rather than left to be inferred, and `DynkinType.IsLongSimpleRoot` gives length-exchanging maps something to refer to. Both belong with `DynkinType.cartanMatrix` itself rather than after it.

Requested by the CFSG statement roadmap (https://github.com/TauCetiProject/TauCetiRoadmap/pull/156), which needs both for the Chevalley-Demazure construction of the finite groups of Lie type, and which pins its own diagram permutations against this numbering.

Checked with `lake env lean TauCetiRoadmap/RepresentationTheory/RootSystems/Suggested.lean` and `python3 .github/scripts/check_roadmap_areas.py`.

🤖 Prepared with Claude Code