### PR TITLE
Add roadmap: algebraic coding theory and code-lattice constructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you want to write or review a roadmap, start with [CONTRIBUTING.md](CONTRIBUT
 
 ## Roadmaps
 
+- [Algebraic codes and code-lattice constructions](TauCetiRoadmap/AlgebraicCodingTheory/README.md)
 - [A statement of the classification of finite simple groups](TauCetiRoadmap/CFSGStatement/README.md)
 - [Combinatorial Heegaard Floer and grid homology](TauCetiRoadmap/CombinatorialHeegaardFloer/README.md)
 - [Conformal mapping and the geometric theory of holomorphic functions](TauCetiRoadmap/ConformalMapping/README.md)

--- a/TauCetiRoadmap.lean
+++ b/TauCetiRoadmap.lean
@@ -3,6 +3,7 @@
 -- The per-topic `README.md` files are the definitive roadmaps. The Lean `Suggested.lean`
 -- files suggest declaration forms for particular milestones (with `sorry`, which is
 -- allowed here); they are not exhaustive, and discharging one does not finish its roadmap.
+import TauCetiRoadmap.AlgebraicCodingTheory.Suggested
 import TauCetiRoadmap.RepresentationTheory.SemisimpleAlgebras.Suggested
 import TauCetiRoadmap.RepresentationTheory.CharacterTheory.Suggested
 import TauCetiRoadmap.RepresentationTheory.InductionRestriction.Suggested

--- a/TauCetiRoadmap/AlgebraicCodingTheory/README.md
+++ b/TauCetiRoadmap/AlgebraicCodingTheory/README.md
@@ -1,0 +1,438 @@
+# Roadmap: algebraic codes and code-lattice constructions
+
+Algebraic codes are the finite algebra which turns coordinate data into lattice overlattices.
+This roadmap develops finite linear and additive codes far enough to support that use: matrix
+presentations, Hamming data, duality, the MacWilliams identity, the small exceptional codes, and
+Construction A.  Its final layer identifies code coordinates with the discriminant modules from
+the [integral-lattices roadmap](../IntegralLattices/README.md), so the lattice attached to an
+isotropic code is literally the preimage construction from that roadmap and has discriminant
+module `C^⊥/C`.
+
+The primary linear code on a finite coordinate type `ι` over a finite field `F` is the existing
+Mathlib object
+
+```lean
+Submodule F (ι → F)
+```
+
+and an additive code over a finite abelian alphabet `A` is
+
+```lean
+AddSubgroup (ι → A).
+```
+
+Dimension, length, distance, and divisibility conditions are derived data or predicates; they are
+not fields of another bundled code structure.  This keeps the full `Submodule` and `AddSubgroup`
+APIs available and agrees with the direction of Mathlib's coding-theory development.
+
+This roadmap does **not** develop decoding algorithms, general bounds, cyclic/BCH/Reed--Solomon
+codes, designs, rank-24 glue tables, a classification of codes or lattices, theta series, or any
+categorical construction.  It does not identify Golay automorphism groups with Mathieu groups.
+The named codes and discriminant-coordinate checks below are reusable input for explicit lattice
+constructions, not a classification of the resulting lattices.
+
+Suggested home: `TauCeti/InformationTheory/Coding/`, with the discriminant and Construction A
+bridge in `TauCeti/LinearAlgebra/IntegralLattice/ConstructionA.lean`.
+
+## Standing conventions
+
+- A coordinate set `ι` is an arbitrary finite type.  Use `Fin n` only for a displayed matrix or a
+  named code with a conventional ordering.  The length is `Fintype.card ι`; changing coordinates
+  along an equivalence must not require transport through an equality with `Fin n`.
+- A linear code is a `Submodule F (ι → F)`, for a field `F` with `[Finite F]`.  Install a local
+  `Fintype` or decidable-equality instance only for finite sums or enumeration.  The dimension is
+  `Module.finrank F C`, and `#C = (#F)^(finrank F C)` is a theorem.
+- An additive code is an `AddSubgroup (ι → A)` for a finite commutative additive group `A`.
+  Linearity over a field or ring is extra structure, never inferred from additive closure.  An
+  arbitrary subgroup of a discriminant module is called a subgroup, not automatically a binary or
+  field-linear code.
+- Words are functions.  Hamming support is the set of nonzero coordinates; Hamming weight and
+  distance are Mathlib's `hammingNorm` and `hammingDist`.  The minimum distance of the zero code is
+  `0`; for a nonzero linear or additive code it is the least weight of a nonzero codeword and also
+  the least distance between distinct codewords.
+- The Euclidean dual of a linear code uses the standard bilinear form
+  `⟪x,y⟫ = ∑ i, x i * y i`, with no conjugation.  Hermitian duality is a separate construction over
+  a finite field with a specified involutive field automorphism `σ`.  Its pinned orientation is
+  `hσ(x,y)=∑ i, x_i σ(y_i)`: it is linear in the first entry and `σ`-semilinear in the
+  second.  For `F₄`, `σ` is Frobenius `x ↦ x²`.  With this orientation, a generator matrix
+  `G` for `C` becomes the entrywise-conjugate parity-check matrix `σ(G)` for `C^⊥_H`; using
+  `G` itself would silently compute the Euclidean dual.
+- A generator matrix `G : Matrix ρ ι F` generates the row space, namely the range of
+  `G.vecMulLinear`.  A parity-check matrix `H : Matrix σ ι F` cuts out
+  `ker H.mulVecLin`.  Thus a systematic generator `[I | A]` has parity check
+  `[-Aᵀ | I]`.  Row indices carry no coordinate meaning.
+- A permutation equivalence is induced only by a coordinate equivalence.  A monomial equivalence
+  additionally multiplies coordinates by nonzero field elements.  Both preserve Hamming data.
+  Semilinear equivalence, which also applies a field automorphism, remains a distinct notion.
+  `Aut(C)` means the monomial stabilizer unless a declaration explicitly says
+  `PermutationAut(C)`.
+- The homogeneous Hamming weight enumerator has coefficients in `ℤ` and variable order
+  `(X,Y)`:
+  `W_C(X,Y)=∑_{c∈C} X^(n-wt(c)) Y^wt(c)`.  Also expose the weight distribution and the
+  one-variable specialization.  The MacWilliams identity is stated without division as
+  `#C · W_{C⊥}(X,Y) = W_C(X+(q-1)Y, X-Y)`.
+- A binary code is **doubly even** when every weight is divisible by four.  A **Type II** code is a
+  doubly-even Euclidean self-dual binary code.  “Even” alone means weights divisible by two and is
+  not a synonym for Type II.
+- Fix `F₄` as a field of four elements and choose `ω` with `ω²+ω+1=0`; write
+  `F₄={0,1,ω,ω²}`.  The hexacode statements must be invariant under exchanging `ω` and `ω²`.
+- For Construction A, every declaration has `m ≥ 2` (or at least a `NeZero m` parameter where
+  only nonvanishing is used); no helper is defined at `m=0`.  Reduce coordinatewise
+  `ρ_m : ℤ^ι → (ZMod m)^ι`, and put `P_m(C)=ρ_m⁻¹(C)`.  The Lean lattice stays in the rational
+  ambient space `ℚ^ι`, has carrier the image of `P_m(C)`, and has form
+  `B_m(x,y)=(∑ i, x_i y_i)/m`.  After scalar extension to `ℝ` it is isometric to the usual
+  `m^(-1/2) P_m(C)`.  This convention avoids adjoining square roots and makes all dual carriers
+  literal submodules of one rational space.
+- The integral-lattices dependency uses the half-norm discriminant convention
+  `q(x)=B(x,x)/2 mod ℤ`.  All code-to-discriminant comparisons below use that convention.
+
+## Existing library material to consume
+
+### Mathlib
+
+- `Mathlib/InformationTheory/Hamming.lean` defines `hammingDist`, `hammingNorm`, and their
+  invariance and triangle lemmas on finite Pi types.  Do not introduce a second Hamming weight.
+- `Submodule`, `AddSubgroup`, `Module.finrank`, finite-dimensional duality, and
+  `LinearMap.BilinForm.orthogonal` and the root declaration `dotProductBilin` supply the primary
+  carriers, dimension, and dual-code
+  machinery.  `Matrix.vecMulLinear`, `Matrix.mulVecLin`, kernels, ranges, rank, transpose, and block
+  matrices supply generator and check presentations.
+- `MvPolynomial` supplies the homogeneous enumerator and substitution in the MacWilliams identity.
+  `AddChar.FiniteField.primitiveChar` and `AddChar.sum_eq_zero_of_ne_one` supply the character and
+  vanishing sum for the character-sum proof.  Do not prove MacWilliams through theta series.
+- `GaloisField`, `ZMod`, finite-field cardinality and Frobenius APIs supply the named alphabets.
+  Use an existing four-element field rather than defining a private four-element ring.
+- Mathlib's open linear-code work in
+  [PR #38014](https://github.com/leanprover-community/mathlib4/pull/38014) uses
+  `Subspace F (Hamming (fun _ : Fin n ↦ F))`, hence a `Fin n` coordinate type and the Hamming
+  type synonym,
+  and defines minimum distance through `Set.infsep`.  This roadmap agrees with that unbundled-
+  subspace design, but its arbitrary finite coordinate type is a genuine generalization, not the
+  PR's present interface.  Supply explicit reindexing/Hamming-type bridges, and either reuse
+  `Set.infsep` or prove the equality between it and the least-nonzero-weight formula.  If the PR
+  lands first, consume its declarations for `Fin n`; do not claim that the current signatures are
+  already import-compatible.
+
+### Tau Ceti and neighboring roadmaps
+
+Tau Ceti has no general coding-theory layer.  Its finite-field, matrix, polynomial, and root-data
+material is input, not an alternative representation of codes.  The integral-lattices roadmap
+supplies `IntegralLattice`, finite bilinear and quadratic modules, discriminant forms, isotropic
+subgroups, `IntegralLattice.ofIsotropicSubgroup`, and the isometry
+`A_{L_H} ≅ H^⊥/H`.  Construction A and every root-discriminant coordinate check must consume those
+objects directly.
+
+There are independent Lean drafts involving Golay codes and Mathieu groups, discussed in the Lean
+Zulip [Mathieu groups topic](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Mathieu.20groups/with/608500915).
+Coordinate with their authors before copying or adapting code.  The intrinsic targets and
+conventions in this roadmap, rather than any one draft's file layout, remain the specification.
+
+---
+
+## Layer 1: finite codes, matrices, and elementary constructions
+
+Build the carrier API once for arbitrary finite coordinate types.
+
+- Give namespace aliases for linear and additive codes, membership and extensionality lemmas, the
+  zero, top, inclusion, sum, intersection, map, and comap operations inherited from their carriers,
+  and finite-cardinality results.  Do not wrap these operations in a structure which hides the
+  lattice of subobjects.
+- Define the code generated by a matrix as `range G.vecMulLinear` and the code checked by a matrix
+  as `ker H.mulVecLin`.  Define generator- and parity-check-matrix predicates by equality to those
+  submodules.  Prove existence from finite bases, the row-span and syndrome membership criteria,
+  the rank/dimension formulae, deletion of dependent rows, and invariance under invertible row
+  operations.
+- Prove that full-rank generator and check matrices for `C` have respectively `k` and `n-k` rows.
+  Relate a generator for `C` to a check matrix for `C^⊥`.  Develop systematic form relative to a
+  chosen information set and verify directly that `[I | A]` and `[-Aᵀ | I]` generate/check
+  orthogonal codes.  Do not assert that a canonical information set exists.
+- For `s : Set ι`, take `s` to mean the coordinates **retained**.  Define puncturing by restriction
+  to `s`, and shortening by first imposing zero outside `s` and then restricting.  Supply single-
+  coordinate forms, membership and dimension lemmas, repeated-operation identities, and naturality
+  under reindexing.  State bounds using the finite number of deleted coordinates.
+- Define the direct sum on the disjoint-union coordinate type and prove its universal membership,
+  dimension, cardinality, Hamming, and associativity/commutativity statements.  Supply canonical
+  reindexing equivalences rather than identifying different function types by proof irrelevance.
+- Construct permutation, monomial, and semilinear word equivalences, the induced code maps, and the
+  equivalence relations.  Define their stabilizer groups and actions on codewords.  Prove
+  preservation of dimension, support cardinality, weight, distance, and weight enumerator by the
+  appropriate equivalences.
+
+Acceptance at this layer includes converting a full-rank generator matrix to a parity-check matrix,
+then recovering the same code as the kernel, and checking that this calculation is natural under a
+nontrivial coordinate reindexing.
+
+## Layer 2: Hamming data and dual codes
+
+- Relate `Function.support`, its finite version, `hammingNorm`, and `hammingDist`.  Prove the support
+  formulae for addition and scalar multiplication, the weight bound by length, and
+  `dist(x,y)=wt(y-x)` with the pinned subtraction orientation.
+- Define minimum distance for linear and additive codes with the zero-code convention above.  For a
+  nonzero code, prove attainment by a nonzero word and equality with the least pairwise distance.
+  Prove invariance under Hamming isometries, that shortening cannot decrease minimum distance, the
+  sharp deleted-coordinate bound for puncturing, and the minimum formula for direct sums.
+- Define the standard bilinear form on `ι → F` using Mathlib's finite dot product, prove symmetry
+  and nondegeneracy, and define `C^⊥` with `BilinForm.orthogonal`.  Prove membership, order reversal,
+  `C ≤ C^⊥` and `C=C^⊥` characterizations, `(C^⊥)^⊥=C`,
+  `dim C + dim C^⊥ = #ι`, and `#C · #C^⊥ = (#F)^(#ι)`.
+- Prove the duality formulae
+  `(puncture C s)^⊥ = shorten (C^⊥) s`,
+  `(shorten C s)^⊥ = puncture (C^⊥) s`, and
+  `(C ⊕ D)^⊥ = C^⊥ ⊕ D^⊥`, with the retained-coordinate convention visible in each statement.
+  Describe the contragredient action of a monomial equivalence on the dual.
+- Develop Hermitian duality separately for a finite field with a specified involutive
+  automorphism using Mathlib's sesquilinear-map and `Submodule.orthogonalBilin` APIs.  Prove the
+  membership, nondegeneracy, double-dual, and dimension formulae, and the generator/check theorem
+  `rowspan(G)=C ⇔ ker(σ(G))=C^⊥_H`.  Specialize to Frobenius on `F₄`.  No theorem may
+  silently replace a Hermitian dual by the Euclidean dual.
+- For a finite bilinear alphabet `A` from the integral-lattices roadmap, construct the coordinate
+  power on `ι → A` by summing pairings.  Define the orthogonal additive code and prove the
+  finite-cardinality and double-perpendicular results under nondegeneracy.  Construct the analogous
+  coordinate finite quadratic module by summing quadratic values.
+
+## Layer 3: weight enumerators and MacWilliams
+
+- Define the weight distribution `A_w(C)`, prove it vanishes above the length, sums to `#C`, has
+  `A_0=1`, and is invariant under monomial equivalence.  Define the one-variable and homogeneous
+  weight enumerators and prove their coefficient formulae, finite support, homogeneity, evaluation
+  at `(1,1)`, direct-sum product, and recovery of minimum distance for a nonzero code.
+- Establish the finite-character orthogonality lemma for a linear subspace and its Euclidean dual.
+  Reuse Mathlib's primitive additive character on a finite field and its nontrivial-character sum;
+  expose the resulting finite Fourier transform lemma as reusable API rather than burying it in the
+  final polynomial calculation.
+- Prove the `q`-ary MacWilliams identity for every finite field `F`, `q=#F`, in the integral,
+  division-free form
+
+  `#C · W_{C^⊥}(X,Y) = W_C(X+(q-1)Y, X-Y)`.
+
+  Derive the rational normalized form, the coefficient/Krawtchouk formula, and invariance of the
+  enumerator of a self-dual code under the normalized transform.  Check the identity on the zero,
+  whole-space, repetition, and single-parity-check codes.
+
+This layer does not introduce theta series or use a theta transformation as a proof of MacWilliams.
+
+## Layer 4: binary doubly-even and Type II codes
+
+- Define even, doubly-even, self-orthogonal, self-dual, and Type II predicates without bundling
+  proofs into a new code type.  Prove that a doubly-even binary linear code is self-orthogonal by
+  the support-intersection weight identity.
+- For a binary self-dual code, prove that every word has even weight, the all-ones word lies in the
+  code, the dimension is half the length, and the code has `2^(n/2)` words.  For Type II codes prove
+  the stronger length congruence `#ι ≡ 0 (mod 8)` with all finiteness and nondegeneracy hypotheses
+  explicit.
+- Prove closure of doubly-even and Type II codes under direct sum and preservation under coordinate
+  permutation.  Record the exact behavior under general monomial and semilinear maps, even though
+  these collapse to permutations over `F₂`.
+- Specialize MacWilliams to Type II codes and prove the two elementary weight-enumerator
+  invariances forced by self-duality and divisibility by four, with their coefficient rings pinned:
+
+  `W_C(X+Y,X-Y)=2^(#ι/2) W_C(X,Y)` in `ℤ[X,Y]`, and
+
+  `W_C(X,iY)=W_C(X,Y)` after base change to `ℤ[i][X,Y]` (or `ℂ[X,Y]`).
+
+  Full Gleason invariant theory and classification of Type II codes are outside this roadmap.
+
+## Layer 5: tetracode, hexacode, and the extended Golay codes
+
+Each named code is defined by a displayed finite matrix (or an equivalent finite spanning list),
+then its properties are proved by exact finite algebra.  A declaration which merely assumes the
+desired parameters does not construct the named code.
+
+- Define the ternary tetracode from
+
+  ```text
+  [ 1 0 1  1 ]
+  [ 0 1 1 -1 ]
+  ```
+
+  over `ZMod 3`.  Prove it has parameters `[4,2,3]`, is Euclidean self-dual, every nonzero word has
+  weight `3`, and
+  `W_T(X,Y)=X^4+8XY^3`.
+- With `ω²+ω+1=0`, define the hexacode over `F₄` from
+
+  ```text
+  [ 1 0 0 1 ω ω ]
+  [ 0 1 0 ω 1 ω ]
+  [ 0 0 1 ω ω 1 ].
+  ```
+
+  Prove it has parameters `[6,3,4]`, is **Hermitian** self-dual, has only weights `0`, `4`, and
+  `6`, and
+  `W_H(X,Y)=X^6+45X^2Y^4+18Y^6`.  Verify explicitly that exchanging `ω` and `ω²` gives an equivalent
+  code: in the displayed one-based coordinate order, the permutation
+  `(1,2,4,6,3,5)` carries the coordinatewise Frobenius conjugate back to `H`.  This must be an
+  actual permutation-equivalence theorem, not just invariance of the parameters.  As a convention
+  check, compute that the displayed generator has zero Hermitian Gram matrix but a nonzero
+  Euclidean Gram matrix.
+- Define the extended binary Golay code `G₂₄` by the standard bordered reverse-circulant systematic
+  generator matrix in Huffman--Pless §1.9.1, transcribed as a concrete `Fin 12 × Fin 24` matrix.
+  Prove rank `12`, minimum distance `8`, self-duality, doubly-evenness, and
+
+  `W_G₂₄(X,Y)=X^24+759X^16Y^8+2576X^12Y^12+759X^8Y^16+Y^24`.
+
+  Prove that puncturing any coordinate gives a binary `[23,12,7]` Golay code and that extending it
+  by the parity coordinate recovers a code permutation-equivalent to `G₂₄`.
+- Define the extended ternary Golay code `G₁₂` from the systematic matrix `[I₆ | A]`
+
+  ```text
+  A = [ 0 1 1 1 1 1
+        1 0 1 2 2 1
+        1 1 0 1 2 2
+        1 2 1 0 1 2
+        1 2 2 1 0 1
+        1 1 2 2 1 0 ]
+  ```
+
+  over `ZMod 3`.  Prove parameters `[12,6,6]`, Euclidean self-duality, divisibility of every weight
+  by `3`, and
+  `W_G₁₂(X,Y)=X^12+264X^6Y^6+440X^3Y^9+24Y^12`.
+
+For all four codes, evaluate the finite sum defining the enumerator and independently verify the
+dual through the generator/check interface.  Full uniqueness up to equivalence and identification
+of permutation automorphism groups with Mathieu groups are not targets: neither is needed to use
+these explicit codes in a lattice construction.  The general automorphism API from Layer 1 remains
+in scope.
+
+## Layer 6: Construction A with exact hypotheses
+
+Let `m ≥ 2` and let `C ≤ (ZMod m)^ι` be an additive code.  Define its standard dual by the
+`ZMod m` dot product and construct `P_m(C)` and `B_m` using the standing convention.
+Ebeling Proposition 1.3 is the exact binary specialization.  For general `ZMod m`,
+Harada--Munemasa--Venkov §2 fixes the `A_m(C)` normalization for arbitrary positive `m` and
+records the self-dual-to-unimodular implication and its frame converse.  Munemasa--Tamura §4
+states the exact integrality/self-orthogonality and unimodularity/self-duality criteria.  Translate
+their real `m^(-1/2)` normalization to `B_m` on the rational carrier.  The stronger literal
+carrier identity `A_m(C)^∨=A_m(C^⊥)` is an elementary inverse-image/residue-pairing lemma to be
+proved here; it is not attributed to a theorem which those sources do not state.  The Type II theorem of
+Dougherty--Gulliver--Harada is used only for codes over `Z/(2^r)`: do not extrapolate its named
+Type II/even-lattice result to arbitrary composite moduli.  Elementary residue calculations below
+may be stated for every `m ≥ 2`, with their proof and exact hypotheses visible.
+
+- Prove that `P_m(C)` is a full `ℤ`-lattice in `ℚ^ι` for every `C`.  It bundles as an
+  `IntegralLattice` exactly when `C ≤ C^⊥`.  Prove the literal carrier equality
+  `P_m(C)^∨ = P_m(C^⊥)` under the form `B_m`; do not replace it by a cardinality calculation.
+- Prove
+  `disc(P_m(C)) = m^(#ι) / (#C)^2` for self-orthogonal `C`, including the divisibility which makes
+  the right side a natural number.  For a linear `[n,k]` code over `ZMod p`, with `p` prime, derive
+  `disc(P_p(C))=p^(n-2k)`.
+- Prove that integral `P_m(C)` is unimodular exactly when `C=C^⊥`.  Keep self-orthogonality visible
+  in the construction so “unimodular” is never asserted of an unbundled nonintegral carrier.
+- When `m` is even, define
+  `q_m(c)=∑ i lift(c_i)^2/(2m) mod ℤ`; prove independence of integer lifts and identify its polar
+  form with the coordinate discriminant pairing.  Prove that `P_m(C)` is even exactly when
+  `q_m|_C=0`.  If `m` is odd and `ι` is nonempty, prove `P_m(C)` is not even because it contains a
+  coordinate vector of norm `m`.
+- At `m=2`, prove `q_2(c)=wt(c)/4 mod ℤ`, so evenness is exactly doubly-evenness.  Deduce that the
+  Construction A lattice of a Type II code is positive-definite, even, and unimodular.  Apply this
+  to the explicit `G₂₄`; this end-to-end theorem is an acceptance test, without identifying or
+  classifying the resulting rank-24 lattice.
+- For the published higher-modulus terminology, separately define a Type II `Z/(2^r)` code as a
+  self-dual code whose Euclidean weights are divisible by `2^(r+1)`, and prove the corresponding
+  Construction-A lattice is even unimodular.  Do not install “Type II” as a predicate on every
+  `ZMod m` code.
+- Prove naturality under coordinate permutations and the precise lattice isometry induced by a
+  signed coordinate change.  State separately which general monomial code equivalences lift to
+  rational or integral lattice isometries; a unit of `ZMod m` is not automatically a Euclidean
+  coordinate isometry.
+
+## Layer 7: codes as isotropic discriminant subgroups
+
+This layer is the bridge to the integral-lattices roadmap, not a second gluing theory.
+The `A₂` and `D₄` coordinate calculations use the discriminant-glue convention of
+Conway--Sloane Chapter 4 §3 and the nonbinary constructions in Chapter 7 §§8--9; the Lean targets
+must exhibit the isometries rather than relying on those identifications as folklore.
+
+- Let `L₀(m,ι)` have carrier `mℤ^ι` in `ℚ^ι` and form `B_m`.  Prove
+  `L₀(m,ι)^∨=ℤ^ι` and construct an isometry
+  `A_{L₀} ≅ (ZMod m)^ι` carrying the class of an integer vector to its coordinatewise
+  reduction modulo `m`, and carrying the discriminant pairing to
+  `∑ lift(x_i)lift(y_i)/m mod ℤ`.  For even `m`, identify the half-norm quadratic form with `q_m`.
+- Under this isometry, transport an additive code `C` to an actual
+  `AddSubgroup L₀.DiscriminantGroup`; define it as the inverse image under the displayed
+  isometry, not as opaque existential data.  Prove its orthogonal complement is exactly the inverse
+  image of `C^⊥`, bilinear isotropy is equivalent to
+  `C ≤ C^⊥`, quadratic isotropy for even `m` is equivalent to `q_m|_C=0`, and the preimage lattice
+  `L₀.ofIsotropicSubgroup` is isometric to `P_m(C)`.
+- Consume the general gluing theorem to obtain, for isotropic `C`, the natural isometry
+  `A_{P_m(C)} ≅ C^⊥/C`, first as an isometry of finite bilinear modules and, when `m` is even
+  and `q_m|_C=0`, as an isometry of finite quadratic modules.  Its underlying quotient must be the
+  actual subtype quotient built from `C ≤ C^⊥`; a cardinality equality is not a substitute.
+  Deduce unimodularity from the Lagrangian condition `C=C^⊥`, not from an unexplained determinant
+  computation.
+- Build finite coordinate powers and coordinatewise isometries for other discriminant alphabets.
+  Verify that the tetracode and `G₁₂` become quadratic-isotropic, Lagrangian subgroups for the
+  standard `A₂` discriminant alphabet.  Pin its generator so that, for `a,b∈F₃`,
+  `q_A₂(a)=a²/3 mod ℤ` and `b_A₂(a,b)=2ab/3 mod ℤ`.
+  Identify the standard `D₄` alphabet additively with `F₄` by sending
+  `1` to the vector class and `ω,ω²` to the two spinor classes.  On a coordinate power use
+  `q_D₄(x)=wt(x)/2 mod ℤ` and
+  `b_D₄(x,y)=(1/2) Tr_{F₄/F₂}(∑_i x_i y_i²) mod ℤ`.
+  Construct the corresponding quadratic-module isometries to the actual discriminant modules,
+  then verify that the tetracode and `G₁₂` are quadratic-isotropic Lagrangians for `A₂`, and the
+  hexacode is one for `D₄`.  These are coordinate checks, not rank-24 glue tables or lattice
+  identifications.
+- State the reusable interface for an isometry from a coordinate finite quadratic module to the
+  discriminant module of an orthogonal lattice sum.  Its input subgroup remains an
+  `AddSubgroup`; field-linearity is used only when separately proved for a named code.
+
+Acceptance at this layer sends the explicit binary Golay code through the coordinate discriminant
+isometry, constructs the same lattice both as Construction A and as
+`IntegralLattice.ofIsotropicSubgroup`, and obtains evenness, unimodularity, and trivial
+`C^⊥/C` from the general APIs.
+
+## Ordering and completion criterion
+
+Layer 1 fixes carriers and matrix conventions before any invariant depends on them.  Hamming and
+dual APIs in Layer 2 feed the enumerator theorem in Layer 3 and Type II theory in Layer 4.  The four
+finite examples in Layer 5 exercise those general layers.  Construction A then consumes the code
+API, and Layer 7 identifies it with the discriminant-subgroup construction in the integral-lattices
+roadmap.
+
+The roadmap is complete only when all general operations, duality and MacWilliams, all four named
+code computations, Construction A criteria, and the discriminant bridge have been formalized.
+Having a matrix called “Golay” without verified rank, distance, dual, and enumerator, or proving
+even unimodularity without the `ofIsotropicSubgroup`/`C^⊥/C` comparison, is not completion.
+
+## References
+
+- W. C. Huffman and V. Pless, *Fundamentals of Error-Correcting Codes*, Cambridge University Press
+  (2003), [book DOI](https://doi.org/10.1017/CBO9780511807077).  §§1.2--1.7 give matrices, duals,
+  Hamming data, puncturing, shortening, direct sums, and equivalence; §1.9 gives the initial Golay
+  matrices; Chapter 7 gives weight distributions and the MacWilliams equations; Chapters 9--10
+  give self-dual codes, additive `F₄` codes, the binary and ternary Golay codes, and the hexacode.
+  Examples 1.3.3--1.3.4 fix the tetracode and Hermitian hexacode conventions used here.
+- F. J. MacWilliams and N. J. A. Sloane, *The Theory of Error-Correcting Codes*, North-Holland
+  Mathematical Library 16 (1977),
+  [publisher page](https://www.sciencedirect.com/bookseries/north-holland-mathematical-library/vol/16).
+  Chapters 1 and 5 supply linear-code foundations, dual weight distributions, and MacWilliams;
+  Chapters 18--20 supply code constructions, self-dual codes, and the Golay codes.
+- J. H. Conway and N. J. A. Sloane, *Sphere Packings, Lattices and Groups*, 3rd ed., Springer
+  (1999), [DOI](https://doi.org/10.1007/978-1-4757-6568-7).  Chapter 4 §3 supplies discriminant
+  glue coordinates; Chapter 5 §2 and Chapter 7 §§2, 6, 8--9 supply Construction A and its binary,
+  Type II, and nonbinary forms.  The code descriptions used by the later rank-24 constructions are
+  treated as examples, not as a classification target here.
+- W. Ebeling, *Lattices and Codes*, 3rd ed., Springer (2013),
+  [DOI](https://doi.org/10.1007/978-3-658-00360-9).  §§1.2--1.3 give binary codes and the exact
+  Construction A equivalences (Proposition 1.3); §§2.8--2.9 give the Golay enumerator and
+  MacWilliams normalization; §3.3 gives the discriminant-coordinate viewpoint; §§5.2 and 5.4 give
+  the ternary code and dual-lattice calculations.  Its theta-function proofs are background only:
+  theta series are outside this roadmap.
+- M. Harada, A. Munemasa, and B. Venkov, “Classification of ternary extremal self-dual codes of
+  length 28,” *Math. Comp.* **78** (2009), 1787--1796,
+  [DOI](https://doi.org/10.1090/S0025-5718-08-02194-7).  Section 2 fixes the general `Z_k`
+  Construction-A normalization, the self-dual-to-unimodular implication, and the converse through
+  `k`-frames.  It does not state the full dual-carrier identity targeted above.
+- A. Munemasa and H. Tamura, “The codes and the lattices of Hadamard matrices,” *European J.
+  Combin.* **33** (2012), 519--533,
+  [DOI](https://doi.org/10.1016/j.ejc.2011.11.007).  Section 4 uses the general `Z_m`
+  integrality/self-orthogonality and unimodularity/self-duality criteria in the normalization which
+  this roadmap translates to its rational ambient space.
+- S. T. Dougherty, T. A. Gulliver, and M. Harada, “Type II self-dual codes over finite rings and
+  even unimodular lattices,” *J. Algebraic Combin.* **9** (1999), 233--250,
+  [DOI](https://doi.org/10.1023/A:1018696102510).  This is the source for Type II codes over
+  `Z/(2^r)` and their even-unimodular Construction-A lattices; its modulus restriction is retained.
+
+Mathematical review is wanted from a coding theorist, especially for the equivalence conventions,
+the `F₄` Hermitian/D₄ discriminant identification, and the exact hypotheses of the generalized
+`ZMod m` Construction A statements, and from a Lean contributor familiar with finite sums,
+matrices, `MvPolynomial`, and finite character sums.

--- a/TauCetiRoadmap/AlgebraicCodingTheory/Suggested.lean
+++ b/TauCetiRoadmap/AlgebraicCodingTheory/Suggested.lean
@@ -1,0 +1,716 @@
+import Mathlib
+import TauCetiRoadmap.IntegralLattices.Suggested
+
+/-!
+# Algebraic coding theory and Construction A: target signatures
+
+**This file is not the roadmap and is not exhaustive.** The definitive specification is
+`README.md`. The declarations below suggest Lean forms for load-bearing milestones, so that
+contributors and reviewers can test the carrier choices, normalizations, and dependency boundary.
+Proving every declaration here would not by itself complete a layer or the roadmap. `sorry` is
+permitted in this human-owned roadmap repository: these are targets, not implementations.
+
+Linear codes remain Mathlib `Submodule`s and additive codes remain `AddSubgroup`s. Hamming weight
+is Mathlib's `hammingNorm`. Construction A uses the rational form `dotProduct / m`, and its gluing
+comparison consumes the integral-lattices roadmap's actual discriminant quotient and
+`ofIsotropicSubgroup`. The Markdown roadmap remains definitive.
+-/
+
+namespace TauCetiRoadmap.AlgebraicCodingTheory
+
+open scoped BigOperators
+open MvPolynomial
+
+universe u v w
+
+/-! ## Carriers, matrix presentations, and elementary operations -/
+
+/-- The primary representation: no length or dimension is bundled into the code. -/
+abbrev LinearCode (F : Type u) [Field F] (ι : Type v) := Submodule F (ι → F)
+
+/-- Additive codes include the subgroups used as discriminant glue. -/
+abbrev AdditiveCode (A : Type u) [AddCommGroup A] (ι : Type v) := AddSubgroup (ι → A)
+
+section LinearCodes
+
+variable {F : Type u} [Field F]
+variable {ι : Type v} [Fintype ι]
+variable {ρ : Type w} [Fintype ρ]
+
+/-- The standard Euclidean bilinear form, with no field involution. -/
+def standardBilin : LinearMap.BilinForm F (ι → F) := dotProductBilin F F
+
+/-- The Euclidean dual code is Mathlib's orthogonal submodule. -/
+def dual (C : LinearCode F ι) : LinearCode F ι := (standardBilin (F := F) (ι := ι)).orthogonal C
+
+theorem mem_dual_iff (C : LinearCode F ι) (y : ι → F) :
+    y ∈ dual C ↔ ∀ x ∈ C, ∑ i, x i * y i = 0 := sorry
+
+/-- Row vectors multiply the generator matrix on the left. -/
+def generatedCode (G : Matrix ρ ι F) : LinearCode F ι := LinearMap.range G.vecMulLinear
+
+/-- A parity-check matrix sends a word to its syndrome. -/
+def checkedCode {σ : Type*} [Fintype σ] (H : Matrix σ ι F) : LinearCode F ι :=
+  LinearMap.ker H.mulVecLin
+
+def IsGeneratorMatrix (G : Matrix ρ ι F) (C : LinearCode F ι) : Prop :=
+  generatedCode G = C
+
+def IsParityCheckMatrix {σ : Type*} [Fintype σ]
+    (H : Matrix σ ι F) (C : LinearCode F ι) : Prop :=
+  checkedCode H = C
+
+/-- A generator for `C` is a parity check for `C⊥`, with the pinned row convention. -/
+theorem generator_iff_check_dual (G : Matrix ρ ι F) (C : LinearCode F ι) :
+    IsGeneratorMatrix G C ↔ IsParityCheckMatrix G (dual C) := sorry
+
+/-! Hermitian duality is expressed through Mathlib's sesquilinear maps.  The form below is
+linear in its first input and `σ`-semilinear in its second input. -/
+
+/-- The coordinate Hermitian form `Σ i, x i * σ (y i)` for a chosen field automorphism. -/
+noncomputable def standardHermitian (σ : F ≃+* F) :
+    (ι → F) →ₗ[F] (ι → F) →ₛₗ[σ.toRingHom] F := sorry
+
+theorem standardHermitian_apply (σ : F ≃+* F) (x y : ι → F) :
+    standardHermitian σ x y = ∑ i, x i * σ (y i) := sorry
+
+theorem standardHermitian_nondegenerate (σ : F ≃+* F) :
+    (standardHermitian (ι := ι) σ).Nondegenerate := sorry
+
+/-- The Hermitian dual uses `orthogonalBilin`, not the Euclidean `BilinForm.orthogonal`. -/
+noncomputable def hermitianDual (σ : F ≃+* F) (C : LinearCode F ι) : LinearCode F ι :=
+  C.orthogonalBilin (standardHermitian σ)
+
+theorem mem_hermitianDual_iff (σ : F ≃+* F) (C : LinearCode F ι) (y : ι → F) :
+    y ∈ hermitianDual σ C ↔ ∀ x ∈ C, ∑ i, x i * σ (y i) = 0 := sorry
+
+theorem hermitianDual_hermitianDual (σ : F ≃+* F) (hσ : Function.Involutive σ)
+    (C : LinearCode F ι) :
+    hermitianDual σ (hermitianDual σ C) = C := sorry
+
+theorem finrank_add_finrank_hermitianDual (σ : F ≃+* F) (hσ : Function.Involutive σ)
+    (C : LinearCode F ι) :
+    Module.finrank F C + Module.finrank F (hermitianDual σ C) = Fintype.card ι := sorry
+
+/-- With our orientation, the conjugated generator, not `G`, checks the Hermitian dual. -/
+theorem generator_iff_conjugate_check_hermitianDual
+    (σ : F ≃+* F) (hσ : Function.Involutive σ)
+    (G : Matrix ρ ι F) (C : LinearCode F ι) :
+    IsGeneratorMatrix G C ↔
+      IsParityCheckMatrix (G.map σ) (hermitianDual σ C) := sorry
+
+/-- Puncturing retains exactly the coordinates in `s`. -/
+noncomputable def puncture (C : LinearCode F ι) (s : Set ι) [Fintype s] :
+    LinearCode F s := sorry
+
+/-- Shortening first imposes zero outside `s`, then retains `s`. -/
+noncomputable def shorten (C : LinearCode F ι) (s : Set ι) [Fintype s] :
+    LinearCode F s := sorry
+
+/-- Direct sum uses a disjoint-union coordinate type. -/
+noncomputable def directSum {κ : Type*} [Fintype κ]
+    (C : LinearCode F ι) (D : LinearCode F κ) : LinearCode F (ι ⊕ κ) := sorry
+
+theorem dual_puncture (C : LinearCode F ι) (s : Set ι) [Fintype s] :
+    dual (puncture C s) = shorten (dual C) s := sorry
+
+theorem dual_shorten (C : LinearCode F ι) (s : Set ι) [Fintype s] :
+    dual (shorten C s) = puncture (dual C) s := sorry
+
+/-- Data for a coordinate permutation followed by multiplication by nonzero scalars. -/
+structure MonomialEquiv (κ : Type*) where
+  reindex : ι ≃ κ
+  scale : κ → Fˣ
+
+noncomputable def MonomialEquiv.toLinearEquiv {κ : Type*}
+    (e : MonomialEquiv (F := F) (ι := ι) κ) : (ι → F) ≃ₗ[F] (κ → F) := sorry
+
+def MonomialEquiv.mapsCode {κ : Type*}
+    (e : MonomialEquiv (F := F) (ι := ι) κ)
+    (C : LinearCode F ι) (D : LinearCode F κ) : Prop :=
+  C.map e.toLinearEquiv.toLinearMap = D
+
+/-- The stabilizer notion behind `Aut(C)`; permutation automorphisms are a named subgroup. -/
+def IsMonomialAutomorphism (C : LinearCode F ι)
+    (e : MonomialEquiv (F := F) (ι := ι) ι) : Prop := e.mapsCode C C
+
+end LinearCodes
+
+/-! ## Hamming data and weight enumerators -/
+
+section Hamming
+
+variable {F : Type u} [Field F] [Finite F] [DecidableEq F]
+variable {ι : Type v} [Fintype ι]
+
+/-- The zero code has minimum distance zero.  This follows Mathlib PR #38014's `Set.infsep`
+interface; a later bridge identifies `Fin n` instances with its `InformationTheory.minDist`. -/
+noncomputable def minimumDistance (C : LinearCode F ι) : ℕ :=
+  ⌊({x : Hamming fun _ : ι ↦ F | Hamming.ofHamming x ∈ C} :
+      Set (Hamming fun _ : ι ↦ F)).infsep⌋₊
+
+/-- The metric definition equals the least-nonzero-weight formula, including the empty-set
+convention for the zero code. -/
+theorem minimumDistance_eq_sInf_weights (C : LinearCode F ι) :
+    minimumDistance C =
+      sInf {d : ℕ | ∃ c : C, (c : ι → F) ≠ 0 ∧ d = hammingNorm (c : ι → F)} := sorry
+
+theorem minimumDistance_eq_minimumWeight (C : LinearCode F ι) (hC : C ≠ ⊥) :
+    ∃ c : C, (c : ι → F) ≠ 0 ∧ hammingNorm (c : ι → F) = minimumDistance C := sorry
+
+/-- Coefficients are integral and variables `0,1` are respectively `X,Y`. -/
+noncomputable def weightEnumerator (C : LinearCode F ι) : MvPolynomial (Fin 2) ℤ := by
+  classical
+  letI := Fintype.ofFinite C
+  exact ∑ c : C,
+    X 0 ^ (Fintype.card ι - hammingNorm (c : ι → F)) *
+      X 1 ^ hammingNorm (c : ι → F)
+
+/-- The integral MacWilliams substitution `(X,Y) ↦ (X+(q-1)Y,X-Y)`. -/
+noncomputable def macWilliamsSubstitution (q : ℕ) :
+    MvPolynomial (Fin 2) ℤ →+* MvPolynomial (Fin 2) ℤ :=
+  eval₂Hom (MvPolynomial.C : ℤ →+* MvPolynomial (Fin 2) ℤ)
+    ![X 0 + C ((q : ℤ) - 1) * X 1, X 0 - X 1]
+
+/-- Division-free, hence valid over the integral coefficient ring. -/
+theorem macWilliams (D : LinearCode F ι) :
+    MvPolynomial.C (Nat.card D : ℤ) * weightEnumerator (dual D) =
+      macWilliamsSubstitution (Nat.card F) (weightEnumerator D) := sorry
+
+theorem weightEnumerator_directSum {κ : Type*} [Fintype κ]
+    (C₁ : LinearCode F ι) (C₂ : LinearCode F κ) :
+    weightEnumerator (directSum C₁ C₂) = weightEnumerator C₁ * weightEnumerator C₂ := sorry
+
+end Hamming
+
+/-! ## Binary Type II codes -/
+
+abbrev F2 := ZMod 2
+
+section TypeII
+
+variable {ι : Type v} [Fintype ι]
+
+def IsDoublyEven (C : LinearCode F2 ι) : Prop :=
+  ∀ c ∈ C, 4 ∣ hammingNorm c
+
+def IsSelfDual (C : LinearCode F2 ι) : Prop := dual C = C
+
+def IsTypeII (C : LinearCode F2 ι) : Prop := IsDoublyEven C ∧ IsSelfDual C
+
+theorem typeII_length_mod_eight (C : LinearCode F2 ι) (hC : IsTypeII C) :
+    Fintype.card ι % 8 = 0 := sorry
+
+/-- Self-duality gives the integral, division-free MacWilliams invariance. -/
+theorem typeII_macWilliams_invariance (C : LinearCode F2 ι) (hC : IsTypeII C) :
+    macWilliamsSubstitution 2 (weightEnumerator C) =
+      MvPolynomial.C ((2 ^ (Fintype.card ι / 2) : ℕ) : ℤ) * weightEnumerator C := sorry
+
+/-- The substitution `(X,Y) ↦ (X,iY)` after the coefficient base change `ℤ → ℂ`. -/
+noncomputable def typeIIRotationSubstitution :
+    MvPolynomial (Fin 2) ℂ →+* MvPolynomial (Fin 2) ℂ :=
+  eval₂Hom (MvPolynomial.C : ℂ →+* MvPolynomial (Fin 2) ℂ)
+    ![X 0, C Complex.I * X 1]
+
+/-- Divisibility of all weights by four gives `W_C(X,iY)=W_C(X,Y)`. -/
+theorem typeII_rotation_invariance (C : LinearCode F2 ι) (hC : IsTypeII C) :
+    typeIIRotationSubstitution
+        (MvPolynomial.map (Int.castRingHom ℂ) (weightEnumerator C)) =
+      MvPolynomial.map (Int.castRingHom ℂ) (weightEnumerator C) := sorry
+
+end TypeII
+
+/-! ## Explicit exceptional codes -/
+
+/-- The ternary tetracode matrix, in the displayed coordinate order from the roadmap. -/
+def tetracodeGenerator : Matrix (Fin 2) (Fin 4) (ZMod 3) :=
+  ![![1, 0, 1, 1], ![0, 1, 1, -1]]
+
+def tetracode : LinearCode (ZMod 3) (Fin 4) := generatedCode tetracodeGenerator
+
+theorem tetracode_selfDual : dual tetracode = tetracode := sorry
+
+theorem tetracode_minimumDistance : minimumDistance tetracode = 3 := sorry
+
+/-- The chosen four-element field; changing the root of `X²+X+1` gives an equivalent code. -/
+abbrev F4 := GaloisField 2 2
+
+noncomputable local instance : DecidableEq F4 := Classical.decEq F4
+
+noncomputable def omega : F4 := sorry
+
+theorem omega_spec : omega ^ 2 + omega + 1 = 0 := sorry
+
+noncomputable def hexacodeGenerator : Matrix (Fin 3) (Fin 6) F4 :=
+  ![![1, 0, 0, 1, omega, omega],
+    ![0, 1, 0, omega, 1, omega],
+    ![0, 0, 1, omega, omega, 1]]
+
+noncomputable def hexacode : LinearCode F4 (Fin 6) := generatedCode hexacodeGenerator
+
+/-- Frobenius squaring as the nontrivial involutive automorphism of `F₄`. -/
+noncomputable def frobeniusF4 : F4 ≃+* F4 := sorry
+
+theorem frobeniusF4_apply (x : F4) : frobeniusF4 x = x ^ 2 := sorry
+
+theorem frobeniusF4_involutive : Function.Involutive frobeniusF4 := sorry
+
+/-- Hermitian duality is the generic sesquilinear construction specialized to Frobenius. -/
+noncomputable abbrev hermitianDualF4 (C : LinearCode F4 (Fin 6)) :
+    LinearCode F4 (Fin 6) := hermitianDual frobeniusF4 C
+
+theorem hexacode_hermitian_selfDual : hermitianDualF4 hexacode = hexacode := sorry
+
+theorem hexacode_minimumDistance : minimumDistance hexacode = 4 := sorry
+
+/-- Entrywise Frobenius conjugation of an `F₄`-linear code. -/
+noncomputable def frobeniusConjugateF4 {n : ℕ} (C : LinearCode F4 (Fin n)) :
+    LinearCode F4 (Fin n) := sorry
+
+/-- In one-based notation this is the coordinate ordering `(1,2,4,6,3,5)`. -/
+noncomputable def hexacodeConjugationPermutation : Equiv.Perm (Fin 6) := sorry
+
+theorem hexacodeConjugationPermutation_values :
+    List.ofFn (fun i ↦ (hexacodeConjugationPermutation i).val + 1) = [1, 2, 4, 6, 3, 5] := sorry
+
+/-- Exchanging `ω` and `ω²` produces a genuinely permutation-equivalent code. -/
+theorem hexacode_conjugate_permutation_equivalent :
+    ∃ e : MonomialEquiv (F := F4) (ι := Fin 6) (Fin 6),
+      e.reindex = hexacodeConjugationPermutation ∧
+        e.mapsCode (frobeniusConjugateF4 hexacode) hexacode := sorry
+
+theorem hexacode_frobeniusConjugate_ne : frobeniusConjugateF4 hexacode ≠ hexacode := sorry
+
+theorem natCard_hexacode_inf_frobeniusConjugate :
+    Nat.card ↑(hexacode ⊓ frobeniusConjugateF4 hexacode) = 4 := sorry
+
+/-- The displayed rows are Hermitian-orthogonal; this is the Gram-matrix convention check. -/
+theorem hexacodeGenerator_hermitian_gram_zero :
+    hexacodeGenerator * (hexacodeGenerator.map frobeniusF4).transpose = 0 := sorry
+
+/-- The same matrix is not Euclidean self-orthogonal. -/
+theorem hexacodeGenerator_euclidean_gram_ne_zero :
+    hexacodeGenerator * hexacodeGenerator.transpose ≠ 0 := sorry
+
+/-- The quadratic residues modulo eleven, together with zero. -/
+def isGolayResidue (a : ℕ) : Bool :=
+  a % 11 == 0 || a % 11 == 1 || a % 11 == 3 ||
+    a % 11 == 4 || a % 11 == 5 || a % 11 == 9
+
+/-- The bordered reverse-circulant block in Huffman--Pless §1.9.1; index zero is the border. -/
+def binaryGolayBlock : Matrix (Fin 12) (Fin 12) F2 := fun i j ↦
+  if i.val = 0 then
+    if j.val = 0 then 0 else 1
+  else if j.val = 0 then 1
+  else if isGolayResidue ((i.val - 1) + (j.val - 1)) then 1 else 0
+
+/-- A concrete systematic generator `[I₁₂ | A]`, on sum coordinates. -/
+def binaryGolayGenerator : Matrix (Fin 12) (Fin 12 ⊕ Fin 12) F2 := fun i j ↦
+  match j with
+  | Sum.inl k => if i = k then 1 else 0
+  | Sum.inr k => binaryGolayBlock i k
+
+def extendedBinaryGolay : LinearCode F2 (Fin 12 ⊕ Fin 12) :=
+  generatedCode binaryGolayGenerator
+
+theorem binaryGolayGenerator_isParityCheck :
+    IsParityCheckMatrix binaryGolayGenerator extendedBinaryGolay := sorry
+
+theorem extendedBinaryGolay_typeII : IsTypeII extendedBinaryGolay := sorry
+
+theorem extendedBinaryGolay_minimumDistance : minimumDistance extendedBinaryGolay = 8 := sorry
+
+theorem extendedBinaryGolay_weightEnumerator :
+    weightEnumerator extendedBinaryGolay =
+      X 0 ^ 24 + 759 * X 0 ^ 16 * X 1 ^ 8 + 2576 * X 0 ^ 12 * X 1 ^ 12 +
+        759 * X 0 ^ 8 * X 1 ^ 16 + X 1 ^ 24 := sorry
+
+def ternaryGolayBlock : Matrix (Fin 6) (Fin 6) (ZMod 3) :=
+  ![![0, 1, 1, 1, 1, 1],
+    ![1, 0, 1, 2, 2, 1],
+    ![1, 1, 0, 1, 2, 2],
+    ![1, 2, 1, 0, 1, 2],
+    ![1, 2, 2, 1, 0, 1],
+    ![1, 1, 2, 2, 1, 0]]
+
+def ternaryGolayGenerator : Matrix (Fin 6) (Fin 6 ⊕ Fin 6) (ZMod 3) := fun i j ↦
+  match j with
+  | Sum.inl k => if i = k then 1 else 0
+  | Sum.inr k => ternaryGolayBlock i k
+
+def extendedTernaryGolay : LinearCode (ZMod 3) (Fin 6 ⊕ Fin 6) :=
+  generatedCode ternaryGolayGenerator
+
+theorem extendedTernaryGolay_selfDual : dual extendedTernaryGolay = extendedTernaryGolay := sorry
+
+theorem extendedTernaryGolay_minimumDistance : minimumDistance extendedTernaryGolay = 6 := sorry
+
+/-! ## Construction A and the discriminant-subgroup bridge -/
+
+open TauCetiRoadmap.IntegralLattices
+
+section ConstructionA
+
+variable {ι : Type v} [Fintype ι]
+
+/-- Orthogonality for additive `ZMod m` codes uses the coordinate dot product. -/
+noncomputable def zmodDual (m : ℕ) (_hm : 2 ≤ m) (C : AdditiveCode (ZMod m) ι) :
+    AdditiveCode (ZMod m) ι := sorry
+
+/-- At modulus two the additive and linear Euclidean duals are the same carrier. -/
+theorem zmodDual_two_toAddSubgroup (C : LinearCode F2 ι) :
+    zmodDual 2 (by decide) C.toAddSubgroup = (dual C).toAddSubgroup := sorry
+
+/-- The inverse image of `C` in integer vectors, embedded in the fixed rational ambient space. -/
+noncomputable def constructionACarrier (m : ℕ) (_hm : 2 ≤ m)
+    (C : AdditiveCode (ZMod m) ι) :
+    Submodule ℤ (ι → ℚ) := sorry
+
+theorem mem_constructionACarrier_iff (m : ℕ) (hm : 2 ≤ m)
+    (C : AdditiveCode (ZMod m) ι)
+    (x : ι → ℚ) :
+    x ∈ constructionACarrier m hm C ↔
+      ∃ z : ι → ℤ, (∀ i, x i = (z i : ℚ)) ∧ (fun i ↦ (z i : ZMod m)) ∈ C := sorry
+
+/-- The rational normalization corresponding over `ℝ` to scaling vectors by `m⁻¹/²`. -/
+noncomputable def constructionAForm (m : ℕ) (_hm : 2 ≤ m) : LinearMap.BilinForm ℚ (ι → ℚ) :=
+  (m : ℚ)⁻¹ • dotProductBilin ℚ ℚ
+
+/-- Integrality requires exactly self-orthogonality of the residue code. -/
+noncomputable def constructionA (m : ℕ) (hm : 2 ≤ m) (C : AdditiveCode (ZMod m) ι)
+    (hC : C ≤ zmodDual m hm C) : IntegralLattice (ι → ℚ) := sorry
+
+/-- Dual carriers are identified literally in the same rational ambient space. -/
+theorem constructionA_dual (m : ℕ) (hm : 2 ≤ m) (C : AdditiveCode (ZMod m) ι)
+    (hC : C ≤ zmodDual m hm C) :
+    (constructionA m hm C hC).dual = constructionACarrier m hm (zmodDual m hm C) := sorry
+
+theorem constructionA_unimodular_iff (m : ℕ) (hm : 2 ≤ m)
+    (C : AdditiveCode (ZMod m) ι) (hC : C ≤ zmodDual m hm C) :
+    (constructionA m hm C hC).IsUnimodular ↔ C = zmodDual m hm C := sorry
+
+/-- For even `m`, this is independent of the chosen integer representatives. -/
+noncomputable def constructionAQuadraticValue (m : ℕ) (_hm₂ : 2 ≤ m) (_hmeven : Even m)
+    (c : ι → ZMod m) : AddCircle (1 : ℚ) :=
+  ((↑((∑ i, ((c i).val : ℚ) ^ 2 / (2 * (m : ℚ))) : ℚ)) : AddCircle (1 : ℚ))
+
+/-- Any integer lifts give the same half-norm residue value. -/
+theorem constructionAQuadraticValue_eq_sum_lifts
+    (m : ℕ) (hm₂ : 2 ≤ m) (hmeven : Even m) (c : ι → ZMod m)
+    (z : ι → ℤ) (hz : ∀ i, (z i : ZMod m) = c i) :
+    constructionAQuadraticValue m hm₂ hmeven c =
+      (↑((∑ i, (z i : ℚ) ^ 2 / (2 * (m : ℚ))) : ℚ) : AddCircle (1 : ℚ)) := sorry
+
+theorem constructionA_even_iff (m : ℕ) (hm₂ : 2 ≤ m) (hmeven : Even m)
+    (C : AdditiveCode (ZMod m) ι) (hC : C ≤ zmodDual m hm₂ C) :
+    (constructionA m hm₂ C hC).IsEven ↔
+      ∀ c ∈ C, constructionAQuadraticValue m hm₂ hmeven c = 0 := sorry
+
+/-- The half-norm residue value at modulus two is Hamming weight divided by four. -/
+theorem constructionAQuadraticValue_two (c : ι → F2) :
+    constructionAQuadraticValue 2 (by decide) (by decide) c =
+      ((↑((hammingNorm c : ℚ) / 4) : AddCircle (1 : ℚ))) := sorry
+
+/-- Euclidean weight for a residue word, using least absolute residue representatives. -/
+noncomputable def zmodEuclideanWeight (m : ℕ) (_hm₂ : 2 ≤ m) (c : ι → ZMod m) : ℕ :=
+  ∑ i, min (c i).val (m - (c i).val) ^ 2
+
+/-- The published higher-modulus Type II notion is restricted to `Z/(2^r)`. -/
+def IsTypeIIZModTwoPower (r : ℕ) (hr : 1 ≤ r)
+    (C : AdditiveCode (ZMod (2 ^ r)) ι) : Prop :=
+  let hm : 2 ≤ 2 ^ r := by
+    simpa using (pow_le_pow_right' (a := (2 : ℕ)) (by omega) hr)
+  C = zmodDual (2 ^ r) hm C ∧
+    ∀ c ∈ C, 2 ^ (r + 1) ∣ zmodEuclideanWeight (2 ^ r) hm c
+
+/-- Dougherty--Gulliver--Harada's Type II/even-unimodular Construction-A implication. -/
+theorem constructionA_typeIIZModTwoPower_even_unimodular
+    (r : ℕ) (hr : 1 ≤ r) (C : AdditiveCode (ZMod (2 ^ r)) ι)
+    (hC : IsTypeIIZModTwoPower r hr C) :
+    let hm : 2 ≤ 2 ^ r := by
+      simpa using (pow_le_pow_right' (a := (2 : ℕ)) (by omega) hr)
+    ∃ hself : C ≤ zmodDual (2 ^ r) hm C,
+      (constructionA (2 ^ r) hm C hself).IsEven ∧
+        (constructionA (2 ^ r) hm C hself).IsUnimodular := sorry
+
+/-- The integral base has carrier `mℤ^ι`; its dual is `ℤ^ι`; it is even for even `m`. -/
+noncomputable def constructionABase (m : ℕ) (hm₂ : 2 ≤ m) :
+    IntegralLattice (ι → ℚ) := sorry
+
+theorem constructionABase_isEven (m : ℕ) (hm₂ : 2 ≤ m) (hmeven : Even m) :
+    (constructionABase (ι := ι) m hm₂).IsEven := sorry
+
+/-- The coordinate discriminant pairing at every nonzero modulus. -/
+noncomputable def coordinateBilinearModule (ι : Type v) [Fintype ι]
+    (m : ℕ) (hm₂ : 2 ≤ m) : FiniteBilinearModule := by
+  letI : NeZero m := ⟨by omega⟩
+  letI : DecidableEq ι := Classical.decEq ι
+  letI : Fintype (ZMod m) := ZMod.fintype m
+  letI : Fintype (ι → ZMod m) := Pi.instFintype
+  exact
+    { A := ι → ZMod m
+      addCommGroup := inferInstance
+      finite := Finite.of_fintype (ι → ZMod m)
+      pairing := sorry
+      symmetric := sorry }
+
+/-- The coordinate quadratic module with values `Σ lift(cᵢ)²/(2m) mod ℤ`. -/
+noncomputable def coordinateQuadraticModule (ι : Type v) [Fintype ι]
+    (m : ℕ) (hm₂ : 2 ≤ m) (_hmeven : Even m) : FiniteQuadraticModule where
+      toFiniteBilinearModule := coordinateBilinearModule ι m hm₂
+      quadratic := sorry
+      polar := sorry
+
+/-- An integer vector is canonically in the dual of the base `mℤ^ι`. -/
+noncomputable def constructionABaseDualOfInt (m : ℕ) (hm₂ : 2 ≤ m) (z : ι → ℤ) :
+    (constructionABase (ι := ι) m hm₂).dual := sorry
+
+/-- The discriminant quotient of `mℤ^ι` is coordinatewise reduction modulo `m`. -/
+noncomputable def constructionABaseDiscriminantEquiv (m : ℕ) (hm₂ : 2 ≤ m) :
+    (constructionABase (ι := ι) m hm₂).DiscriminantGroup ≃+ (ι → ZMod m) := sorry
+
+theorem constructionABaseDiscriminantEquiv_integerClass
+    (m : ℕ) (hm₂ : 2 ≤ m) (z : ι → ℤ) :
+    constructionABaseDiscriminantEquiv m hm₂
+        ((constructionABase (ι := ι) m hm₂).carrierInDual.mkQ
+          (constructionABaseDualOfInt m hm₂ z)) =
+      fun i ↦ (z i : ZMod m) := sorry
+
+/-- The additive equivalence also preserves the residue/discriminant bilinear pairings. -/
+theorem constructionABaseDiscriminantEquiv_pairing
+    (m : ℕ) (hm₂ : 2 ≤ m)
+    (x y : (constructionABase (ι := ι) m hm₂).DiscriminantGroup) :
+    (coordinateBilinearModule ι m hm₂).pairing
+        (constructionABaseDiscriminantEquiv m hm₂ x)
+        (constructionABaseDiscriminantEquiv m hm₂ y) =
+      (constructionABase (ι := ι) m hm₂).discriminantPairing x y := sorry
+
+/-- The key normalization check between residues and the actual discriminant quotient. -/
+noncomputable def constructionABaseDiscriminantIsometry
+    (m : ℕ) (hm₂ : 2 ≤ m) (hmeven : Even m) :
+    FiniteQuadraticModule.Isometry
+      ((constructionABase (ι := ι) m hm₂).discriminantQuadraticModule
+        (constructionABase_isEven (ι := ι) m hm₂ hmeven))
+      (coordinateQuadraticModule ι m hm₂ hmeven) where
+  toAddEquiv := constructionABaseDiscriminantEquiv m hm₂
+  map_quadratic := sorry
+
+/-- The actual inverse image of `C` under the pinned discriminant-coordinate equivalence. -/
+noncomputable def codeInBaseDiscriminant
+    (m : ℕ) (hm₂ : 2 ≤ m)
+    (C : AdditiveCode (ZMod m) ι) :
+    AddSubgroup (constructionABase (ι := ι) m hm₂).DiscriminantGroup :=
+  C.comap (constructionABaseDiscriminantEquiv m hm₂).toAddMonoidHom
+
+/-- Orthogonal complement commutes with the coordinate/discriminant equivalence. -/
+theorem orthogonalComplement_codeInBaseDiscriminant
+    (m : ℕ) (hm₂ : 2 ≤ m) (C : AdditiveCode (ZMod m) ι) :
+    (constructionABase (ι := ι) m hm₂).discriminantBilinearModule.orthogonalComplement
+        (codeInBaseDiscriminant m hm₂ C) =
+      codeInBaseDiscriminant m hm₂ (zmodDual m hm₂ C) := sorry
+
+theorem codeInBaseDiscriminant_isIsotropic
+    (m : ℕ) (hm₂ : 2 ≤ m) (hmeven : Even m)
+    (C : AdditiveCode (ZMod m) ι)
+    (hC : ∀ c ∈ C, constructionAQuadraticValue m hm₂ hmeven c = 0) :
+    ((constructionABase (ι := ι) m hm₂).discriminantQuadraticModule
+      (constructionABase_isEven (ι := ι) m hm₂ hmeven)).IsIsotropic
+        (codeInBaseDiscriminant m hm₂ C) := sorry
+
+/-- Construction A is the existing preimage/gluing construction, not a parallel notion. -/
+noncomputable def constructionAAsGluing
+    (m : ℕ) (hm₂ : 2 ≤ m) (hmeven : Even m)
+    (C : AdditiveCode (ZMod m) ι) (hself : C ≤ zmodDual m hm₂ C)
+    (hq : ∀ c ∈ C, constructionAQuadraticValue m hm₂ hmeven c = 0) :
+    IntegralLattice.Isometry (ι → ℚ)
+      (constructionA m hm₂ C hself)
+      ((constructionABase (ι := ι) m hm₂).ofIsotropicSubgroup
+        (constructionABase_isEven (ι := ι) m hm₂ hmeven)
+        (codeInBaseDiscriminant m hm₂ C)
+        (codeInBaseDiscriminant_isIsotropic m hm₂ hmeven C hq)) := sorry
+
+/-- The literal copy of `C` inside `C^⊥`, used to form the quotient `C^⊥/C`. -/
+noncomputable def codeInZModDual (m : ℕ) (hm₂ : 2 ≤ m) (C : AdditiveCode (ZMod m) ι)
+    (_hself : C ≤ zmodDual m hm₂ C) : Submodule ℤ (zmodDual m hm₂ C) :=
+  (C.comap (zmodDual m hm₂ C).subtype).toIntSubmodule
+
+/-- The quotient `C^⊥/C`, not merely a group of the same cardinality. -/
+abbrev CodeOrthogonalQuotient (m : ℕ) (hm₂ : 2 ≤ m)
+    (C : AdditiveCode (ZMod m) ι) (hself : C ≤ zmodDual m hm₂ C) :=
+  zmodDual m hm₂ C ⧸ codeInZModDual m hm₂ C hself
+
+/-- The bilinear form induced on the literal quotient `C^⊥/C`. -/
+noncomputable def codeOrthogonalQuotientBilinearModule
+    (m : ℕ) (hm₂ : 2 ≤ m) (C : AdditiveCode (ZMod m) ι)
+    (hself : C ≤ zmodDual m hm₂ C) : FiniteBilinearModule where
+  A := CodeOrthogonalQuotient m hm₂ C hself
+  addCommGroup := inferInstance
+  finite := sorry
+  pairing := sorry
+  symmetric := sorry
+
+/-- The quadratic refinement on `C^⊥/C` when `C` is quadratically isotropic. -/
+noncomputable def codeOrthogonalQuotientQuadraticModule
+    (m : ℕ) (hm₂ : 2 ≤ m) (hmeven : Even m)
+    (C : AdditiveCode (ZMod m) ι) (hself : C ≤ zmodDual m hm₂ C)
+    (_hq : ∀ c ∈ C, constructionAQuadraticValue m hm₂ hmeven c = 0) :
+    FiniteQuadraticModule where
+  toFiniteBilinearModule := codeOrthogonalQuotientBilinearModule m hm₂ C hself
+  quadratic := sorry
+  polar := sorry
+
+theorem constructionA_isEven
+    (m : ℕ) (hm₂ : 2 ≤ m) (hmeven : Even m)
+    (C : AdditiveCode (ZMod m) ι) (hself : C ≤ zmodDual m hm₂ C)
+    (hq : ∀ c ∈ C, constructionAQuadraticValue m hm₂ hmeven c = 0) :
+    (constructionA m hm₂ C hself).IsEven :=
+  (constructionA_even_iff m hm₂ hmeven C hself).2 hq
+
+/-- The promised bilinear isometry `A_{P_m(C)} ≅ C^⊥/C`, packaged as an additive
+equivalence together with its form-preservation equation until PR 1's general bilinear-isometry
+structure is available. -/
+noncomputable def constructionADiscriminantBilinearIsometry
+    (m : ℕ) (hm₂ : 2 ≤ m) (C : AdditiveCode (ZMod m) ι)
+    (hself : C ≤ zmodDual m hm₂ C) :
+    { e : (constructionA m hm₂ C hself).DiscriminantGroup ≃+
+          CodeOrthogonalQuotient m hm₂ C hself //
+      ∀ x y, (codeOrthogonalQuotientBilinearModule m hm₂ C hself).pairing (e x) (e y) =
+        (constructionA m hm₂ C hself).discriminantPairing x y } := sorry
+
+/-- The quadratic strengthening of `A_{P_m(C)} ≅ C^⊥/C`. -/
+noncomputable def constructionADiscriminantQuadraticIsometry
+    (m : ℕ) (hm₂ : 2 ≤ m) (hmeven : Even m)
+    (C : AdditiveCode (ZMod m) ι) (hself : C ≤ zmodDual m hm₂ C)
+    (hq : ∀ c ∈ C, constructionAQuadraticValue m hm₂ hmeven c = 0) :
+    FiniteQuadraticModule.Isometry
+      ((constructionA m hm₂ C hself).discriminantQuadraticModule
+        (constructionA_isEven m hm₂ hmeven C hself hq))
+      (codeOrthogonalQuotientQuadraticModule m hm₂ hmeven C hself hq) := sorry
+
+end ConstructionA
+
+/-! ## `A₂` and `D₄` discriminant-coordinate normalizations -/
+
+/-- The `A₂` discriminant alphabet, with `q(a)=a²/3` and polar form `2ab/3`. -/
+noncomputable def a2DiscriminantAlphabet : FiniteQuadraticModule where
+  A := ZMod 3
+  addCommGroup := inferInstance
+  finite := inferInstance
+  pairing := sorry
+  symmetric := sorry
+  quadratic := sorry
+  polar := sorry
+
+theorem a2DiscriminantAlphabet_quadratic (a : ZMod 3) :
+    a2DiscriminantAlphabet.quadratic a =
+      ((↑((((a.val : ℚ) ^ 2) / (3 : ℚ) : ℚ)) : AddCircle (1 : ℚ))) := sorry
+
+theorem a2DiscriminantAlphabet_pairing (a b : ZMod 3) :
+    a2DiscriminantAlphabet.pairing a b =
+      ((↑(((2 * (a.val : ℚ) * (b.val : ℚ)) / (3 : ℚ) : ℚ)) : AddCircle (1 : ℚ))) :=
+  sorry
+
+/-- The trace `F₄ → F₂` used in the `D₄` polar form. -/
+noncomputable def traceF4F2 : F4 →+ F2 := sorry
+
+theorem traceF4F2_apply (x : F4) :
+    algebraMap F2 F4 (traceF4F2 x) = x + x ^ 2 := sorry
+
+/-- The `D₄` discriminant alphabet under `1↦vector`, `ω↦spinor`, `ω²↦conjugate spinor`. -/
+noncomputable def d4DiscriminantAlphabet : FiniteQuadraticModule where
+  A := F4
+  addCommGroup := inferInstance
+  finite := inferInstance
+  pairing := sorry
+  symmetric := sorry
+  quadratic := sorry
+  polar := sorry
+
+noncomputable def d4VectorClass : F4 := 1
+
+noncomputable def d4SpinorClass : F4 := omega
+
+noncomputable def d4ConjugateSpinorClass : F4 := omega ^ 2
+
+theorem d4DiscriminantAlphabet_quadratic (x : F4) :
+    d4DiscriminantAlphabet.quadratic x =
+      ((↑((if x = 0 then 0 else (1 : ℚ) / 2) : ℚ) : AddCircle (1 : ℚ))) := sorry
+
+theorem d4DiscriminantAlphabet_pairing (x y : F4) :
+    d4DiscriminantAlphabet.pairing x y =
+      ((↑((((traceF4F2 (x * y ^ 2)).val : ℚ) / (2 : ℚ) : ℚ)) : AddCircle (1 : ℚ))) :=
+  sorry
+
+/-- Orthogonal coordinate powers of the `A₂` discriminant alphabet. -/
+noncomputable def a2CoordinateQuadraticModule (ι : Type*) [Fintype ι] :
+    FiniteQuadraticModule where
+  A := ι → ZMod 3
+  addCommGroup := inferInstance
+  finite := inferInstance
+  pairing := sorry
+  symmetric := sorry
+  quadratic := sorry
+  polar := sorry
+
+theorem a2CoordinateQuadraticModule_quadratic { ι : Type*} [Fintype ι]
+    (x : ι → ZMod 3) :
+    (a2CoordinateQuadraticModule ι).quadratic x =
+      ∑ i, ((↑(((((x i).val : ℚ) ^ 2) / (3 : ℚ) : ℚ)) : AddCircle (1 : ℚ))) := sorry
+
+/-- Orthogonal coordinate powers of the `D₄` alphabet. -/
+noncomputable def d4CoordinateQuadraticModule (ι : Type*) [Fintype ι] :
+    FiniteQuadraticModule where
+  A := ι → F4
+  addCommGroup := inferInstance
+  finite := inferInstance
+  pairing := sorry
+  symmetric := sorry
+  quadratic := sorry
+  polar := sorry
+
+theorem d4CoordinateQuadraticModule_quadratic { ι : Type*} [Fintype ι]
+    (x : ι → F4) :
+    (d4CoordinateQuadraticModule ι).quadratic x =
+      ((↑(((hammingNorm x : ℚ) / (2 : ℚ) : ℚ)) : AddCircle (1 : ℚ))) := sorry
+
+theorem d4CoordinateQuadraticModule_pairing { ι : Type*} [Fintype ι]
+    (x y : ι → F4) :
+    (d4CoordinateQuadraticModule ι).pairing x y =
+      ((↑((((traceF4F2 (∑ i, x i * y i ^ 2)).val : ℚ) / (2 : ℚ) : ℚ)) :
+        AddCircle (1 : ℚ))) := sorry
+
+/-- The named ternary codes are Lagrangians for the pinned `A₂` coordinate form. -/
+theorem tetracode_a2_isLagrangian :
+    (a2CoordinateQuadraticModule (Fin 4)).IsIsotropic tetracode.toAddSubgroup ∧
+      tetracode.toAddSubgroup =
+        (a2CoordinateQuadraticModule (Fin 4)).toFiniteBilinearModule.orthogonalComplement
+          tetracode.toAddSubgroup := sorry
+
+theorem ternaryGolay_a2_isLagrangian :
+    (a2CoordinateQuadraticModule (Fin 6 ⊕ Fin 6)).IsIsotropic
+        extendedTernaryGolay.toAddSubgroup ∧
+      extendedTernaryGolay.toAddSubgroup =
+        (a2CoordinateQuadraticModule (Fin 6 ⊕ Fin 6)).toFiniteBilinearModule.orthogonalComplement
+          extendedTernaryGolay.toAddSubgroup := sorry
+
+/-- The Hermitian hexacode is a Lagrangian for the pinned traced `D₄` coordinate form. -/
+theorem hexacode_d4_isLagrangian :
+    (d4CoordinateQuadraticModule (Fin 6)).IsIsotropic hexacode.toAddSubgroup ∧
+      hexacode.toAddSubgroup =
+        (d4CoordinateQuadraticModule (Fin 6)).toFiniteBilinearModule.orthogonalComplement
+          hexacode.toAddSubgroup := sorry
+
+/-! ## End-to-end named-code acceptance path -/
+
+noncomputable def golayConstructionA : IntegralLattice ((Fin 12 ⊕ Fin 12) → ℚ) :=
+  constructionA 2 (by decide) extendedBinaryGolay.toAddSubgroup
+    (by
+      rw [zmodDual_two_toAddSubgroup, extendedBinaryGolay_typeII.2])
+
+theorem golayConstructionA_isEven : golayConstructionA.IsEven := sorry
+
+theorem golayConstructionA_isUnimodular : golayConstructionA.IsUnimodular := sorry
+
+theorem golayConstructionA_isPositiveDefinite : golayConstructionA.IsPositiveDefinite := sorry
+
+end TauCetiRoadmap.AlgebraicCodingTheory


### PR DESCRIPTION
## Summary

Adds a literature roadmap for finite linear and additive codes, matrices and Hamming invariants,
Euclidean and Hermitian duality, MacWilliams identities, Type II codes, the tetracode, hexacode
and extended Golay codes, exact Construction A, and the bridge from codes to lattice discriminant
subgroups.

The primary carriers are Mathlib `Submodule` and `AddSubgroup` objects. The roadmap pins the
Hermitian orientation and conjugated parity-check convention, all Construction-A normalizations,
and literal quotient/isometry targets `A_{P_m(C)} ≅ C^⊥/C`. `Suggested.lean` exercises these
interfaces against Mathlib’s sesquilinear/orthogonal APIs and the integral-lattice prerequisite.

## Dependencies

This roadmap consumes the integral-lattices and discriminant-forms specification in #200. Per the
owner’s batching decision, it is opened against `main` before #200 merges. Consequently the public
CI build is expected to report the absent
`TauCetiRoadmap.IntegralLattices.Suggested` import until #200 lands; with that prerequisite overlaid,
`lake build` succeeds. Any review-driven change to #200 will be rippled here.

## Sources and scope

Primary anchors include Huffman–Pless, MacWilliams–Sloane, Conway–Sloane, Ebeling,
Harada–Munemasa–Venkov, Munemasa–Tamura, and Dougherty–Gulliver–Harada. The roadmap deliberately
excludes decoding algorithms, theta series, code/lattice classifications, rank-24 glue tables,
Mathieu automorphism identifications, and categorical constructions.

## Verification

- `lake exe cache get`
- `lake env lean TauCetiRoadmap/AlgebraicCodingTheory/Suggested.lean` — succeeds with #200’s
  prerequisite interface available
- `lake build` — succeeds with the #200 prerequisite overlaid (8741 jobs)
- `git diff --check`

The main-based standalone build currently has only the dependency import failure described above.
The `sorry` declarations are intentional roadmap targets.

## Review provenance

The complete draft was written by `gpt-5.6-sol` and independently red-teamed by a fresh
`gpt-5.6-sol` reviewer. A separate Sol correction pass resolved the Hermitian-duality API,
Mathlib-PR compatibility, Type-II scope, Construction-A modulus hypotheses, literal dual and
quotient interfaces, code/discriminant normalizations, and the hexacode conjugation issue. I then
read the resulting diff and reran its elaboration.

This is not a claim that a human subject expert has reviewed the mathematics. Review is especially
wanted from a coding theorist and Lean contributors familiar with finite-field, matrix,
sesquilinear, and finite-character APIs.

Authored with Codex.
