### PR TITLE
progress: EllipticCurves report for 2026-08-11

### DIFF
--- a/TauCetiRoadmap/EllipticCurves/PROGRESS.md
+++ b/TauCetiRoadmap/EllipticCurves/PROGRESS.md
@@ -1,0 +1,37 @@
+# Progress log: EllipticCurves
+
+An append-only record of what landed on the EllipticCurves roadmap, one section per window of
+merged pull requests, oldest first. Generated; the prose is not security-validated.
+For a current snapshot instead, read `STATUS.md` beside this file.
+
+<!--tauceti-progress:v1 {"from_sha":"d61e56dfdaf58eb7d50f6d2df92611b30a312ca8","prs":[2246,2248,2254,2256,2259,2268,2271,2285,2287,2293,2296,2307,2323,2328,2344,2346,2350,2353,2364,2381,2403,2409,2421,2424,2434,2436,2440,2449,2465,2474,2479,2486,2495,2536,2561,2565,2572,2575,2583,2592,2593,2609,2643,2645,2661,2674,2686,2696,2697,2714,2724,2727,2755,2769,2772,2782,2795,2808],"roadmap":"EllipticCurves","to_sha":"0c1efce3abbc827ff6d7534077387f04adf9b66c"}-->
+## EllipticCurves: 2026-08-07 to 2026-08-11 (`d61e56d` to `0c1efce`)
+
+Layer 0 opened. The coordinate ring of an elliptic curve is now a
+[Dedekind domain](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.html#TauCeti.WeierstrassCurve.Affine.isDedekindDomain_coordinateRing),
+the [integrally closed](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.html#TauCeti.WeierstrassCurve.Affine.isIntegrallyClosed_coordinateRing)
+half being the normality input the induced map on points of an isogeny wants, and the function
+field is a [quadratic extension](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Finrank.html#WeierstrassCurve.Affine.finrank_functionField)
+of the rational function field `K(x)`. On that base sit both halves of the point–place dictionary:
+the [place at infinity](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.html#WeierstrassCurve.Affine.infinityPlace),
+where `x` has a double pole, `y` a triple pole and [`x / y` is a uniformiser](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.html#WeierstrassCurve.Affine.infinityPlace.isUniformizer_X_div_mk_Y),
+and the [place of an affine point](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.html#TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace),
+injective in the point and of [degree one](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.html#TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace.finrank_residueField_eq_one).
+Divisors, the fundamental identity, and surjectivity of `toClass` are not there yet.
+
+The [isogeny structure](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Basic.html#TauCeti.Isogeny)
+was seeded verbatim — a coordinate-ring pullback with its integrality condition — with its
+injectivity and [unique extension](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.html#TauCeti.Isogeny.fieldPullback)
+to the function field. Degree, finiteness and Frobenius are absent, though the field theory the
+last of them wants, [`[K(W) : K(W)^q] = q`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FrobeniusTower.html#TauCeti.WeierstrassCurve.Affine.finrank_fieldRange_frobeniusAlgHom),
+landed alongside.
+
+Quadratic twists are close to complete at the level of equations: the twist by parameters `(t, n)`
+with the transformation of every invariant, the [twist by a separable quadratic extension](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.html#WeierstrassCurve.quadraticTwist)
+with `j` unchanged, the change of variables trivialising it over `L`, and the cocycle that change
+carries, which is the automorphism `[-1]`. Out of those come the non-isomorphy over `K` and a
+[classification of the forms of `E` split by `L`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.html#WeierstrassCurve.exists_smul_eq_or_exists_smul_eq_quadraticTwist)
+when `j ∉ {0, 1728}`, with the matching computation [`Aut(E) = {±1}`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Aut.html#WeierstrassCurve.autGroupMulEquiv).
+Elsewhere the `S`-integers of a Dedekind domain were built out to their class group and their unit
+group (TauCeti#2645, TauCeti#2727), Nagell–Lutz-style denominator bounds appeared, and the points
+of a Weierstrass curve over a finite field were shown to be finite in number.

--- a/TauCetiRoadmap/EllipticCurves/STATUS.md
+++ b/TauCetiRoadmap/EllipticCurves/STATUS.md
@@ -1,0 +1,95 @@
+<!--tauceti-status:v1 {"roadmap":"EllipticCurves","to_sha":"0c1efce3abbc827ff6d7534077387f04adf9b66c","ts":"2026-08-11T15:34:55Z"}-->
+# Status: EllipticCurves
+
+This file documents the status of the EllipticCurves roadmap up until `0c1efce` (2026-08-11T15:34:55Z). There may have been subsequent updates.
+
+It is generated, and its prose is not security-validated; see
+https://github.com/TauCetiProject/TauCetiProgress for what that means.
+
+## Where this roadmap stands
+
+**At a glance.** No layer is finished. Layer 5's quadratic twists are essentially complete at
+equation level; Layer 0 has the function field and its places but no divisor calculus; Layer 1 has
+the isogeny type with nothing computed about it. Layers 2, 4 and 7 have only scattered
+prerequisites, and the Hasse bound and Mordell–Weil have supporting algebra but not themselves.
+
+### Named results
+
+- **The coordinate ring of an elliptic curve is a Dedekind domain**
+  ([`isDedekindDomain_coordinateRing`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.html#TauCeti.WeierstrassCurve.Affine.isDedekindDomain_coordinateRing)),
+  the normality half
+  ([`isIntegrallyClosed_coordinateRing`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/CoordinateRing.html#TauCeti.WeierstrassCurve.Affine.isIntegrallyClosed_coordinateRing))
+  being what the induced map on points of an isogeny needs; its fraction field is
+  [quadratic](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/Finrank.html#WeierstrassCurve.Affine.finrank_functionField)
+  over `K(x)`.
+- **Classification of the forms split by a quadratic extension** — for `j(E) ∉ {0, 1728}`, a curve
+  becoming isomorphic to `E` over a separable quadratic `L/K` is already `K`-isomorphic to `E` or
+  to its quadratic twist by `L`
+  ([`exists_smul_eq_or_exists_smul_eq_quadraticTwist`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.html#WeierstrassCurve.exists_smul_eq_or_exists_smul_eq_quadraticTwist)),
+  and those two are genuinely different over `K`
+  ([`not_exists_smul_quadraticTwist_eq`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.html#WeierstrassCurve.not_exists_smul_quadraticTwist_eq)):
+  the `H¹` classification for that `j`-range, concretely rather than cohomologically.
+- **`Aut(E) = {±1}` away from `j = 0, 1728`** — the stabiliser of `E` among admissible changes of
+  variables is `{1, [-1]}`
+  ([`autGroupMulEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Aut.html#WeierstrassCurve.autGroupMulEquiv)):
+  the rational group, not the geometric one Layer 5's classification needs.
+- **The class group and units of the `S`-integers** — `Cl(𝒪_S)` is `Cl(R)` modulo the classes of
+  the primes in `S`
+  ([`integerClassGroupEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/RingTheory/DedekindDomain/SInteger/ClassGroup.html#IsDedekindDomain.integerClassGroupEquiv)),
+  hence finite when `Cl(R)` is, and the `S`-units are finitely generated once `Rˣ` is and `S` is
+  finite
+  ([`unit_fg_of_units`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/RingTheory/DedekindDomain/SInteger/Unit.html#Set.unit_fg_of_units)):
+  the inputs weak Mordell–Weil needs.
+
+### Notable definitions and infrastructure
+
+- **The isogeny** ([`Isogeny`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/Basic.html#TauCeti.Isogeny)),
+  seeded verbatim: an algebra map out of the target coordinate ring into the source function
+  field, integrality expressing `φ(O₁) = O₂`. It is injective and extends uniquely across the
+  fraction field
+  ([`fieldPullback`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Isogeny/FunctionField.html#TauCeti.Isogeny.fieldPullback)),
+  so degree and composition can now be defined on it.
+- **The two families of places** — the valuation at infinity
+  ([`infinityPlace`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FunctionField/InfinityPlace.html#WeierstrassCurve.Affine.infinityPlace)),
+  ramified of index two over the infinite place of `K(x)`, with uniformiser `x / y`; and the
+  maximal ideal of an affine point
+  ([`pointPlace`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Point/Place.html#TauCeti.WeierstrassCurve.Affine.CoordinateRing.pointPlace)),
+  of degree one, injective, its local ring a discrete valuation ring.
+- **The node polynomial**, of discriminant `-c₄c₆`
+  ([`nodePolynomial`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/NodePolynomial.html#WeierstrassCurve.nodePolynomial)),
+  its roots the tangent slopes at a node, with splitting criteria in residue characteristic two
+  and away from it: the split/nonsplit test.
+
+### Roadmap coverage
+
+Layer 0 has coordinate ring, function field, local rings and both families of places, but no
+divisors, no induced place along a field embedding, no fundamental identity `Σ e·f = deg`, and no
+point–place bijection. Layer 0.5 has base change, the variable-change action on points, and
+Galois descent across a quadratic extension, but no translations. Layer 1 has the isogeny type and
+`Aut(E)`; degree, `[n]`, relative Frobenius, the hom-group and its degree form, the dual, Vélu and
+the formal group are all missing, though two of their inputs exist: the relative ideal norm on
+class groups, and a semilinear map of Kähler differentials. Layer 2 is untouched; Layer 3 has
+finiteness of `E(𝔽_q)` and an abstract binary-quadratic-form core, not the bound; Layer 4 has only
+the node polynomial; Layer 5 lacks only its point-level statements. Layer 6 has the `S`-integer
+arithmetic and the Nagell–Lutz integrality lemmas, no heights and no theorem. Layer 7 is untouched.
+
+## The frontier
+
+- **Degree and the Frobenius isogeny.** Nothing is computed on the isogeny type yet: `deg φ` as a
+  finrank over the pulled-back function field, finiteness, positivity, composition, `π_q`. That
+  [`[K(W) : K(W)^q] = q`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FrobeniusTower.html#TauCeti.WeierstrassCurve.Affine.finrank_fieldRange_frobeniusAlgHom)
+  is already proved, so Frobenius is packaging.
+- **Divisors and the class-group anchor.** Layer 0's remainder: the divisor group,
+  `deg (div f) = 0`, surjectivity of `toClass`, and the point–place bijection, of which only
+  injectivity and degree one are proved. The Weil pairing is built from this calculus, so Layer 2
+  waits on it.
+- **The Hasse bound.** Finiteness of `E(𝔽_q)` is in, as is the arithmetic core: a rank-two pencil
+  determinant is forced to be `q r² - t rs + s²`, and a form non-negative on enough of the lattice
+  has non-positive discriminant. The elliptic half — `deg(1 - π_q) = #E(𝔽_q)`, the degree read as
+  a determinant — is missing.
+- **The two remaining twist milestones.** The point isomorphism `E^L(M) ≅ E(M)` with its Galois
+  anti-equivariance, and the theorem that nonsplit multiplicative reduction becomes split after a
+  separable quadratic twist, whose input is the node polynomial.
+- **Weak Mordell–Weil.** The `S`-integer class group and unit group are in place; finiteness of
+  `K(S, n)` and the Kummer map into the square classes of `K[X]/(f)` are not, and no height
+  exists.


### PR DESCRIPTION
<!--tauceti-progress-pr:v1 {"from_sha":"d61e56dfdaf58eb7d50f6d2df92611b30a312ca8","prs":[2246,2248,2254,2256,2259,2268,2271,2285,2287,2293,2296,2307,2323,2328,2344,2346,2350,2353,2364,2381,2403,2409,2421,2424,2434,2436,2440,2449,2465,2474,2479,2486,2495,2536,2561,2565,2572,2575,2583,2592,2593,2609,2643,2645,2661,2674,2686,2696,2697,2714,2724,2727,2755,2769,2772,2782,2795,2808],"roadmap":"EllipticCurves","to_sha":"0c1efce3abbc827ff6d7534077387f04adf9b66c","version":"880e8b9737973bfbd8f1f214f4ac2ded67f5b856"}-->
This PR records progress on the EllipticCurves roadmap for the window `d61e56d..0c1efce` of TauCeti `main`, covering 58 merged pull requests.

`STATUS.md` is rewritten as a snapshot at `0c1efce`; `PROGRESS.md` gains one appended section for the window. Both files are machine-owned and their prose is not security-validated.

Pull requests in the window: #2246, #2248, #2254, #2256, #2259, #2268, #2271, #2285, #2287, #2293, #2296, #2307, #2323, #2328, #2344, #2346, #2350, #2353, #2364, #2381, #2403, #2409, #2421, #2424, #2434, #2436, #2440, #2449, #2465, #2474, #2479, #2486, #2495, #2536, #2561, #2565, #2572, #2575, #2583, #2592, #2593, #2609, #2643, #2645, #2661, #2674, #2686, #2696, #2697, #2714, #2724, #2727, #2755, #2769, #2772, #2782, #2795, #2808

Generated by [TauCetiProgress](https://github.com/TauCetiProject/TauCetiProgress) at `880e8b9737973bfbd8f1f214f4ac2ded67f5b856`.

🤖 Prepared with Claude Code
