### PR TITLE
doc: state the Mathlib relationship and the missing roadmap principles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,17 @@
+# Tau Ceti roadmaps
+
+Read [`README.md`](../README.md) before doing anything in this repository. It is normative, not
+background: the **Writing a roadmap** section is the standing checklist that all roadmap content is
+held against, and it covers how we relate to Mathlib (defer to Mathlib, never wait for it, never
+push work to it).
+
+Read [`CONTRIBUTING.md`](../CONTRIBUTING.md) as well before opening or reviewing a pull request.
+
+## Reviewing a pull request
+
+Generic praise is not helpful and wastes the author's time. Don't open with an assessment of how
+good the PR is, don't summarise back what it does, and don't pad each finding with a compliment.
+Get straight to the defects that need fixing, most important first, and say concretely what is
+wrong and what would fix it. Specific praise is fine where it carries information, for example that
+a design choice resolves a problem the author raised or that a proof is already the right shape;
+"this is nice work" carries none.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.claude/CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -64,58 +64,94 @@ A roadmap is a specification for material we want added to Tau Ceti, written so 
 reviewers, can act on it without guessing.
 
 - **Build the library, don't race to the theorem.** For each object you introduce, ask for its
-  complete basic theory, not just the lemma the headline needs.
-  Named theorems are milestones inside a fuller development, not the whole of it.
+  complete basic theory, not just the lemma the headline needs. Named theorems are milestones
+  inside a fuller development, not the whole of it. Mario's rule from Mathlib's early days still
+  applies: when you make a definition, it is your job to make it *usable*, which means the right
+  amount of API. A definition with no lemmas about it is not a contribution.
 
-- **Everything is grounded, with no leaps.** Every milestone must rest on existing Mathlib or
-  Tau Ceti material, on earlier material in the same roadmap, or on an explicitly cited
-  dependency in another roadmap. Anything else is a leap: a forward reference to a later layer, a
-  connection between two developments that nobody builds, an object named but never made a
-  target. If the roadmap needs something that doesn't exist, building it must itself be a target,
-  here or in a roadmap you cite. The bigger the gap, the worse AIs do with it.
+- **No gaps.** Every milestone must rest on existing Mathlib or Tau Ceti material, on earlier
+  material in the same roadmap, or on an explicitly cited dependency in another roadmap. Anything
+  else is a leap: a forward reference to a later layer, a connection between two developments that
+  nobody builds, an object named but never made a target. If the roadmap needs something that
+  doesn't exist, building it must itself be a target, here or in a roadmap you cite. The bigger the
+  gap, the worse AIs do with it.
 
-- **Check what's already in motion.** Before specifying an object, search Zulip and the open Mathlib
-  PRs for it — someone may already be building the API, settling the design, or have formalized it.
-  Cite what you find, follow the direction it's taking, and flag milestones that will refactor onto
-  in-flight Mathlib work once it lands. Reinventing an API Mathlib is already building, or picking a
-  convention the community is deciding against, wastes the work.
+- **Every item must be unambiguous.** A reasonably clever agent has to be able to work out exactly
+  which definition or theorem you mean, without guessing between candidates.
+
+- **Clear boundaries.** We keep roadmaps non-overlapping as far as we can, and where one depends on
+  material from another, that dependency is stated. Minimize the number of words a reader needs in
+  order to decide whether something is in scope; jagged boundaries make that impossible.
+
+- **Be definite about scope.** Nothing is "optional", "deferred" or "for later": don't use the
+  words and don't imply them. Everything on a roadmap is work we want. Sequencing is good, so split
+  into milestones and put the harder material later, but every item lives in *some* milestone, or a
+  contributor may misread "later" as "never". Decide the generality up front and write it down,
+  rather than recommending intermediate implementations that will be replaced.
+
+- **Roadmaps are timeless.** They say what we want, not how they came to say it. Don't call an item
+  "blocked" because an earlier roadmap is still being implemented; point at that roadmap instead.
+  When revising, don't leave war stories about why or how the roadmap changed, and don't refer to
+  the review process. Someone reading a year from now should not be able to tell which parts were
+  contentious.
+
+- **Aim for reusable material.** This one is a *should*, not a *must*, but it is what makes a
+  roadmap pay for itself beyond its own headline.
+
+- **Deep or broad is up to you.** Broad roadmaps are usually better: if we are doing
+  representation theory, let's cover everything taught in graduate classes at more than one
+  university. Breadth makes boundaries easier to draw and optimizes for reuse. But roadmaps also
+  have to *motivate* people to contribute, and a deep one is sometimes better at that.
+
+### Working with Mathlib
 
 - **Use Mathlib's vocabulary.** Where Mathlib already has a way to say something, use it rather
   than a private version, both in the roadmap and in the code. A standard notion said in our own
   dialect drifts from the library it builds on and grows a redundant theory of lemmas Mathlib
