### PR TITLE
roadmap(ModularForms): stop waiting on unmerged Mathlib stacks

### DIFF
--- a/TauCetiRoadmap/ModularForms/README.md
+++ b/TauCetiRoadmap/ModularForms/README.md
@@ -167,32 +167,35 @@ Pin these conventions before writing code — implementors make bad, divergent c
   `EulerProduct/*`).
 - **Number fields:** `NumberField`, `IntermediateField`, the Galois theory of `ℚ̄/ℚ` — the target
   of the coefficient-field layer.
-- **The abstract Hecke ring (landing now — July 2026):**
+- **The abstract Hecke ring, definitions only:**
   [`NumberTheory/HeckeRing/Defs.lean`](https://github.com/leanprover-community/mathlib4/pull/41251)
   has the Hecke-triple compatibility class `IsHeckeTriple Δ H₁ H₂` (commensurable subgroups of a
   common submonoid `Δ` lying in their commensurator — the finiteness making `H₁gH₂` a finite
   union of left cosets), the double-coset basis `HeckeCoset Δ H₁ H₂`, the coset module
   `HeckeCosetModule Δ H₁ H₂ Z`, and the Hecke ring `HeckeRing Δ H Z` (notation `𝕋`), on top of
-  `GroupTheory/DoubleCoset` and `GroupTheory/Commensurable`. The **convolution product, identity,
-  and associativity** are the open review stack
-  [#41253](https://github.com/leanprover-community/mathlib4/pull/41253)–[#41256](https://github.com/leanprover-community/mathlib4/pull/41256), [#41277](https://github.com/leanprover-community/mathlib4/pull/41277), [#41279](https://github.com/leanprover-community/mathlib4/pull/41279), and [#41328](https://github.com/leanprover-community/mathlib4/pull/41328),
-  upstreamed from AINTLIB's `HeckeRIngs/AbstractHeckeRing/*`. Layer 2 **consumes** this; do not
-  re-found the abstract ring in `TauCeti/`.
-- **The Sturm bound — level one merged, finite index in review:**
-  `ModularForm.sturm_bound_levelOne` and the even-weight dimension formula
-  `ModularForm.dimension_level_one` (`LevelOne/DimensionFormula.lean`,
-  [#38993](https://github.com/leanprover-community/mathlib4/pull/38993)); the finite-index Sturm
-  bound `ModularForm.sturm_bound_finiteIndex` with a `Module.Finite ℂ (ModularForm 𝒢 k)`
-  instance — finite-dimensionality at **every** level — is the open stack
-  [#39000](https://github.com/leanprover-community/mathlib4/pull/39000)
-  (+[#39083](https://github.com/leanprover-community/mathlib4/pull/39083)/[#39086](https://github.com/leanprover-community/mathlib4/pull/39086)/[#39087](https://github.com/leanprover-community/mathlib4/pull/39087)/[#39088](https://github.com/leanprover-community/mathlib4/pull/39088):
-  cusp widths, the modular norm map and its `q`-expansion decomposition). Layer 10 **consumes**
-  finite-dimensionality from here; the exact dimension formulas remain the hard target.
+  `GroupTheory/DoubleCoset` and `GroupTheory/Commensurable`. Consume these, and do not re-found
+  them in `TauCeti/`. The **convolution product, identity, and associativity** are *not* in
+  Mathlib; they are a Layer 2 target here (see below).
+- **The Sturm bound, level one only:** `ModularForm.sturm_bound_levelOne` and the even-weight
+  dimension formula `ModularForm.dimension_level_one` (`LevelOne/DimensionFormula.lean`,
+  [#38993](https://github.com/leanprover-community/mathlib4/pull/38993)). The finite-index bound
+  `ModularForm.sturm_bound_finiteIndex` and the `Module.Finite ℂ (ModularForm 𝒢 k)` instance —
+  finite-dimensionality at **every** level — are *not* in Mathlib; Layer 10 builds them here.
 
-⚠ **Dependency policy, stated once.** In-review Mathlib stacks are consumed **with a named
-fallback**: if the Sturm stack (#39000 + companions) stalls, AINTLIB's `dim_gen_cong_levels`
-(which it upstreams) is vendored; if the Hecke-ring convolution stack (#41253–#41328) stalls,
-AINTLIB's `AbstractHeckeRing/*` is. No milestone rests on an unmerged PR without its fallback.
+⚠ **Dependency policy, stated once.** Merged Mathlib material is consumed. Unmerged Mathlib
+material is not a dependency and never a reason to leave a gap: where a layer needs something that
+exists only as an open pull request, it is built here now, from AINTLIB's implementation where one
+exists, and named and shaped the way that pull request names and shapes it, so adopting Mathlib's
+version later is a deletion plus an import rather than a rewrite. Two instances:
+[#39000](https://github.com/leanprover-community/mathlib4/pull/39000)
+(+[#39083](https://github.com/leanprover-community/mathlib4/pull/39083)/[#39086](https://github.com/leanprover-community/mathlib4/pull/39086)/[#39087](https://github.com/leanprover-community/mathlib4/pull/39087)/[#39088](https://github.com/leanprover-community/mathlib4/pull/39088):
+cusp widths, the modular norm map and its `q`-expansion decomposition) carries the finite-index
+Sturm bound, so Layer 10 builds it from AINTLIB's `dim_gen_cong_levels` under the name
+`ModularForm.sturm_bound_finiteIndex`;
+[#41253](https://github.com/leanprover-community/mathlib4/pull/41253)–[#41256](https://github.com/leanprover-community/mathlib4/pull/41256), [#41277](https://github.com/leanprover-community/mathlib4/pull/41277), [#41279](https://github.com/leanprover-community/mathlib4/pull/41279), [#41328](https://github.com/leanprover-community/mathlib4/pull/41328)
+carry the Hecke-ring convolution product, so Layer 2 builds it from AINTLIB's
+`HeckeRIngs/AbstractHeckeRing/*` on top of Mathlib's merged definitions. No milestone waits on a
+pull request.
 
 ## What is missing (build here)
 
@@ -343,12 +346,14 @@ below sketches signatures; it is illustrative, not required to compile.
   dimension formulas.
 
 ### Layer 2: Hecke operators and the Hecke algebra
-- **(a) The Hecke ring, stated at `GL_n` — consume Mathlib's abstract ring, migrate AINTLIB's
-  `GLn/` development.** The double-coset ring of a Hecke pair is
-  landing in Mathlib (`NumberTheory/HeckeRing/Defs.lean` #41251, merged; the convolution ring
-  structure in review, #41253–#41256, #41277, #41279, #41328 — see *What Mathlib already has*): `IsHeckeTriple`,
-  `HeckeCoset`, `𝕋 Δ H Z`, with the finiteness (`Γ ∩ gΓg⁻¹` of finite index, so `ΓgΓ = ⊔ᵢ gᵢΓ`
-  is a finite union of cosets) packaged in the commensurator conditions. On top of it this
+- **(a) The Hecke ring, stated at `GL_n` — consume Mathlib's definitions, build the convolution
+  product here, migrate AINTLIB's `GLn/` development.** Mathlib has the double-coset objects of a
+  Hecke pair (`NumberTheory/HeckeRing/Defs.lean`, #41251 — see *What Mathlib already has*):
+  `IsHeckeTriple`, `HeckeCoset`, `𝕋 Δ H Z`, with the finiteness (`Γ ∩ gΓg⁻¹` of finite index, so
+  `ΓgΓ = ⊔ᵢ gᵢΓ` is a finite union of cosets) packaged in the commensurator conditions. The ring
+  structure on `𝕋` — convolution product, identity, associativity — is built here from AINTLIB's
+  `HeckeRIngs/AbstractHeckeRing/*`, under the names #41253–#41256, #41277, #41279 and #41328 give
+  it, and deleted if that stack lands. On top of it this
   roadmap states the concrete theory at **general `n`**, where AINTLIB has already built most of
   it (`HeckeRIngs/GLn/*`): the pair `(SL_n(ℤ), Δ_n)` with `Δ_n` the positive-determinant
   integral matrices (Shimura §3.2; `GLn/Basic.lean`); **commutativity** via the transpose
@@ -986,15 +991,16 @@ The modular curve here is the **analytic quotient `Γ\ℍ`**, compactified to a 
 surface `X(Γ) = Γ\ℍ*` by adjoining the cusps `Γ\ℙ¹(ℚ)` — defined directly, with **no functor, no
 representability, no moduli problem**.
 
-- **The Sturm bound and finite-dimensionality — consume from Mathlib, don't re-prove.** A
+- **The Sturm bound and finite-dimensionality — consume level one, build the general case.** A
   nonzero `f ∈ M_k(Γ)` has `q`-order at `∞` at most `k·[SL₂(ℤ):Γ]/12`; consequently `M_k(Γ)`
-  and `S_k(Γ)` are **finite-dimensional at every level**. Level one is merged
-  (`ModularForm.sturm_bound_levelOne`, #38993); the finite-index/arithmetic case —
-  `ModularForm.sturm_bound_finiteIndex` and the `Module.Finite ℂ (ModularForm 𝒢 k)` instance —
-  is the in-review stack #39000 (+#39083/#39086/#39087/#39088), proved by the elementary
-  **modular norm map** route (`∏_γ f∣[k]γ` over coset representatives lands at level one, where
-  the level-one bound kills it) — the same argument as AINTLIB's `dim_gen_cong_levels`
-  (`Modularforms/DimGenCongLevels/*`), which it upstreams. Downstream, the Sturm bound is this
+  and `S_k(Γ)` are **finite-dimensional at every level**. Level one is Mathlib's
+  (`ModularForm.sturm_bound_levelOne`, #38993) and is consumed. The finite-index/arithmetic case —
+  `ModularForm.sturm_bound_finiteIndex` and the `Module.Finite ℂ (ModularForm 𝒢 k)` instance — is
+  built here, under those names, from AINTLIB's `dim_gen_cong_levels`
+  (`Modularforms/DimGenCongLevels/*`), by the elementary **modular norm map** route (`∏_γ f∣[k]γ`
+  over coset representatives lands at level one, where the level-one bound kills it). Mathlib's
+  #39000 (+#39083/#39086/#39087/#39088) is the same argument; if it lands, ours goes and the
+  imports change. Downstream, the Sturm bound is this
   layer's **main computational criterion**: two forms agreeing on the first `⌊k·[SL₂(ℤ):Γ]/12⌋ + 1`
   coefficients are equal, which is how the concrete dimension instances in `Suggested.lean` and
   the LMFDB layer's equality checks (Layer 9) become finite computations.
@@ -1397,7 +1403,7 @@ Not a linear order: a graph, with the consumption edges named ("→" means "cons
 |---|---|
 | Layer 0 diamonds/nebentypus | migrate (AINTLIB); the cusp–Eisenstein decomposition is **new** |
 | Layer 1 valence formula | migrate (level one); the order dictionary and general level are **new** |
-| Layer 2 abstract ring | upstream Mathlib PR stack, AINTLIB fallback |
+| Layer 2 abstract ring | definitions consumed from Mathlib; the convolution product built here from AINTLIB |
 | Layer 2 `GL_n` block | migrate; general `n`: two named steps open (**source gap**); consumer PR #120 |
 | Layer 3 Petersson, old/new | migrate; bad-prime newspace stability a **known source gap**, route pinned |
 | Layers 4A/5/4B newforms, SMO | migrate (fixed-space); cross-level newform SMO **new** |


### PR DESCRIPTION
This PR removes the two places where a ModularForms layer rests on a Mathlib pull request that has not merged, and rewrites the dependency policy that made that the intended arrangement.

Layer 2 was told to consume the Hecke-ring convolution product from an open review stack and not to re-found the ring in `TauCeti/`. Layer 10 was told to consume finite-index finite-dimensionality from another open stack. The policy paragraph then made vendoring AINTLIB's implementations conditional on those stacks stalling, which puts the unmerged pull request on the critical path and Tau Ceti in the fallback position. The README's rule is the other way round: an open Mathlib PR is not a blocker, not a reason to leave a gap, so build the thing here now, named and shaped the way that PR does, and delete ours if it lands.

Mathlib's merged Hecke-ring definitions (`IsHeckeTriple`, `HeckeCoset`, `HeckeCosetModule`, `HeckeRing`, from mathlib4#41251) are still consumed and still must not be re-founded here; that part was always correct and is unchanged. What moves is the convolution product, identity and associativity, which become a Layer 2 target built from AINTLIB's `HeckeRIngs/AbstractHeckeRing/*` under the names mathlib4#41253-#41256, #41277, #41279 and #41328 give them. Likewise `ModularForm.sturm_bound_finiteIndex` and the `Module.Finite ℂ (ModularForm 𝒢 k)` instance become Layer 10 targets built from AINTLIB's `dim_gen_cong_levels` by the modular norm map route, with level one still consumed from mathlib4#38993 where it is merged.

The dependency policy now states the rule rather than a stalling condition, and names both instances so a contributor can see which material this applies to. The per-block status table row for the Layer 2 abstract ring says what is consumed and what is built rather than "upstream Mathlib PR stack, AINTLIB fallback".

Found by a second-opinion review of https://github.com/TauCetiProject/TauCetiRoadmap/pull/169 (doc: conform roadmaps to "never push work to Mathlib"), which deliberately fixed only the never-push rule and left this.

Opened as a draft: this is a judgement call about someone else's roadmap, and the repository queues every non-draft PR for auto-merge on a single code-owner approval.

🤖 Prepared with Claude Code