### PR TITLE
chore: bump TauCetiProgress to 880e8b9

### DIFF
--- a/.github/workflows/progress-announce.yml
+++ b/.github/workflows/progress-announce.yml
@@ -24,9 +24,9 @@ permissions:
 jobs:
   announce:
     # Same full SHA as progress-merge.yml uses; bump both together.
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@f73dcd7b92d0b191e44c22ffe1959873f9f24f01
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/announce.yml@880e8b9737973bfbd8f1f214f4ac2ded67f5b856
     with:
-      progress_ref: f73dcd7b92d0b191e44c22ffe1959873f9f24f01
+      progress_ref: 880e8b9737973bfbd8f1f214f4ac2ded67f5b856
       channel: Tau Ceti
       topic: Progress logs
     secrets:

--- a/.github/workflows/progress-merge.yml
+++ b/.github/workflows/progress-merge.yml
@@ -127,10 +127,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@f73dcd7b92d0b191e44c22ffe1959873f9f24f01
+    uses: TauCetiProject/TauCetiProgress/.github/workflows/merge.yml@880e8b9737973bfbd8f1f214f4ac2ded67f5b856
     with:
       pr: ${{ fromJSON(needs.resolve.outputs.pr) }}
-      progress_ref: f73dcd7b92d0b191e44c22ffe1959873f9f24f01
+      progress_ref: 880e8b9737973bfbd8f1f214f4ac2ded67f5b856
       # There is deliberately no author allowlist. Anyone may publish a progress report, including
       # from a fork: what bounds this is the shape of the diff (two generated files, one roadmap,
       # append-only log, window ending in published history), not who sent it. See


### PR DESCRIPTION
This PR moves the merge gate and the announcer to 880e8b9, the same TauCetiProgress build the worker moves to in https://github.com/kim-em/TauCetiWorker/pull/174 — chore: bump TauCetiProgress to 880e8b9. Both pins document that they must match the version the worker runs, so they land together.

The build it picks up is https://github.com/TauCetiProject/TauCetiProgress/pull/10 — fix: expire the docs cache and skip an unpublished area. That fixes the cause of a five-day progress reporting outage: a documentation cache with no expiry pinned the window's end commit to a build from 2026-08-03, which put four roadmap areas' bootstrap cursors outside the documented history and aborted every `plan` run for every area. It also makes one run read one documentation build instead of straddling a deploy, and stops two further single-area conditions from aborting the whole plan.

Nothing in that change touches the `STATUS.md` / `PROGRESS.md` wire formats or the validators this workflow runs, so from this repository's side it is a version move rather than a behaviour change.

🤖 Prepared with Claude Code