-  already proves. As an example: Mathlib has no "bounded on a set" predicate, so a
-  result that needs an explicit bound carries `∀ x ∈ s, ‖f x‖ ≤ C` directly in its hypotheses (as
-  in `norm_cfc_le`), and uses `Bornology.IsBounded` when no constant is needed
-  (`isBounded_iff_forall_norm_le'` relates the two). We do the same, and never wrap a one-line
-  bound in a new predicate. When Mathlib's name for something is itself a Mathlib-ism that a
-  mathematician would not recognize (`ModularFormClass`, say), link the Mathlib declaration the
-  first time you use it, so a reader can see what the term denotes rather than guess.
+  already proves. For example: Mathlib has no "bounded on a set" predicate, so a result needing an
+  explicit bound carries `∀ x ∈ s, ‖f x‖ ≤ C` directly in its hypotheses (as in `norm_cfc_le`), and
+  uses `Bornology.IsBounded` when no constant is needed (`isBounded_iff_forall_norm_le'` relates
+  the two). We do the same, and never wrap a one-line bound in a new predicate. When Mathlib's name
+  is itself a Mathlib-ism a mathematician would not recognize (`ModularFormClass`, say), link the
+  declaration the first time you use it.
+
+- **Defer to Mathlib.** Before specifying an object, search Zulip and the open Mathlib PRs for it.
+  Someone may already have formalized it or settled its design. **Mathlib owns its API decisions.**
+  Tau Ceti adopts the resulting design and refactors when it lands. Cite what you find, follow the
+  direction it takes, and don't argue for a Tau Ceti spelling against Mathlib's.
+
+- **But never wait.** Deferring to Mathlib is about *shape*, never about *timing*. An open Mathlib
+  PR covering ground a roadmap needs is not a blocker, not a reason to leave a gap, and not a
+  reason to send contributors elsewhere: build the thing here, now, naming and shaping it the way
+  that PR does so the eventual swap is a deletion plus an import rather than a rewrite. If it
+  lands, we delete ours and adopt Mathlib's; if it doesn't, we already have what we needed. Nothing
+  on a roadmap is ever "pending upstream".
+
+- **Never push work to Mathlib.** Tau Ceti material is built in Tau Ceti and stays there. Plenty of
+  it would make good Mathlib material, and Mathlib contributors are welcome to take any of it at
+  any time, but deciding what Mathlib absorbs is solely theirs. So don't write a roadmap item as
+  "to be upstreamed", don't hold one back because it "really belongs in Mathlib", and don't treat
+  opening a Mathlib pull request as part of discharging a target.
+
+### Porting existing work
 
 - **Specify the mathematics, not your existing code.** Say what each milestone should prove,
-  intrinsically, so a reviewer can judge it on its own terms.
-  A Tau Ceti roadmap may direct either a greenfield development, where the checks above have
-  identified no existing formalization, or the integration of existing work into Tau Ceti.
+  intrinsically, so a reviewer can judge it on its own terms. A roadmap may direct either a
+  greenfield development or the integration of existing work into Tau Ceti.
 
-- **Coordinate before integrating existing work.** Work with the authors of the existing material
-  and obtain their agreement before integrating it. If coordination is not possible, do not assume
-  that mathematical overlap permits reuse of their code: verify that its licence permits the
-  intended copying or adaptation, and discuss the plan on the Lean Zulip before proceeding so the
-  community can provide input. A roadmap that independently develops the same mathematics should
-  still cite the existing work and coordinate where possible to avoid needless duplication or
-  incompatible design choices.
+- **Coordinate first.** Work with the authors of the existing material and obtain their agreement
+  before integrating it. If coordination is not possible, do not assume that mathematical overlap
+  permits reuse of their code: verify that its licence permits the intended copying or adaptation,
+  and discuss the plan on the Lean Zulip first. A roadmap that independently develops the same
+  mathematics should still cite the existing work and coordinate where possible, to avoid needless
+  duplication or incompatible design choices.
 
-- **Improve existing work rather than canonizing it.** When porting material, do not write the
-  roadmap merely to follow the existing formalization. Apply all the principles above and use the
-  review process to make the result more general, reusable, and maintainable. Put any file-by-file
-  map in a clearly secondary provenance section so reviewers do not treat the source code as
-  prescriptive or exemplary.
+- **Improve it rather than canonizing it.** Do not write the roadmap merely to follow the existing
+  formalization; apply all the principles above to make the result more general, reusable and
+  maintainable. Put any file-by-file map in a clearly secondary provenance section, so that nobody
+  treats the source code as prescriptive.
 
-- **Nothing is "optional".** Don't use the word, and don't imply it. Everything on a roadmap is
-  work we want. Sequencing is good, so split into milestones and put the harder material later,
-  but every item lives in *some* milestone, or a contributor may misread "later" as "never".
-
-- **Do things right the first time.** Decide the generality up front and write it down. Don't
-  recommend intermediate implementations that will be replaced later.
+### Prototyping
 
 - **Write Lean code.** It's really helpful to prototype signatures, particularly for structures,
   classes, and definitions, by writing Lean code, either embedded in markdown or in associated


### PR DESCRIPTION
This PR states the three rules governing Tau Ceti's relationship to Mathlib, and folds into the roadmap checklist the principles from the [Getting started: roadmaps](https://leanprover.zulipchat.com/#narrow/channel/610393-Tau-Ceti/topic/Getting.20started.3A.20roadmaps) Zulip topic that it did not yet spell out.

The Mathlib rules become a new "Working with Mathlib" group. Defer to Mathlib: where it has decided something, or is visibly deciding it, that decision is ours too and we refactor onto whatever lands. But never wait: an open Mathlib PR covering ground a roadmap needs is not a blocker and not a reason to leave a gap, so build the thing here, now, named and shaped to match, and delete ours if theirs lands. And never push work to Mathlib: plenty of Tau Ceti material would make good Mathlib material and Mathlib contributors are welcome to take any of it, but deciding what Mathlib absorbs is solely theirs, so no roadmap item is written as "to be upstreamed" or held back because it "really belongs in Mathlib".

From the Zulip topic: every item must be unambiguous, roadmaps need clear boundaries, roadmaps must be definite about scope, and roadmaps are timeless, meaning no calling an item "blocked" because an earlier roadmap is still being implemented, no war stories about why a roadmap changed, and no references to the review process. Material should aim to be reusable, and depth versus breadth stays the author's call, with the reasons for preferring breadth recorded. Kevin's point that a definition is not a contribution until it has API joins "build the library, don't race to the theorem".

To stop the section growing, the porting and prototyping bullets are grouped under headings, the overlapping "nothing is optional" and "do things right the first time" bullets are merged, and the vocabulary bullet is tightened. Six principles are added for about thirty lines.

Also adds `.claude/CLAUDE.md`, with `AGENTS.md` as a symlink to it, so an agent entering the repository is pointed at the checklist and at `CONTRIBUTING.md` before it does anything else. It carries one further instruction: when reviewing a pull request, skip the generic praise and go straight to the defects.

Written with Claude Opus 5.

🤖 Prepared with Claude Code