### PR TITLE
Add roadmap: hopfological algebra and categorification at roots of unity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ If you want to write or review a roadmap, start with [CONTRIBUTING.md](CONTRIBUT
 - [Grothendieck groups, Cartan maps, and Euler forms](TauCetiRoadmap/GrothendieckEulerForms/README.md)
 - [Heegaard Floer homology, analytically](TauCetiRoadmap/HeegaardFloer/README.md)
 - [Hodge structures: pure, mixed, and polarized](TauCetiRoadmap/HodgeStructures/README.md)
+- [Hopfological algebra](TauCetiRoadmap/HopfologicalAlgebra/README.md)
 - [Modular forms — Hecke theory, newforms, and L-functions](TauCetiRoadmap/ModularForms/README.md)
 - [Multiquadratic fields and genus theory](TauCetiRoadmap/Multiquadratic/README.md)
 - [One-parameter semigroups, completely monotone functions, and BCR Bochner](TauCetiRoadmap/OneParameterSemigroups/README.md)

--- a/TauCetiRoadmap.lean
+++ b/TauCetiRoadmap.lean
@@ -22,6 +22,7 @@ import TauCetiRoadmap.ReductiveGroups.Suggested
 import TauCetiRoadmap.PDE.Suggested
 import TauCetiRoadmap.CombinatorialHeegaardFloer.Suggested
 import TauCetiRoadmap.HeegaardFloer.Suggested
+import TauCetiRoadmap.HopfologicalAlgebra.Suggested
 import TauCetiRoadmap.GeometricTopology.Suggested
 import TauCetiRoadmap.Exchangeability.Suggested
 import TauCetiRoadmap.ContourIntegration.Suggested

--- a/TauCetiRoadmap/HopfologicalAlgebra/README.md
+++ b/TauCetiRoadmap/HopfologicalAlgebra/README.md
@@ -1,0 +1,661 @@
+# Hopfological algebra
+
+Hopfological algebra replaces the single square-zero differential of ordinary homological
+algebra by an action of a finite-dimensional Hopf algebra.  Its first layer is already useful:
+the stable category of modules over a finite-dimensional Hopf algebra is triangulated monoidal.
+Its relative layer starts with a left module algebra `A`, forms the smash product `A # H`, and
+uses a stronger, `A`-relative null-homotopy relation before localizing at the morphisms which
+become invertible in the stable category of `H`-modules.  This roadmap builds those reusable
+layers, their compact and Grothendieck-group theories, and the standard differential and
+root-of-unity examples.
+
+The constructions here do not select a Hopf algebra for an ADE or E8 problem.  They do not
+quotient an affine null root, assert an E8 finiteness or specialness statement, or construct or
+categorify a lattice.  Roots of unity and the Jones--Wenzl projector appear only where a cited
+published theorem supplies a reusable example of the general theory.
+
+## Dependency boundary
+
+This roadmap extends, rather than replaces, four neighboring roadmaps.
+
+- [Grothendieck groups, Euler forms, and numerical quotients](../GrothendieckEulerForms/README.md)
+  supplies exact- and triangulated-category Grothendieck groups, quotient presentations,
+  graded `K₀`, and the distinction between `K₀` and `G₀`.  This roadmap instantiates those
+  constructions and proves the Hopfological relations; it does not build a second `K₀` engine.
+- [DG and A-infinity algebra](../DGAInfinity/README.md) supplies ordinary cohomological DG
+  categories, perfect objects, derived localization, and ordinary chain homotopy.  The exterior
+  Hopf-superalgebra example below is compared to that implementation.  General hopfological
+  homotopy is not defined to be DG homotopy.
+- [Frobenius, stable, periodic, and curved homological algebra](../StablePeriodicCurved/README.md)
+  supplies Frobenius and self-injective algebras, exact Frobenius categories, stable morphisms
+  modulo projective-injectives, triangulated stable categories, and the periodic and curved
+  interfaces.  This roadmap proves finite Hopf algebras meet those hypotheses, proves that the
+  Hopf tensor product descends to make their stable category tensor-triangulated, and builds a
+  new **relative** Frobenius exact structure on smash-product modules.  It consumes the published
+  interface of that roadmap without prescribing a private implementation.
+- Tau Ceti already supplies Mathlib's `Bialgebra` and `HopfAlgebra` structures together with
+  antipode compatibility, the binomial coproduct of a primitive element, bialgebra quotients,
+  and Tau Ceti's right-comodule API.  Every milestone below uses those declarations directly.
+
+## Conventions
+
+These choices are part of the specification.
+
+| Item | Convention |
+|---|---|
+| Base | `k` is a field.  The core hopfological theory assumes `H` is a nonzero finite-dimensional Hopf algebra over `k`. |
+| Antipode | `S` is Mathlib's `HopfAlgebra.antipode`.  Its bijectivity is proved from finite-dimensionality.  Any theorem stated beyond the finite-dimensional setting carries bijectivity explicitly. |
+| Modules | All unqualified algebra modules and Hopf modules are **left** modules. |
+| Module algebra | `A` is a left `H`-module algebra: `h·1 = ε(h)1` and `h·(ab) = Σ(h₁·a)(h₂·b)`. |
+| Comodule algebra | Tau Ceti's convention is right coaction `ρ : A → A ⊗ H`.  A right comodule algebra has `ρ(1)=1⊗1` and `ρ(ab)=ρ(a)ρ(b)`. |
+| Smash product | `B = A # H` has carrier `A ⊗ H`, unit `1 # 1`, and `(a # h)(b # l) = Σ a(h₁·b) # h₂l`. |
+| Tensor action | On left modules, `h·(m⊗n)=Σ(h₁·m)⊗(h₂·n)` and `h·c=ε(h)c` on the monoidal unit. |
+| Integral | A left integral is `0 ≠ Λ ∈ H` with `hΛ=ε(h)Λ`.  Left and right integrals and cointegrals are separate notions. |
+| Grading | Gradings are by `ℤ`.  An element of degree `i` in `M` has degree `i+r` in `M{r}`.  The class of `{1}` is the Laurent variable.  The triangulated suspension `T` is not the internal shift `{1}`. |
+| Differential degree | The structural DG, `p`-DG, and one-generator `N`-complex APIs put `d` in degree `+1`.  Regraded degree-`+2` `p`-DG aliases and theorems are supplied for the Qi--Sussan convention.  Laugwitz--Qi's `d_k` has degree `n/p_k`. |
+| Braiding and signs | Ordinary vector-space tensor products have no Koszul sign.  Super and `q`-graded examples use their braided tensor multiplication; the braiding, not an ad hoc rewrite, produces the sign or `q`-factor. |
+| Null ideal | In `A # H`-modules, hopfological null maps factor through an object `N ⊗ H`, equivalently through `m ↦ m⊗Λ`.  This is distinct from factoring through an ordinary `A # H`-projective. |
+| Stable notation | `H-StMod` is the stable quotient of **all** left `H`-modules and has arbitrary coproducts.  `H-stmod` is its essentially small finite-dimensional full subcategory, used for rigidity and `K₀`. |
+| Quasi-isomorphism | A morphism in the relative homotopy category is a quasi-isomorphism when restriction to `H` is an isomorphism in the large ordinary stable category `H-StMod`. |
+
+Sweedler notation in prose always denotes a finite representation of Mathlib's
+`Coalgebra.comul`; Lean statements use `Coalgebra.Repr` or equality of tensor-product maps and
+do not assume a chosen basis.
+
+## Baseline audit
+
+The audited baseline is Tau Ceti
+`86cc55d9192fc3f094f293ead6f2e7a153c79d17` on Mathlib
+`de5ce8a9a66a4aa68a9bdbb35b63a06d34d9ca11`.
+
+- `TauCeti.Algebra.Bialgebra.Primitive` proves the binomial formula for
+  `Δ(a^n)` when `a` is primitive.  This is the required input for the characteristic and sign
+  tests below.
+- `TauCeti.Algebra.Bialgebra.Quotient` constructs quotient bialgebras and their lift.
+- `TauCeti.Algebra.HopfAlgebra.Basic` and `.Antipode` provide preservation of antipodes and
+  anti-comultiplicativity.
+- `TauCeti.Algebra.Coalgebra.Comodule.Basic` provides right comodules and morphisms.  The
+  finite-comodule development already supplies monoidal and rigid categories where its
+  hypotheses apply.
+- Neither this Mathlib pin nor this Tau Ceti pin contains integrals of Hopf algebras, the
+  finite-Hopf-to-Frobenius theorem, Hopf module algebras, smash products, the stable category
+  of Hopf modules, or the relative hopfological category.  Those are real targets here.
+
+Read-only searches of the Lean community Zulip for Hopf-module monoidality, stable categories,
+smash products, and Frobenius algebras found no competing implementation or settled spelling.
+The relevant discussion confirms the mathematical requirement that a group/Hopf algebra's
+coproduct makes its module category monoidal; it does not provide the missing API.  New upstream
+Mathlib work is adopted if it lands, following Mathlib's naming and deleting the corresponding
+Tau Ceti duplicate.
+
+## Layer 1: finite Hopf algebras are Frobenius
+
+Build a usable theory of integrals before using the word Frobenius.
+
+1. Define submodules of left and right integrals in `H`:
+   `hΛ=ε(h)Λ` and `Λh=ε(h)Λ`.  Define left and right cointegrals as the corresponding
+   invariance equations in `H*`.  Prove closure, functoriality under Hopf equivalences, behavior
+   under the antipode, and the left/right conversions when the antipode is bijective.
+2. For nonzero finite-dimensional `H`, prove that each integral space is one-dimensional and
+   contains a nonzero element.  State precisely which result chooses a left integral in `H` and
+   which chooses a right cointegral in `H*`; do not conflate the two one-dimensional spaces.
+3. Prove the Larson--Sweedler Frobenius theorem in a form consumed by the Frobenius roadmap:
+   a nonzero right cointegral `λ : H → k` makes `(x,y) ↦ λ(xy)` nondegenerate, equivalently
+   `x ↦ (y ↦ λ(xy))` is a linear equivalence `H ≃ₗ[k] H*`.  Construct Frobenius dual bases and
+   pin the handed Nakayama convention.  For a chosen nonzero left integral `Λ`, define the
+   modular character `α : H → k` by `Λh=α(h)Λ`.  Define `ν` by
+   `λ(xy)=λ(ν(y)x)`.  With this convention prove
+
+   `ν(h)=Σ α(h₁)S²(h₂)
+         = a⁻¹(Σ α(h₂)S⁻²(h₁))a`,
+
+   where `a` is the distinguished group-like element of `H`; changing the cointegral or
+   defining-equation convention must change the displayed winding formula explicitly.  The
+   stable/Frobenius dependency uses the convention
+   `λ(ab)=λ(bν_S(a))`.  Nondegeneracy of `(x,y)↦λ(xy)` gives uniqueness and the required
+   orientation bridge `ν_H=ν_S⁻¹`; pass `ν_S=ν_H⁻¹`, not `ν_H`, to that interface.  Prove
+   the exact published criterion: a finite-dimensional Hopf algebra is symmetric **if and only
+   if** it is unimodular and `S²` is inner.  Symmetry is never inferred from finite
+   dimensionality alone.
+4. Prove that the antipode of a finite-dimensional Hopf algebra over a field is bijective.  Use
+   this theorem, rather than adding bijectivity redundantly to every finite-Hopf result.
+5. Instantiate the Frobenius/self-injective interface from `StablePeriodicCurved`.  Prove for
+   arbitrary left `H`-modules, not just finite-dimensional ones, that projective and injective
+   objects coincide.  Separate the finite-dimensional essentially small subcategory used for
+   `K₀` from the large module category used for coproducts and compact generation.
+
+The main algebraic source for this layer is Larson--Sweedler.  Khovanov and Qi may be used for
+the consequences for module categories, but not as a substitute for the Frobenius proof.
+
+## Layer 2: Hopf modules and their stable monoidal category
+
+Construct left `H`-modules and their monoidal API over the existing bialgebra structure.
+
+- Define the diagonal action on `M ⊗ N`, prove it is independent of a chosen coproduct
+  representation, and construct associator and unit compatibility.  This layer needs only a
+  bialgebra.
+- For a Hopf algebra with bijective antipode, define dual actions on finite-dimensional modules
+  and prove rigidity.  Pin the action on the linear dual and relate left and right duals to `S`
+  and `S⁻¹`.
+- Prove `M ⊗ P`, `Hom_k(M,P)`, and `Hom_k(P,M)` are projective when `P` is projective, with
+  the correct antipode action on internal Hom.  These results make the ideal of morphisms
+  through `H`-projectives a tensor ideal.
+- Form the large category `H-StMod` from all modules using the ordinary Frobenius
+  stable-category interface, and define `H-stmod` as its essentially small full subcategory on
+  finite-dimensional modules.  The suspension on either category can be modeled, after choosing
+  `Λ`, by
+  `T(M)=M⊗(H/kΛ)` and its inverse by `M⊗ker ε`; prove independence up to natural isomorphism.
+  In the graded case, shift the homogeneous integral so that `m ↦ m⊗Λ` has degree zero.
+- Prove `H-StMod` is triangulated monoidal, has the coproducts required later, and tensoring in
+  either variable is exact.  Prove its finite-dimensional subcategory `H-stmod` is closed under
+  tensor, suspension, and duals.  Both are symmetric monoidal when `H` is cocommutative.  For a
+  general `H` they are only monoidal; a braiding requires a quasitriangular or braided-Hopf
+  hypothesis and is never inferred from finite-dimensionality.
+
+This is the **ordinary stable quotient**: a morphism is zero exactly when it factors through an
+`H`-projective.  Later ideals are compared to it, not identified with it by notation.
+
+## Layer 3: module algebras, comodule algebras, and smash products
+
+### Left module algebras
+
+Define a left `H`-module algebra using an action linear in `H` and `A`, the module laws, and the
+two displayed unit and product equations from the convention table.  Supply:
+
+- equivariant algebra morphisms, restriction along bialgebra morphisms, invariant subalgebras,
+  opposite and tensor constructions with exactly the cocommutativity or braiding hypotheses they
+  need;
+- the equivalence between left modules over `B=A#H` and left `A`-modules `M` with a left
+  `H`-action satisfying
+  `h·(am)=Σ(h₁·a)(h₂·m)`;
+- the smash-product algebra on `A ⊗ H`, associativity and unit from the literal formula
+  `(a#h)(b#l)=Σa(h₁·b)#h₂l`, and the canonical embeddings of `A` and `H`;
+- functoriality of `A#H` in equivariant algebra maps and Hopf maps, together with the expected
+  universal property.  The implementation reuses the existing quotient-bialgebra API when an
+  example is presented by generators and relations.
+
+The prototype therefore bundles an actual `k`-algebra `B`, a linear equivalence
+`B ≃ₗ[k] A⊗H`, pure-tensor multiplication and unit theorems, the two algebra embeddings, a
+pure-tensor spanning theorem, and the covariance universal property.  A type synonym for
+`A⊗H` which ignores the action is not a smash product.
+
+### Right comodule algebras
+
+Extend Tau Ceti's right `Comodule k C A` with the equations making the coaction an algebra
+map.  First instantiate the tensor-product algebra structure on `A ⊗ H` from the existing
+algebra structures, so the literal equation `ρ(ab)=ρ(a)ρ(b)` has its intended multiplication;
+do not hide this behind an unverified equality signature.  Build comodule-algebra morphisms and
+prove that the smash product has the right
+`H`-coaction
+
+`ρ(a#h) = Σ(a#h₁) ⊗ h₂`.
+
+Khovanov's original paper often starts with a left comodule algebra and also writes an example
+using a right module algebra.  Those are translated into the primary convention explicitly;
+there is no second overload of `smashProduct` with silently reversed sides.
+
+### Finite-dual bridge
+
+For finite-dimensional `H`, construct the Hopf structure on `H*` and prove that a left
+`H`-module algebra structure on `A` is equivalent to a right `H*`-comodule algebra structure.
+For a finite basis `(e_i)` with dual basis `(e_i*)`, expose the formula
+
+`ρ(a)=Σ(e_i·a)⊗e_i*`
+
+and prove it is basis-independent.  State the inverse by evaluation.  Generalize over a
+commutative base ring only under the finite-projective and required flatness hypotheses; do not
+replace finite projectivity by finite generation.  Relate the module-algebra smash product to the
+finite-dual comodule construction and record all op/cop and left/right translations.
+
+## Layer 4: the relative hopfological category
+
+Fix `B=A#H`.  Give `B-Mod` the exact structure whose conflations are the short exact sequences
+which split after restriction to `A`.  Prove, using finite-dimensionality of `H`, bijectivity of
+its antipode, and the Frobenius result, that this is a Frobenius exact category.  Identify its
+projective-injective objects as retracts of the appropriate induced/coinduced objects and reconcile
+that description with the objects `N⊗H` carrying diagonal `B`-action.
+
+Choose a nonzero left integral `Λ`.  For a `B`-module `M`, construct the `B`-linear map
+
+`λ_M : M → M⊗H,   m ↦ m⊗Λ`.
+
+A `B`-linear morphism `f : M → N` is **hopfologically null-homotopic** when either of the
+following equivalent conditions holds:
+
+1. `f` factors through `X⊗H` for some `B`-module `X`;
+2. `f` factors through `λ_M`;
+3. under the invariant description of `B`-linear maps, `f=Λ·g` for an `A`-linear map `g`.
+
+For the third condition, construct Qi's `H`-action on `Hom_A(M,N)`:
+
+`(h·g)(m)=Σ h₂·g(S⁻¹(h₁)·m)`.
+
+Prove `Hom_B(M,N)=Hom_A(M,N)^H` and identify the hopfological morphism space with
+
+`Hom_A(M,N)^H / (Λ·Hom_A(M,N))`.
+
+The quotient category is `C(A,H)`, the stable category of the `A`-split relative Frobenius
+structure.  Construct its triangles, suspension and inverse suspension, and its right action by
+`H-StMod`; tensoring a hopfological module on the right by an arbitrary `H`-module is exact.
+At signature level, objects and conflation arrows are genuine `B`-modules and `B`-linear maps;
+only the chosen retraction/section is `A`-linear.  Likewise the Hom action is constructed on
+literal `Hom_A`, its invariants are identified with literal `Hom_B`, and the property-(P)
+filtration below consists of `B`-submodules with `B`-linear cell-layer identifications.
+
+The following comparison is mandatory.
+
+- The ordinary stable category of the algebra `B` kills maps through **`B`-projectives**.
+- `C(A,H)` kills maps through the generally larger class `X⊗H` of relative
+  projective-injectives.  Every ordinary `B`-projective gives a relative projective, but equality
+  is not asserted.  When `A=k`, the relative quotient on all modules recovers `H-StMod`; its
+  finite-dimensional full subcategory recovers `H-stmod`.
+- Ordinary chain homotopy is the formula `f=dh+hd` in the exterior Hopf-superalgebra example.
+  The integral ideal above specializes to it only after the super grading and signs are installed.
+- A Verdier quotient localizes a triangulated category at a thick subcategory.  It is introduced
+  in the next layer and is not the additive ideal quotient used to define `C(A,H)`.
+
+## Layer 5: derived localization, property (P), and compact objects
+
+Restriction along `H ↪ A#H` gives an exact functor `C(A,H) → H-StMod`.  Define a morphism
+to be a quasi-isomorphism when its restriction is invertible.  Prove that these morphisms form a
+localizing class and that the following constructions agree:
+
+`D(A,H) = C(A,H)[quasi-isomorphisms⁻¹]
+         ≃ C(A,H) / (H-acyclic objects)`.
+
+Here `M` is `H`-acyclic exactly when its restriction is zero in `H-StMod`, equivalently is
+projective as an `H`-module.  The second expression is a Verdier quotient by the thick
+subcategory of acyclics.  Build cones and prove the localization is triangulated and remains a
+right triangulated module category over `H-StMod`.
+
+### Cofibrant and property-(P) modules
+
+A `B`-module `P` is cofibrant when every `B`-map from `P` to the target of a surjective
+quasi-isomorphism lifts to its source.  Equivalently, the induced map on the invariant spaces
+`Hom_A(P,-)^H` is surjective.  Prove Qi's characterization: `P` is projective as an `A`-module
+and `Hom_A(P,K)` is `H`-projective for every acyclic `K`.
+
+Call a module **cellular property-(P)** when it has an exhaustive filtration
+
+`0 ⊂ F₀ ⊂ F₁ ⊂ ⋯ ⊂ P`
+
+such that every inclusion is split as an `A`-module map and `F₀` and each
+`F_{r+1}/F_r` are direct sums of modules `A⊗V`, with `V` an indecomposable `H`-module.
+Equivalently, arbitrary `H`-modules may be used as the cells.  Following Qi's actual
+definition, a module satisfies property (P) when it is isomorphic in `C(A,H)` to a cellular
+property-(P) module.  Keep that homotopy-invariant condition separate from the data of a chosen
+filtration.  Every filtration stage is a `B`-submodule, every inclusion is `B`-linear, and its
+chosen splitting is only `A`-linear.  Each displayed layer is identified by a `B`-linear
+isomorphism with `A⊗V` carrying
+`(a#h)(b⊗v)=Σa(h₁·b)⊗h₂·v`; merely identifying underlying `A`-modules is insufficient.  Prove:
+
+- property (P) implies cofibrant;
+- every module has a functorial surjective quasi-isomorphism from a property-(P) bar
+  replacement;
+- the cofibrant objects are exactly the `B`-module direct summands of property-(P) objects;
+- morphisms out of a cofibrant/property-(P) object agree in `C(A,H)` and `D(A,H)`;
+- the homotopy categories of property-(P) and cofibrant objects are each equivalent to
+  `D(A,H)`.
+
+Do not rename every cofibrant object “property P”: the idempotent-completion distinction is a
+theorem and is visible in the API.
+
+### Compact generation and finiteness
+
+Define compactness by preservation of the actual categorical coproducts by the preadditive
+representable `Hom(P,-) : D(A,H) → AddCommGrp`; equivalently, require preservation of every
+small discrete colimit, whose comparison is canonically induced by the coproduct injections.
+Do not store an arbitrary object-valued “coproduct” function or comparison bijection.  Prove `D(A,H)`
+is compactly generated by the finite set `{A⊗V}`, where `V` ranges over representatives of the
+simple finite-dimensional `H`-modules.  Then prove the Ravenel--Neeman description used by Qi:
+the compact subcategory `Dᶜ(A,H)` is the thick idempotent closure of these generators, and every
+compact object is a direct summand of a finite extension of shifts `T^n(A⊗V)`.
+
+The following finiteness words have fixed, noninterchangeable meanings.
+
+- Prove Qi's finite-Hopf smash-product result that `A` is left Noetherian if and only if `A#H`
+  is left Noetherian.  For the nontrivial direction, use finite freeness on the correct `A`-side
+  (the antipode gives the right-sided normal form), faithful flatness, and descent of finite
+  generation; finite freeness only on the evident left side is not a proof.  Under these
+  equivalent hypotheses, `Dᵇ(A,H)` is the strictly full subcategory of objects isomorphic to
+  a finitely generated `A`-module.
+- `Dᶠ(A,H)` consists of objects isomorphic to a finite-length `A`-module.  It is contained in
+  `Dᵇ`; if `A` is finite-dimensional over `k`, they coincide.
+- If `A` is Artinian, a compact object is isomorphic in the derived category to a finite
+  projective `A`-module.
+- Qi's “smooth basic” comparison assumes `A` is Artinian (or graded finite-dimensional), basic
+  in its Morita class, smooth in the precise sense that `A` has a finite projective resolution as
+  an `(A,A)`-bimodule, and has **trivial `H`-action**.  Under those hypotheses
+  `Dᶜ(A,H) ≃ Dᶠ(A,H)`.
+- In the specialized `p`-DG terminology of Qi--Sussan, property (P) has filtration quotients
+  which are sums of `p`-DG direct summands of `A`; a finite-cell module has property (P) and is
+  finitely generated as an `A`-module.  This is not a synonym for compactness in an arbitrary
+  hopfological category.
+
+Implement the exact published Qi--Sussan finiteness test as a scoped worked theorem.  For their
+specific `p`-DG algebras `A=A_n^!` and `C=C_n` over a field of characteristic prime `p`, the
+categorified Jones--Wenzl functor `P` is represented by a finite-cell `(A,A)`-bimodule **if and
+only if `p` divides `n-1`**.  Outside that divisibility condition their Theorem 5.5 says this
+specific projector has no finite-cell representative.  It says neither that arbitrary
+hopfological objects are infinite nor that a particular root system has a finiteness property.
+
+## Layer 6: Grothendieck groups and rings
+
+Use the Grothendieck/Euler roadmap's construction throughout.
+
+1. For the essentially small stable category of finite-dimensional (graded) `H`-modules,
+   construct `K₀(H-stmod)`.  Tensor product makes it a ring, possibly noncommutative.  It is
+   commutative when the stable category is symmetric, in particular when `H` is cocommutative.
+   Prove the quotient from the ordinary representation ring by the classes of projectives.
+2. Define the hopfological Grothendieck group to be `K₀(Dᶜ(A,H))`, not the group of the entire
+   large derived category.  Prove it is a right module over `K₀(H-stmod)`.
+3. Define `G₀(A,H)` from `Dᵇ(A,H)` and `G₀ᶠ(A,H)` from `Dᶠ(A,H)` under the Noetherian
+   hypotheses above.  Construct Qi's derived pairing
+   `Dᶜ(A,H) × Dᶠ(A,H) → Dᶠ(k,H)` there, and its sesquilinear Grothendieck-group
+   specialization under the Artinian hypotheses used in his smooth-basic section.
+4. If an internal tensor product of compact hopfological `A`-modules is constructed, state all
+   hypotheses making the diagonal action descend through the `A`-balanced tensor product.
+   Under those hypotheses prove that `K₀(A,H)` is a ring.  Commutativity requires a symmetric
+   or adequately braided structure; commutativity of `A` alone does not make `H` cocommutative.
+5. For a smooth basic `A` with trivial `H`-action, prove Qi's comparison
+   `K₀(A,H) ≅ K₀(A) ⊗_ℤ K₀(H-stmod)`, and its graded tensor product over
+   `ℤ[q,q⁻¹]`.  Preserve every hypothesis from Layer 5.
+
+The examples below must prove their displayed relation as a theorem about these general
+constructions, not install the desired quotient ring as a definition.
+
+## Layer 7: differential, super, Nichols, Sweedler, and Taft examples
+
+### Why ordinary dual numbers fail in characteristic zero
+
+Suppose an ordinary bialgebra over `k` contains a primitive `d` with `d²=0`.  Tau Ceti's
+primitive binomial theorem gives
+
+`Δ(d²)=d²⊗1 + 2(d⊗d) + 1⊗d²`.
+
+Since `Δ(0)=0`, square-zero forces `2(d⊗d)=0`.  Over a field with `char k ≠ 2`, a nonzero
+`d` has nonzero pure tensor `d⊗d`, so this is impossible.  In particular the quotient
+`k[d]/(d²)` cannot carry an **ordinary** characteristic-zero Hopf structure with the class of
+`d` nonzero and primitive.  `Suggested.lean` includes the binomial signature, a proof that a
+nonzero self-tensor over a field is nonzero, and the resulting contradiction.  The roadmap must
+also construct the failed quotient attempt through Tau Ceti's bialgebra-quotient criterion and
+show exactly where preservation of `(d²)` fails.
+
+There are two correct sign repairs.
+
+- In super vector spaces, take the exterior Hopf superalgebra `E(d)` with `d` odd,
+  `d²=0`, `Δd=d⊗1+1⊗d`, `εd=0`, and `Sd=-d`.  The super tensor multiplication
+  `(x⊗y)(x'⊗y')=(-1)^{|y||x'|}xx'⊗yy'` makes the two middle terms cancel.  A left
+  module-superalgebra is an ordinary DG algebra with
+  `d(ab)=d(a)b+(-1)^|a| a d(b)` for `a` in an actual component of its internal grading;
+  homogeneity is not an independent predicate.
+- Bosonize parity to Sweedler's ordinary four-dimensional Hopf algebra `H₄`: for
+  `char k ≠ 2`, use generators `g,d` with
+  `g²=1`, `d²=0`, `gd=-dg`,
+  `Δg=g⊗g`, `Δd=d⊗1+g⊗d`,
+  `εg=1`, `εd=0`, `Sg=g`, and `Sd=-gd`.
+  Then
+  `Δ(d)²=d²⊗1+(dg+gd)⊗d+g²⊗d²=0`.
+  On a module algebra with internal decomposition `A=⊕_r A_r`, prove
+  `g·a=(-1)^r a` for `a∈A_r` and `d·A_r⊆A_{r+1}`; then `d` obeys the signed Leibniz rule.
+  Thus `g` is tied to the actual grading rather than merely called a parity operator.  `H₄`
+  records parity, while the compatible `ℤ`-grading records the full DG degree.
+
+Prove that the hopfological null ideal in these super/bosonized models recovers the ordinary
+chain-homotopy formula with its signs.  This is a comparison theorem to the DG roadmap, not a
+new definition of chain homotopy.
+
+### Characteristic-`p` truncated primitives and `p`-DG algebras
+
+Let `p` be prime and `k` have characteristic `p`.  Construct
+
+`H_p=k[d]/(d^p),  Δd=d⊗1+1⊗d,  εd=0,  Sd=-d`.
+
+The intermediate binomial coefficients vanish in characteristic `p`, so `(d^p)` is a Hopf
+ideal.  Give the generator degree `+1` (and the explicit degree-`+2` regrading).  Module
+algebras are `p`-DG algebras with `d^p=0` and unsigned Leibniz rule
+`d(ab)=d(a)b+a d(b)`.  For `p`-complexes, prove that a degree-zero map is null exactly when
+
+`f = Σ_{i=0}^{p-1} d_N^i h d_M^{p-1-i}`
+
+for a map `h` of the required degree.  Construct the slash-homology groups of a finite-dimensional
+graded `p`-complex using the exact Khovanov--Qi formula
+
+`H^{/k}(M)=ker(d^{k+1})/(im(d^{p-k-1})+ker(d^k)),   0≤k≤p-2`.
+
+Prove homotopy invariance and, for finite-dimensional `M`, the detection theorem that all slash
+groups vanish **if and only if** `M` is projective (equivalently free) over `H_p`.  If `d` has
+degree `+1`, the homotopy `h` in the displayed `p`-null formula has degree `1-p`; in the
+Qi--Sussan degree-`+2` regrading it has degree `2-2p`.  Identify the resulting
+quasi-isomorphism test with restriction to `H_p-stmod`.  Attribute slash homology and its
+detection theorem to Khovanov--Qi (2015), as recalled for example by Qi--Sussan (2022), not to
+the 2017 hopfological-finiteness paper.
+
+For finite-dimensional graded modules, prove
+
+`K₀(H_p-stmod) ≅ ℤ[q,q⁻¹]/(1+q+⋯+q^{p-1})
+                  = ℤ[q,q⁻¹]/(Φ_p(q))`.
+
+The equality with one cyclotomic polynomial uses that `p` is prime.  Do not state the same
+identity for composite `N`.
+
+### One-dimensional Nichols algebras and Taft algebras
+
+First build the reusable ambient theory for `G`-graded vector spaces with braiding on homogeneous
+tensors determined by a multiplicative bicharacter `χ : G×G → kˣ`.  It must cover
+`G=ℤ` and `χ(i,j)=q^{ij}`, which is the ambient used by Laugwitz--Qi.  The super category is the
+specialization `G=ℤ/2`, `χ(i,j)=(-1)^{ij}`.  Model the grading as the canonical internal
+decomposition into subspaces, require `1∈A_0` and `A_gA_h⊆A_{g+h}`, require the coproduct to
+land in the sum of bidegrees `(r,s)` with `r+s=g`, and require the counit to vanish off degree
+zero and the antipode to preserve degree.  Graded module actions must send
+`H_g·M_h` into `M_{g+h}`.  In that general ambient construct
+algebra/coalgebra/bialgebra/Hopf-algebra objects, braided primitives and Hopf ideals,
+Yetter--Drinfeld modules, Nichols algebras in the finite diagonal cases used here, and the
+Radford--Majid bosonization.  Prove the monoidal equivalence between modules internal to the
+braided category and the appropriate rational modules over the bosonization.  The exterior and
+Laugwitz--Qi algebras instantiate this API; they are not isolated structures with copied Hopf
+axioms.
+
+Let `q` be a primitive `N`th root in a field whose characteristic does not divide `N`.  In the
+braided category of `q`-graded vector spaces, construct the one-dimensional Nichols algebra
+`B(V)=k[d]/(d^N)` with braided-primitive `d`.  Prove the `q`-binomial coproduct and show the
+intermediate Gaussian coefficients vanish at the primitive root.  At `q=-1`, this is the exterior
+superalgebra.
+
+Its cyclic bosonization is the Taft Hopf algebra in the pinned convention:
+
+`K^N=1,  d^N=0,  Kd=q dK`,
+
+`ΔK=K⊗K,  Δd=d⊗1+K⊗d`,
+
+`εK=1,  εd=0,  SK=K⁻¹,  Sd=-K⁻¹d`.
+
+Prove all Hopf equations, finite dimension `N²`, the integral and Frobenius data, and the
+module-algebra skew Leibniz equation
+
+`d(ab)=d(a)b+(K·a)d(b)`.
+
+Sweedler `H₄` is the `N=2`, `q=-1` case.  A rational graded Taft module has
+`K·m=q^|m|m`; under that restriction the skew Leibniz equation is the usual `q`-Leibniz rule.
+
+For every named example, separate **construction** from **recognition**.  Construct the algebra
+as the stated free-algebra/polynomial quotient, descend coproduct, counit, and antipode through
+the relation ideal, and prove the standard monomials form a basis.  The recognition records in
+`Suggested.lean` deliberately demand bases `d^i`, `g^i d^j`, `K^i d^j`, or the corresponding
+multi-monomials; hence `H=k`, `K=1`, `d=0` cannot inhabit them as fake Sweedler, Taft, or
+Laugwitz--Qi data.  Recognition data do not replace the quotient constructors.
+
+For Khovanov's graded Taft stable category, prove the relation
+
+`K₀ ≅ ℤ[q,q⁻¹]/(1+q+⋯+q^{N-1})`.
+
+When `N` is composite, `1+q+⋯+q^{N-1}` is not `Φ_N(q)`.  Thus a Taft stable category alone
+does not categorify the full ring of `N`th cyclotomic integers.
+
+## Layer 8: the Laugwitz--Qi characteristic-zero cyclotomic construction
+
+Implement the published construction for every integer `n≥2`, including characteristic zero,
+with its assumptions visible in every top-level theorem.
+
+Write
+
+`n=∏_{k=1}^t p_k^{a_k}`, `m=∏p_k`, `N=n²/m`,
+`n_k=n/p_k`, and `m_k=m/p_k`.
+
+The factorization object records `n≥2`, `t>0`, primality and pairwise distinctness of the
+`p_k`, positivity of every `a_k`, and the complete equality `n=∏p_k^{a_k}`.  Thus the prime
+list cannot omit a divisor.  The values `m`, `N`, `n_k`, and `m_k` are definitions derived from
+that object, never unrelated parameters.
+
+Let `k` contain a primitive `N`th root `q`; this implies `char k ∤ N`.  Put
+`ξ=q^(n/m)`, a primitive `n`th root, and `ξ_k=ξ^{m_k}=q^{n_k}`, a primitive `p_k`th
+root.  In `q`-graded vector spaces define
+
+`H_n=k[d₁,…,d_t]/(d₁^{p₁},…,d_t^{p_t}),   deg d_k=n_k`,
+
+with commuting generators, braided-primitive coproduct, zero counit, and `S(d_k)=-d_k`.
+Prove the braided Hopf equations, the Nichols-algebra description, Frobenius trace on the top
+monomial, and integral `Λ=∏d_k^{p_k-1}`.
+
+Although each generator is braided primitive, do not infer braided cocommutativity: for the
+Laugwitz--Qi braiding, the square of the braiding on `H_n ⊗ H_n` is generally nontrivial.
+
+Construct the ordinary Radford--Majid bosonization by `C_N`, with generator `K` and the exact
+relations
+
+`K^N=1`, `Kd_k=ξ_k d_kK`, `d_k^{p_k}=0`, `[d_k,d_l]=0`,
+
+`ΔK=K⊗K`, `Δd_k=d_k⊗1+K^{n_k}⊗d_k`,
+
+`SK=K⁻¹`, `Sd_k=-K^{-n_k}d_k`, `εK=1`, `εd_k=0`.
+
+The bosonization constructor consumes the factorization and root objects above, so its type uses
+the derived `N`, `n_k`, `m_k`, `ξ`, and `ξ_k`; it cannot accept inconsistent copies of those
+numbers.  Prove that the ordered monomials
+`K^j d_1^{e_1}⋯d_t^{e_t}` (`0≤j<N`, `0≤e_k<p_k`) form a basis, hence its dimension is
+`N·m` and the braided algebra `H_n` has dimension `m`.
+
+Prove that rational graded modules, on which `K` acts in degree `i` by `q^i`, recover modules
+over the braided `H_n`, monoidally.  Do not claim the whole bosonization module category is the
+same graded category.
+
+The stable category first has
+
+`K₀(H_n-gmod) ≅ ℤ[ν,ν⁻¹] /
+  ( ∏_{k=1}^t ([n]_ν/[n_k]_ν) )`,
+
+where `[r]_ν=1+ν+⋯+ν^{r-1}`.  Implement Laugwitz--Qi Definition 4.5 literally.  Let
+`H_{n_k}=k[d_k]/(d_k^{p_k}) ⊂ H_n`, with `k` its trivial module.  When `t>1`, put
+
+`W_k = H_n ⊗_{H_{n_k}} k`.
+
+The API constructs each `H_{n_k}` as the injectively embedded subalgebra generated by the
+concrete `d_k` in the fixed `CyclotomicBraidedDatum`, with its truncated-monomial basis and
+augmentation.  It defines `W_k` by the balanced-tensor universal property (or exposes a graded
+`H_n`-linear equivalence to that literal carrier); neither `H_n`, the inclusions, nor `W_k` is an
+independent family parameter.
+
+Then `I_k` is the full subcategory of direct summands of modules having a **finite** filtration
+by graded `H_n`-submodules whose successive quotients are genuine internal grading shifts
+`W_k{r}`, identified by degree-zero `H_n`-linear maps.  When
+`t=1`, Definition 4.5 instead takes `I_1` to be the projective-injective objects.  Definition
+4.12's `I` consists of objects isomorphic to finite direct sums
+`U_1⊕⋯⊕U_t` with `U_k∈I_k`; it is not the union of the `I_k`.  Prove Proposition 4.16 in the
+needed handed form: if `k≠l`, every degree-zero graded `H_n`-map from an object of `I_k` to an
+object of `I_l` factors through a graded projective and is null-homotopic.  First prove the
+cross-freeness statement for shifts of the concrete induced cells from the standard
+multi-monomial basis and the distinct prime factors, then deduce the filtered/retract case by
+devissage.  No such theorem is asserted for arbitrary algebras or arbitrary cell families.
+This cross-`I_k` vanishing is an explicit input to the proof that the
+image of `I` in the stable category is thick.  Prove in addition that it is a triangulated tensor
+ideal, and form the **Verdier quotient**
+
+`O_n = (H_n-gmod)/I`.
+
+Finally prove their Theorem 5.15:
+
+`K₀(O_n) ≅ ℤ[ν,ν⁻¹]/(Φ_n(ν))`.
+
+This quotient is a third categorical operation: it follows the ordinary stable quotient and is
+not the relative hopfological ideal in `A#H`-modules.  For `n=p^a`, explain and prove the
+specialization to `p`-complexes with differential degree `p^{a-1}`.  In characteristic zero it is
+a braided/root-of-unity lift, never an ordinary primitive truncated-polynomial Hopf algebra.
+
+The tensor-triangulated category `O_n` and its Grothendieck ring are reusable input for
+root-of-unity and quantum-topological constructions.  This roadmap stops there: it does not
+build a Jones invariant, choose an ADE object, or infer a lattice categorification.
+
+## Implementation order and completion criteria
+
+The layers are implemented in order, with reusable files rather than one theorem per source.
+
+1. Integrals, cointegrals, antipode bijectivity, Frobenius duality, and the bridge to the ordinary
+   stable interface.
+2. Monoidal Hopf modules, duals, internal Hom, tensor-triangulated `H-StMod`, and its
+   finite-dimensional subcategory `H-stmod`.
+3. Left module algebras, right comodule algebras, finite duals, and smash products.
+4. The `A`-split relative Frobenius category, integral null ideal, and `C(A,H)`.
+5. Quasi-isomorphisms, the Verdier derived category, property (P), cofibrant replacements,
+   compact generation, and finiteness subcategories.
+6. Stable and compact-derived `K₀`, module/ring structures, and smooth-basic comparisons.
+7. Super/exterior, characteristic-`p`, Sweedler, Nichols, and Taft examples, including the
+   characteristic-zero obstruction.
+8. Laugwitz--Qi's multi-differential bosonization, tensor ideal, and cyclotomic Verdier quotient;
+   the scoped Qi--Sussan finite-cell theorem.
+
+A layer is not complete when only the displayed headline theorem exists.  Definitions require
+the normal morphism, functoriality, equivalence, grading-shift, op/cop, and simp/ext APIs needed
+by the next layer.  Every quotient comes with its universal property and comparison functor;
+every equivalence identifies the underlying carrier/action maps; and every finiteness theorem
+states field characteristic, Hopf dimension, antipode, Noetherian/Artinian, flatness,
+finite-projective, property-(P), and compactness assumptions at the point where they are used.
+
+## Source-to-layer map
+
+| Source | Roadmap layers | Exact imported content and restrictions |
+|---|---|---|
+| Larson--Sweedler; Pareigis; Fischman--Montgomery--Schneider | 1 | Finite-dimensional Hopf algebras over a field are Frobenius via integrals/cointegrals; the handed winding/Nakayama formulas and the exact symmetric criterion.  Symmetry is not automatic. |
+| Khovanov | 2, 4, 6, 7 | Tensor-triangulated stable Hopf-module categories, the comodule/module-algebra hopfological quotient, prime-characteristic truncated primitives, and Taft stable `K₀`.  His prime cyclotomic equality is not extended to composite order. |
+| Khovanov--Qi; Qi--Sussan (2022) | 7 | Slash homology `H^{/k}`, homotopy invariance, and finite-dimensional projectivity detection for `p`-complexes. |
+| Qi | 2--6 | The left-module-algebra and smash convention, relative null ideal, triangles, quasi-isomorphisms, derived localization, property (P), cofibrant replacement, compact generators, and the Noetherian/Artinian/smooth-basic results with their stated hypotheses. |
+| Qi--Sussan (2017) | 5, 7 | `p`-DG conventions, finite-cell modules, and the scoped Jones--Wenzl finite-cell theorem in characteristic prime `p`: exactly `p ∣ n-1`. |
+| Radford and Majid | 7, 8 | Biproduct/bosonization and the passage from braided Hopf algebras to ordinary Hopf algebras. |
+| Laugwitz--Qi | 8 | The exact factorization data, braided multi-differential Hopf algebra, `C_N` bosonization, stable relation, thick tensor ideal, Verdier quotient, and `K₀(O_n)=ℤ[ν,ν⁻¹]/(Φ_n)`, over any field containing the specified primitive `N`th root. |
+| Kapranov | 7, 8 | The characteristic-zero `q`-homological/`N`-complex motivation.  The implemented Hopf objects follow the braided/Taft hypotheses above. |
+
+## References
+
+- M. Khovanov, [*Hopfological algebra and categorification at a root of unity: the first
+  steps*](https://doi.org/10.1142/S021821651640006X), J. Knot Theory Ramifications 25
+  (2016), no. 3, 1640006, 26 pp. (preprint first circulated in 2005/06).
+- Y. Qi, [*Hopfological algebra*](https://doi.org/10.1112/S0010437X13007380), Compos. Math. 150
+  (2014), 1--45.
+- Y. Qi and J. Sussan, [*Categorification at prime roots of unity and hopfological
+  finiteness*](https://doi.org/10.1090/conm/683/13721), Contemp. Math. 683 (2017), 261--286.
+- M. Khovanov and Y. Qi, [*An approach to categorification of some small quantum
+  groups*](https://doi.org/10.4171/QT/63), Quantum Topol. 6 (2015), 185--311.
+- Y. Qi and J. Sussan, [*On some p-differential graded link
+  homologies*](https://doi.org/10.1017/fmp.2022.19), Forum Math. Pi 10 (2022), e26.
+- R. Laugwitz and Y. Qi, [*A categorification of cyclotomic
+  rings*](https://arxiv.org/abs/1804.01478), Quantum Topol. 13 (2022), 539--577,
+  [doi:10.4171/QT/172](https://doi.org/10.4171/QT/172).
+- R. G. Larson and M. E. Sweedler, [*An associative orthogonal bilinear form for Hopf
+  algebras*](https://doi.org/10.2307/2373270), Amer. J. Math. 91 (1969), 75--94.
+- B. Pareigis, [*When Hopf algebras are Frobenius
+  algebras*](https://doi.org/10.1016/0021-8693(71)90141-4), J. Algebra 18 (1971),
+  588--596.
+- S. Montgomery, [*Hopf Algebras and Their Actions on Rings*](https://bookstore.ams.org/cbms-82),
+  CBMS 82, AMS, 1993.
+- D. Fischman, S. Montgomery, and H.-J. Schneider, [*Frobenius extensions of subalgebras
+  of Hopf algebras*](https://doi.org/10.1090/S0002-9947-97-01814-X), Trans. Amer. Math.
+  Soc. 349 (1997), 4857--4895.
+- K. Erdmann, Ø. Solberg, and X. Wang, [*On the structure and cohomology ring of connected
+  Hopf algebras*](https://doi.org/10.1016/j.jalgebra.2019.02.030), J. Algebra 527 (2019),
+  366--398, Theorem 2.2 (published restatement of the Nakayama and symmetric criteria).
+- D. E. Radford, [*The structure of Hopf algebras with a
+  projection*](https://doi.org/10.1016/0021-8693(85)90124-3), J. Algebra 92 (1985), 322--347.
+- S. Majid, [*Comments on bosonisation and
+  biproducts*](https://arxiv.org/abs/q-alg/9512028), 1995; and *Foundations of Quantum Group
+  Theory*, Cambridge University Press, 1995.
+- M. Kapranov, [*On the q-analog of homological
+  algebra*](https://arxiv.org/abs/q-alg/9611005), 1996.

--- a/TauCetiRoadmap/HopfologicalAlgebra/Suggested.lean
+++ b/TauCetiRoadmap/HopfologicalAlgebra/Suggested.lean
@@ -1,0 +1,1337 @@
+-- This file contains suggested target signatures only.  The roadmap in README.md is definitive;
+-- these declarations are deliberately non-exhaustive, and proving them does not finish the roadmap.
+import Mathlib.LinearAlgebra.Dual.Basis
+import Mathlib.LinearAlgebra.Dual.Lemmas
+import Mathlib.Algebra.Module.Injective
+import Mathlib.Algebra.DirectSum.Basic
+import Mathlib.Algebra.DirectSum.Decomposition
+import Mathlib.CategoryTheory.Preadditive.Yoneda.Basic
+import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Products
+import Mathlib.RingTheory.Bialgebra.GroupLike
+import Mathlib.RingTheory.HopfAlgebra.Convolution
+import Mathlib.RingTheory.Polynomial.Cyclotomic.Basic
+import TauCeti.Algebra.Bialgebra.Primitive
+import TauCeti.Algebra.Bialgebra.Quotient
+import TauCeti.Algebra.Coalgebra.Comodule.Basic
+import TauCeti.Algebra.HopfAlgebra.Antipode
+
+open TauCeti
+open CategoryTheory CategoryTheory.Limits
+open scoped Coalgebra DirectSum TensorProduct
+
+namespace TauCetiRoadmap.HopfologicalAlgebra
+
+universe u v w x y
+
+/-! ## Integrals and the finite-Hopf/Frobenius bridge -/
+
+section Integrals
+
+variable (k : Type u) (H : Type v) [Field k] [Ring H] [HopfAlgebra k H]
+
+/-- The convention used throughout the roadmap: a left integral satisfies
+`h * Λ = ε(h) Λ`. -/
+def LeftIntegral : Submodule k H where
+  carrier := {Λ | ∀ h : H, h * Λ = Coalgebra.counit (R := k) h • Λ}
+  zero_mem' := by sorry
+  add_mem' := by sorry
+  smul_mem' := by sorry
+
+/-- Right integrals use the mirror convention. -/
+def RightIntegral : Submodule k H where
+  carrier := {Λ | ∀ h : H, Λ * h = Coalgebra.counit (R := k) h • Λ}
+  zero_mem' := by sorry
+  add_mem' := by sorry
+  smul_mem' := by sorry
+
+@[simp] theorem mem_leftIntegral_iff (Λ : H) :
+    Λ ∈ LeftIntegral k H ↔
+      ∀ h : H, h * Λ = Coalgebra.counit (R := k) h • Λ :=
+  by sorry
+
+@[simp] theorem mem_rightIntegral_iff (Λ : H) :
+    Λ ∈ RightIntegral k H ↔
+      ∀ h : H, Λ * h = Coalgebra.counit (R := k) h • Λ :=
+  by sorry
+
+/-- Larson--Sweedler: the space of left integrals of a nonzero finite-dimensional Hopf
+algebra over a field is one-dimensional. The right-integral theorem is a separate target. -/
+theorem finrank_leftIntegral [FiniteDimensional k H] [Nontrivial H] :
+    Module.finrank k (LeftIntegral k H) = 1 := by
+  sorry
+
+/-- A right cointegral is the elementwise form of a right integral in the finite dual. -/
+def IsRightCointegral (phi : Module.Dual k H) : Prop :=
+  ∀ h : H, ∑ i ∈ (ℛ k h).index,
+    phi ((ℛ k h).left i) • (ℛ k h).right i = phi h • (1 : H)
+
+/-- The multiplication pairing associated to a linear functional. -/
+def mulPairing (phi : Module.Dual k H) : H →ₗ[k] Module.Dual k H :=
+  LinearMap.mk₂ k (fun x y => phi (x * y))
+    (fun x₁ x₂ y => by simp [add_mul])
+    (fun r x y => by simp)
+    (fun x y₁ y₂ => by simp [mul_add])
+    (fun r x y => by simp)
+
+/-- A nonzero cointegral gives the Frobenius functional. This target asks for the actual
+nondegeneracy map, not a field named `isFrobenius`. -/
+theorem cointegral_mulPairing_bijective [FiniteDimensional k H]
+    (phi : Module.Dual k H) (hphi : IsRightCointegral k H phi) (hphi0 : phi ≠ 0) :
+    Function.Bijective (mulPairing k H phi) := by
+  sorry
+
+/-- The finite-dimensional antipode is bijective. Infinite-dimensional uses must instead
+carry bijectivity as a hypothesis. -/
+theorem antipode_bijective [FiniteDimensional k H] :
+    Function.Bijective (HopfAlgebra.antipode k (A := H)) := by
+  sorry
+
+/-- Handed Nakayama data for a chosen right cointegral `phi`.  Our defining convention is
+`phi (x*y) = phi (nu y*x)`.  If `Λ` is a left integral and
+`Λ*h = alpha(h)Λ`, then `nu(h)=Σ alpha(h₁)S²(h₂)`; the second displayed formula records the
+equivalent `S⁻²` expression involving the distinguished group-like element. -/
+structure NakayamaData [FiniteDimensional k H] where
+  phi : Module.Dual k H
+  phi_cointegral : IsRightCointegral k H phi
+  phi_ne_zero : phi ≠ 0
+  integral : LeftIntegral k H
+  integral_normalized : phi (integral : H) = 1
+  alpha : H →ₐ[k] k
+  modular_equation : ∀ h, (integral : H) * h = alpha h • (integral : H)
+  invAntipode : H →ₗ[k] H
+  invAntipode_left : invAntipode.comp (HopfAlgebra.antipode k) = LinearMap.id
+  invAntipode_right : (HopfAlgebra.antipode k).comp invAntipode = LinearMap.id
+  distinguished : Hˣ
+  distinguished_groupLike : IsGroupLikeElem k (distinguished : H)
+  distinguished_equation : ∀ h,
+    ∑ i ∈ (ℛ k h).index,
+      phi ((ℛ k h).right i) • (ℛ k h).left i =
+        phi h • (↑(distinguished⁻¹) : H)
+  nakayama : H ≃ₐ[k] H
+  defining_equation : ∀ x y, phi (x * y) = phi (nakayama y * x)
+  winding_S_sq : ∀ h, nakayama h =
+    ∑ i ∈ (ℛ k h).index,
+      alpha ((ℛ k h).left i) •
+        HopfAlgebra.antipode k (HopfAlgebra.antipode k ((ℛ k h).right i))
+  winding_S_inv_sq : ∀ h, nakayama h =
+    (↑(distinguished⁻¹) : H) *
+      (∑ i ∈ (ℛ k h).index,
+        alpha ((ℛ k h).right i) •
+          invAntipode (invAntipode ((ℛ k h).left i))) *
+      (distinguished : H)
+
+/-- The stable/Frobenius prerequisite uses the opposite handed convention
+`phi (a*b) = phi (b*nuStable a)`.  For the Hopf convention above its automorphism is
+therefore the inverse, not the same map. -/
+noncomputable def NakayamaData.stableNakayama [FiniteDimensional k H]
+    (N : NakayamaData k H) : H ≃ₐ[k] H :=
+  N.nakayama.symm
+
+theorem NakayamaData.stableNakayama_defining_equation [FiniteDimensional k H]
+    (N : NakayamaData k H) (a b : H) :
+    N.phi (a * b) = N.phi (b * NakayamaData.stableNakayama k H N a) := by
+  simpa [NakayamaData.stableNakayama] using
+    (N.defining_equation b (N.nakayama.symm a)).symm
+
+/-- Orientation bridge consumed by the stable-category dependency:
+`nuHopf = nuStable⁻¹`.  Uniqueness follows from nondegeneracy of the multiplication pairing. -/
+theorem NakayamaData.hopfNakayama_eq_stableNakayama_symm [FiniteDimensional k H]
+    (N : NakayamaData k H) :
+    N.nakayama = (NakayamaData.stableNakayama k H N).symm := by
+  rfl
+
+/-- Nondegeneracy makes the stable handed automorphism unique, so the inverse relation above
+is mathematical content rather than a naming convention. -/
+theorem NakayamaData.stableNakayama_unique [FiniteDimensional k H]
+    (N : NakayamaData k H) (sigma : H ≃ₐ[k] H)
+    (hsigma : ∀ a b, N.phi (a * b) = N.phi (b * sigma a)) :
+    sigma = NakayamaData.stableNakayama k H N := by
+  sorry
+
+/-- A concrete symmetric-Frobenius condition: a nondegenerate multiplication functional
+which is a trace. -/
+def IsSymmetricFrobenius : Prop :=
+  ∃ phi : Module.Dual k H,
+    Function.Bijective (mulPairing k H phi) ∧ ∀ x y, phi (x * y) = phi (y * x)
+
+/-- Unimodularity means that the one-dimensional left and right integral subspaces agree. -/
+def IsUnimodular : Prop := LeftIntegral k H = RightIntegral k H
+
+/-- `S²` is inner with the handed conjugation convention shown here. -/
+def AntipodeSquareIsInner : Prop :=
+  ∃ u : Hˣ, ∀ h,
+    HopfAlgebra.antipode k (HopfAlgebra.antipode k h) =
+      (u : H) * h * (↑(u⁻¹) : H)
+
+/-- The exact finite-dimensional criterion: a Hopf algebra is symmetric iff it is
+unimodular and its antipode square is inner. -/
+theorem symmetric_iff_unimodular_and_antipodeSquare_inner
+    [FiniteDimensional k H] [Nontrivial H] :
+    IsSymmetricFrobenius k H ↔ IsUnimodular k H ∧ AntipodeSquareIsInner k H := by
+  sorry
+
+end Integrals
+
+/-! ## Left module algebras and the left smash-product convention -/
+
+section ModuleAlgebra
+
+variable (k : Type u) (H : Type v) (A : Type w)
+variable [Field k] [Ring H] [HopfAlgebra k H] [Ring A] [Algebra k A]
+
+/-- A left action of an algebra `H` on a `k`-module. It is kept explicit here because the
+Hopf-module API is one of the targets of the roadmap. -/
+structure LeftAction (M : Type x) [AddCommGroup M] [Module k M] where
+  act : H →ₗ[k] M →ₗ[k] M
+  one_act : ∀ m, act 1 m = m
+  mul_act : ∀ h l m, act (h * l) m = act h (act l m)
+
+/-- Our primary convention is a **left** `H`-module algebra. The coproduct equation is
+stated using Mathlib's finite `Coalgebra.Repr`, so it is a literal Sweedler-sum equation. -/
+structure LeftModuleAlgebra extends LeftAction k H A where
+  act_one : ∀ h, act h 1 = algebraMap k A (Coalgebra.counit h)
+  act_mul : ∀ h a b,
+    act h (a * b) =
+      ∑ i ∈ (ℛ k h).index, act ((ℛ k h).left i) a * act ((ℛ k h).right i) b
+
+namespace LeftModuleAlgebra
+
+variable {k H A}
+
+/-- The pinned left smash-product formula
+`(a # h)(b # l) = Σ a (h₁ · b) # h₂ l`, on pure tensors. -/
+noncomputable def smashMulPure (X : LeftModuleAlgebra k H A)
+    (a b : A) (h l : H) : A ⊗[k] H :=
+  ∑ i ∈ (ℛ k h).index,
+    (a * X.act ((ℛ k h).left i) b) ⊗ₜ[k] ((ℛ k h).right i * l)
+
+/-- The unit convention for `A # H` is `1 # 1`. -/
+def smashOne : A ⊗[k] H := 1 ⊗ₜ[k] 1
+
+theorem smashMulPure_one_left (X : LeftModuleAlgebra k H A) (a : A) (h : H) :
+    X.smashMulPure 1 a 1 h = a ⊗ₜ[k] h := by
+  sorry
+
+theorem smashMulPure_one_right (X : LeftModuleAlgebra k H A) (a : A) (h : H) :
+    X.smashMulPure a 1 h 1 = a ⊗ₜ[k] h := by
+  sorry
+
+/-- A bundled left smash product.  The carrier is linearly equivalent to `A ⊗ H`, while its
+ring multiplication is part of the object and is pinned by `mul_pure`.  In particular this
+cannot be inhabited merely by choosing the tensor-product algebra and forgetting `X`. -/
+structure SmashProduct (X : LeftModuleAlgebra k H A) where
+  Carrier : Type max v w
+  [instRing : Ring Carrier]
+  [instAlgebra : Algebra k Carrier]
+  carrierEquiv : Carrier ≃ₗ[k] A ⊗[k] H
+  pure : A → H → Carrier
+  pure_equiv : ∀ a h, carrierEquiv (pure a h) = a ⊗ₜ[k] h
+  one_eq : (1 : Carrier) = pure 1 1
+  mul_pure : ∀ a b h l,
+    pure a h * pure b l = carrierEquiv.symm (X.smashMulPure a b h l)
+  includeA : A →ₐ[k] Carrier
+  includeH : H →ₐ[k] Carrier
+  includeA_apply : ∀ a, includeA a = pure a 1
+  includeH_apply : ∀ h, includeH h = pure 1 h
+  pure_eq_embeddings : ∀ a h, pure a h = includeA a * includeH h
+  pure_span :
+    Submodule.span k (Set.range fun z : A × H => pure z.1 z.2) = ⊤
+
+attribute [instance] SmashProduct.instRing SmashProduct.instAlgebra
+
+/-- The construction target: extend the pure formula bilinearly, prove associativity from the
+module-algebra axioms and package the resulting `k`-algebra. -/
+noncomputable def smashProduct (X : LeftModuleAlgebra k H A) : SmashProduct X := by
+  sorry
+
+/-- The bundled ring really supplies associativity, not just a proposed multiplication. -/
+theorem SmashProduct.pure_mul_assoc {X : LeftModuleAlgebra k H A}
+    (S : SmashProduct X) (a b c : A) (h l r : H) :
+    (S.pure a h * S.pure b l) * S.pure c r =
+      S.pure a h * (S.pure b l * S.pure c r) := by
+  exact mul_assoc _ _ _
+
+/-- The covariance relation which characterizes maps out of the left smash product. -/
+def SmashCompatible {X : LeftModuleAlgebra k H A} {C : Type x}
+    [Ring C] [Algebra k C] (fA : A →ₐ[k] C) (fH : H →ₐ[k] C) : Prop :=
+  ∀ h a, fH h * fA a =
+    ∑ i ∈ (ℛ k h).index,
+      fA (X.act ((ℛ k h).left i) a) * fH ((ℛ k h).right i)
+
+/-- Universal property target for the algebra constructed above. -/
+theorem SmashProduct.lift_unique {X : LeftModuleAlgebra k H A}
+    (S : SmashProduct X) {C : Type x} [Ring C] [Algebra k C]
+    (fA : A →ₐ[k] C) (fH : H →ₐ[k] C)
+    (hcompat : SmashCompatible (X := X) fA fH) :
+    ∃! f : S.Carrier →ₐ[k] C,
+      (∀ a, f (S.includeA a) = fA a) ∧ (∀ h, f (S.includeH h) = fH h) := by
+  sorry
+
+end LeftModuleAlgebra
+
+end ModuleAlgebra
+
+/-! ## Right comodule algebras and the finite-dual bridge -/
+
+section ComoduleAlgebra
+
+variable (k : Type u) (C : Type v) (A : Type w)
+variable [Field k] [Ring C] [Bialgebra k C] [Ring A] [Algebra k A]
+variable [TauCeti.Comodule k C A]
+
+/-- Tau Ceti's comodules are right comodules, `ρ : A → A ⊗ C`. The multiplication
+below is the tensor-product algebra multiplication supplied by the `Algebra k A` and
+`Bialgebra k C` instances; constructing and stabilizing that instance is an explicit roadmap
+target before this predicate becomes public API. -/
+structure RightComoduleAlgebra : Prop where
+  coact_one : TauCeti.Comodule.coact (R := k) (C := C) (M := A) 1 = 1 ⊗ₜ[k] 1
+  coact_mul : ∀ a b,
+    TauCeti.Comodule.coact (R := k) (C := C) (M := A) (a * b) =
+      TauCeti.Comodule.coact a * TauCeti.Comodule.coact b
+
+variable {k C A}
+
+end ComoduleAlgebra
+
+section FiniteDual
+
+variable {k : Type u} {H : Type v} {A : Type w}
+variable [Field k] [Ring H] [HopfAlgebra k H] [FiniteDimensional k H]
+variable [Ring A] [Algebra k A]
+
+/-- With a finite basis `e`, a left `H`-action gives the right `H*`-coaction
+`a ↦ Σ (eᵢ · a) ⊗ eᵢ*`. This is the finite-dual bridge; it is not asserted without finite
+projectivity/finite-dimensionality. -/
+noncomputable def coactionFromFiniteDual {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (e : Module.Basis ι k H) (X : LeftModuleAlgebra k H A) (a : A) :
+    A ⊗[k] Module.Dual k H :=
+  ∑ i, X.act (e i) a ⊗ₜ[k] e.dualBasis i
+
+theorem coactionFromFiniteDual_independent_of_basis
+    {ι ι' : Type*} [Fintype ι] [DecidableEq ι] [Fintype ι'] [DecidableEq ι']
+    (e : Module.Basis ι k H) (e' : Module.Basis ι' k H)
+    (X : LeftModuleAlgebra k H A) (a : A) :
+    coactionFromFiniteDual e X a = coactionFromFiniteDual e' X a := by
+  sorry
+
+end FiniteDual
+
+/-! ## Concrete equations for the sign-sensitive examples -/
+
+section PrimitiveObstruction
+
+variable {k : Type u} {H : Type v}
+variable [Field k] [Ring H] [Bialgebra k H]
+
+/-- The roadmap reuses Tau Ceti's binomial coproduct theorem rather than rebuilding it. -/
+theorem primitive_square_coproduct_binomial (d : H)
+    (hprim : Coalgebra.comul d = d ⊗ₜ[k] 1 + 1 ⊗ₜ[k] d) :
+    Coalgebra.comul (d ^ 2) =
+      ∑ mn ∈ Finset.antidiagonal 2, (2 : ℕ).choose mn.1 •
+        ((d ^ mn.1) ⊗ₜ[k] (d ^ mn.2)) :=
+  TauCeti.Bialgebra.comul_pow_of_primitive d hprim 2
+
+/-- In an ordinary tensor product, a square-zero primitive element forces the middle term
+`2(d ⊗ d)` to vanish. This is the signature-level obstruction to making `k[d]/(d²)` an
+ordinary characteristic-zero Hopf algebra with primitive `d`. -/
+theorem primitive_square_zero_forces_two_tmul (d : H)
+    (hprim : Coalgebra.comul d = d ⊗ₜ[k] 1 + 1 ⊗ₜ[k] d)
+    (hsq : d ^ 2 = 0) :
+    (2 : k) • (d ⊗ₜ[k] d) = 0 := by
+  have hdmul : d * d = 0 := by simpa [pow_two] using hsq
+  have hpow := Bialgebra.comul_pow (R := k) d 2
+  rw [hsq, map_zero, hprim] at hpow
+  simp [pow_two, mul_add, add_mul, Algebra.TensorProduct.tmul_mul_tmul, hdmul] at hpow
+  rw [← two_smul k] at hpow
+  exact hpow.symm
+
+/-- A nonzero pure tensor over a field is nonzero. This closes the logical gap between the
+binomial coproduct calculation and the characteristic-zero impossibility statement. -/
+theorem self_tmul_ne_zero (d : H) (hd : d ≠ 0) : d ⊗ₜ[k] d ≠ 0 := by
+  obtain ⟨f, hf⟩ := Module.Projective.exists_dual_eq_one k hd
+  intro h
+  have h' := congrArg
+    (fun z => (TensorProduct.lid k k) (TensorProduct.map f f z)) h
+  simp [hf] at h'
+
+/-- Consequently an ordinary bialgebra over a field of characteristic different from two has
+no nonzero square-zero primitive element. -/
+theorem no_nonzero_square_zero_primitive (h2 : (2 : k) ≠ 0) (d : H) (hd : d ≠ 0)
+    (hprim : Coalgebra.comul d = d ⊗ₜ[k] 1 + 1 ⊗ₜ[k] d)
+    (hsq : d ^ 2 = 0) : False := by
+  have h := primitive_square_zero_forces_two_tmul d hprim hsq
+  exact (smul_ne_zero h2 (self_tmul_ne_zero d hd)) h
+
+/-- In characteristic prime `p`, Tau Ceti's same binomial formula has no intermediate
+terms. This is the load-bearing coproduct equation needed to descend through `(d^p)`. -/
+theorem primitive_pow_coproduct_prime (p : ℕ) (hp : p.Prime) (hchar : ringChar k = p)
+    (d : H) (hprim : Coalgebra.comul d = d ⊗ₜ[k] 1 + 1 ⊗ₜ[k] d) :
+    Coalgebra.comul (d ^ p) = (d ^ p) ⊗ₜ[k] 1 + 1 ⊗ₜ[k] (d ^ p) := by
+  sorry
+
+end PrimitiveObstruction
+
+section ExampleData
+
+/-! The following structures expose the module-algebra equations carried by the examples.
+The definitive roadmap additionally requires genuine `ℤ`-graded objects and homogeneous-map
+degrees; these small signatures keep the nilpotence and Leibniz equations executable today. -/
+
+/-- A multiplicative bicharacter supplies the braiding scalar between homogeneous degrees.
+Taking `G = ℤ` gives the ambient needed by the cyclotomic construction; `G = ZMod 2` is only
+the super specialization. -/
+structure Bicharacter (G k : Type*) [AddCommGroup G] [Field k] where
+  coeff : G → G → k
+  coeff_zero_left : ∀ g, coeff 0 g = 1
+  coeff_zero_right : ∀ g, coeff g 0 = 1
+  coeff_add_left : ∀ g₁ g₂ h, coeff (g₁ + g₂) h = coeff g₁ h * coeff g₂ h
+  coeff_add_right : ∀ g h₁ h₂, coeff g (h₁ + h₂) = coeff g h₁ * coeff g h₂
+  coeff_ne_zero : ∀ g h, coeff g h ≠ 0
+
+/-- An internal grading of an existing algebra.  `DirectSum.Decomposition` uses the canonical
+inclusions of the displayed submodules, so the grading cannot be faked by an unrelated degree
+function or an always-false homogeneity predicate. -/
+structure InternalGrading (G k A : Type*) [AddCommGroup G] [DecidableEq G]
+    [Field k] [Ring A] [Algebra k A] where
+  Piece : G → Submodule k A
+  decomposition : DirectSum.Decomposition Piece
+  one_mem_degree : (1 : A) ∈ Piece 0
+  mul_mem_degree : ∀ {g h} {a b : A},
+    a ∈ Piece g → b ∈ Piece h → a * b ∈ Piece (g + h)
+
+attribute [instance] InternalGrading.decomposition
+
+/-- A nonvacuous algebra object in bicharacter-graded vector spaces.  The ring and algebra
+instances are installed before the component submodules are formed, avoiding unrelated module
+structures on the carrier. -/
+structure GradedBicharacterDatum (G k : Type*) [AddCommGroup G] [DecidableEq G]
+    [Field k] (chi : Bicharacter G k) where
+  Carrier : Type*
+  [instRing : Ring Carrier]
+  [instAlgebra : Algebra k Carrier]
+  Piece : G → Submodule k Carrier
+  decomposition : DirectSum.Decomposition Piece
+  one_mem_degree : (1 : Carrier) ∈ Piece 0
+  mul_mem_degree : ∀ {g h} {a b : Carrier},
+    a ∈ Piece g → b ∈ Piece h → a * b ∈ Piece (g + h)
+
+attribute [instance] GradedBicharacterDatum.instRing
+  GradedBicharacterDatum.instAlgebra GradedBicharacterDatum.decomposition
+
+/-- The concrete bidegree `(g,h)` inside a tensor square. -/
+def tensorBidegreePiece (G k E : Type*) [AddCommGroup G] [DecidableEq G] [Field k]
+    [Ring E] [Algebra k E] (Piece : G → Submodule k E) (g h : G) :
+    Submodule k (E ⊗[k] E) :=
+  Submodule.map
+    (TensorProduct.map (Piece g).subtype (Piece h).subtype) ⊤
+
+/-- The total-degree `n` part of the tensor square is the sum of the actual bidegrees
+`(g,h)` satisfying `g+h=n`. -/
+def tensorTotalDegreePiece (G k E : Type*) [AddCommGroup G] [DecidableEq G] [Field k]
+    [Ring E] [Algebra k E] (Piece : G → Submodule k E) (n : G) :
+    Submodule k (E ⊗[k] E) :=
+  ⨆ gh : {gh : G × G // gh.1 + gh.2 = n},
+    tensorBidegreePiece G k E Piece gh.1.1 gh.1.2
+
+/-- A Hopf-algebra object in the bicharacter-braided category.  In contrast with an ordinary
+`HopfAlgebra`, multiplicativity of `comul` uses the explicitly braided `tensorMul`. -/
+structure BraidedHopfObject (G k : Type*) [AddCommGroup G] [DecidableEq G] [Field k]
+    (chi : Bicharacter G k) extends GradedBicharacterDatum G k chi where
+  tensorMul :
+    (Carrier ⊗[k] Carrier) →ₗ[k]
+      (Carrier ⊗[k] Carrier) →ₗ[k] (Carrier ⊗[k] Carrier)
+  tensorMul_pure : ∀ {gx gy gx' gy'} {x y x' y' : Carrier},
+    x ∈ Piece gx → y ∈ Piece gy → x' ∈ Piece gx' → y' ∈ Piece gy' →
+    tensorMul (x ⊗ₜ[k] y) (x' ⊗ₜ[k] y') =
+      chi.coeff gy gx' • ((x * x') ⊗ₜ[k] (y * y'))
+  comul : Carrier →ₗ[k] Carrier ⊗[k] Carrier
+  comul_mem_degree : ∀ {g} {x : Carrier}, x ∈ Piece g →
+    (tensorTotalDegreePiece G k Carrier Piece g).carrier (comul x)
+  comul_one : comul 1 = 1 ⊗ₜ[k] 1
+  comul_mul : ∀ x y, comul (x * y) = tensorMul (comul x) (comul y)
+  coassoc : ∀ x,
+    TensorProduct.assoc k Carrier Carrier Carrier
+        (TensorProduct.map comul LinearMap.id (comul x)) =
+      TensorProduct.map LinearMap.id comul (comul x)
+  counit : Carrier →ₗ[k] k
+  counit_of_degree_ne_zero : ∀ {g} {x : Carrier},
+    x ∈ Piece g → g ≠ 0 → counit x = 0
+  counit_one : counit 1 = 1
+  counit_mul : ∀ x y, counit (x * y) = counit x * counit y
+  counit_left : ∀ x,
+    TensorProduct.lid k Carrier
+        (TensorProduct.map counit LinearMap.id (comul x)) = x
+  counit_right : ∀ x,
+    TensorProduct.rid k Carrier
+        (TensorProduct.map LinearMap.id counit (comul x)) = x
+  mulTensor : Carrier ⊗[k] Carrier →ₗ[k] Carrier
+  mulTensor_pure : ∀ x y, mulTensor (x ⊗ₜ[k] y) = x * y
+  antipode : Carrier →ₗ[k] Carrier
+  antipode_mem_degree : ∀ {g} {x : Carrier}, x ∈ Piece g → antipode x ∈ Piece g
+  antipode_left : ∀ x,
+    mulTensor (TensorProduct.map antipode LinearMap.id (comul x)) =
+      algebraMap k Carrier (counit x)
+  antipode_right : ∀ x,
+    mulTensor (TensorProduct.map LinearMap.id antipode (comul x)) =
+      algebraMap k Carrier (counit x)
+
+/-- An actual internally graded module over an internally graded algebra.  The action law
+records that a degree-`g` algebra element sends degree `h` to degree `g+h`. -/
+structure GradedModuleDatum (G k H M : Type*) [AddCommGroup G] [DecidableEq G]
+    [Field k] [Ring H] [Algebra k H] [AddCommGroup M] [Module k M]
+    [Module H M] [IsScalarTower k H M] (HGrading : InternalGrading G k H) where
+  Piece : G → Submodule k M
+  decomposition : DirectSum.Decomposition Piece
+  smul_mem_degree : ∀ {g h} {a : H} {m : M},
+    a ∈ HGrading.Piece g → m ∈ Piece h → a • m ∈ Piece (g + h)
+
+attribute [instance] GradedModuleDatum.decomposition
+
+/-- The genuine internal shift: an element formerly in degree `g-r` lies in degree `g` of
+`M{r}`. -/
+noncomputable def GradedModuleDatum.shift
+    {G k H M : Type*} [AddCommGroup G] [DecidableEq G]
+    [Field k] [Ring H] [Algebra k H] [AddCommGroup M] [Module k M]
+    [Module H M] [IsScalarTower k H M] {HGrading : InternalGrading G k H}
+    (MGrading : GradedModuleDatum G k H M HGrading) (r : G) :
+    GradedModuleDatum G k H M HGrading := by
+  refine
+    { Piece := fun g => MGrading.Piece (g - r)
+      decomposition := ?_
+      smul_mem_degree := ?_ }
+  · sorry
+  · intro g h a m ha hm
+    simpa [add_sub_assoc] using MGrading.smul_mem_degree ha hm
+
+/-- A degree-zero map of graded modules.  Its underlying map is genuinely `H`-linear. -/
+structure GradedLinearMap
+    {G k H M N : Type*} [AddCommGroup G] [DecidableEq G]
+    [Field k] [Ring H] [Algebra k H]
+    [AddCommGroup M] [Module k M] [Module H M] [IsScalarTower k H M]
+    [AddCommGroup N] [Module k N] [Module H N] [IsScalarTower k H N]
+    {HGrading : InternalGrading G k H}
+    (MGrading : GradedModuleDatum G k H M HGrading)
+    (NGrading : GradedModuleDatum G k H N HGrading) where
+  toLinearMap : M →ₗ[H] N
+  map_mem_degree : ∀ {g} {m : M}, m ∈ MGrading.Piece g →
+    toLinearMap m ∈ NGrading.Piece g
+
+/-- Pure multiplication in the tensor product of `G`-graded algebras braided by `chi`; both
+degrees affecting the scalar are witnessed in the actual internal grading. -/
+def braidedTensorMulPure (k E G : Type*) [Field k] [Ring E] [Algebra k E]
+    [AddCommGroup G] [DecidableEq G] (chi : Bicharacter G k)
+    (grading : InternalGrading G k E)
+    (x y x' y' : E) (degreeY degreeX' : G)
+    (_hy : y ∈ grading.Piece degreeY) (_hx' : x' ∈ grading.Piece degreeX') :
+    E ⊗[k] E :=
+  chi.coeff degreeY degreeX' • ((x * x') ⊗ₜ[k] (y * y'))
+
+/-- The standard `ℤ`-graded braiding `χ(i,j)=q^(ij)`.  Laugwitz--Qi use this ambient,
+with `q` a specified nonzero root of unity. -/
+noncomputable def integerBicharacter (k : Type*) [Field k] (q : k) (hq : q ≠ 0) :
+    Bicharacter ℤ k := by
+  sorry
+
+/-- The Koszul sign bicharacter is the `ℤ/2` specialization, not the general ambient. -/
+noncomputable def superBicharacter (k : Type*) [Field k] : Bicharacter (ZMod 2) k := by
+  sorry
+
+/-- Pure multiplication in a super tensor product, with degrees witnessed by the genuine
+internal `ZMod 2` grading. -/
+noncomputable def superTensorMulPure (k E : Type*) [Field k] [Ring E] [Algebra k E]
+    (grading : InternalGrading (ZMod 2) k E)
+    (x y x' y' : E) (parityY parityX' : ZMod 2)
+    (_hy : y ∈ grading.Piece parityY) (_hx' : x' ∈ grading.Piece parityX') :
+    E ⊗[k] E :=
+  (superBicharacter k).coeff parityY parityX' •
+    ((x * x') ⊗ₜ[k] (y * y'))
+
+/-- The cross terms in the square of an odd primitive coproduct cancel in the super tensor
+product. This is the sign calculation which fails in the ordinary tensor product. -/
+theorem odd_primitive_cross_terms_cancel
+    (k E : Type*) [Field k] [Ring E] [Algebra k E]
+    (grading : InternalGrading (ZMod 2) k E) (d : E)
+    (hd : d ∈ grading.Piece 1) :
+    superTensorMulPure k E grading d 1 1 d 0 0
+        grading.one_mem_degree grading.one_mem_degree +
+      superTensorMulPure k E grading 1 d d 1 1 1 hd hd = 0 := by
+  sorry
+
+/-- The exterior Hopf **super**algebra is an actual Hopf object in the `ZMod 2`-graded
+bicharacter category, not a disconnected list of maps. -/
+structure ExteriorOddPrimitiveDatum (k : Type*) [Field k]
+    extends BraidedHopfObject (ZMod 2) k (superBicharacter k) where
+  d : Carrier
+  d_degree : d ∈ Piece 1
+  d_ne_zero : d ≠ 0
+  d_sq : d ^ 2 = 0
+  comul_d : comul d = d ⊗ₜ[k] 1 + 1 ⊗ₜ[k] d
+  counit_d : counit d = 0
+  antipode_d : antipode d = -d
+
+/-- An ordinary DG algebra: the sign is attached to the degree of a homogeneous left factor.
+The exterior generator is odd and primitive in super vector spaces, not in ordinary vector spaces. -/
+structure OrdinaryDGDatum (k A : Type*) [Field k] [Ring A] [Algebra k A] where
+  grading : InternalGrading ℤ k A
+  differential : A →ₗ[k] A
+  differential_sq : differential.comp differential = 0
+  differential_degree : ∀ {g} {a : A}, a ∈ grading.Piece g →
+    differential a ∈ grading.Piece (g + 1)
+  leibniz : ∀ (g : ℤ) {a : A}, a ∈ grading.Piece g → ∀ b,
+    differential (a * b) =
+      differential a * b + ((-1 : k) ^ g) • (a * differential b)
+
+/-- A `p`-DG algebra over characteristic `p`: there is no Koszul sign in the Leibniz rule,
+and the differential is nilpotent of order `p`. -/
+structure PDGDatum (k A : Type*) [Field k] [Ring A] [Algebra k A] (p : ℕ) where
+  prime : p.Prime
+  characteristic : ringChar k = p
+  grading : InternalGrading ℤ k A
+  differential : A →ₗ[k] A
+  differential_pow : differential ^ p = 0
+  differential_degree : ∀ {g} {a : A}, a ∈ grading.Piece g →
+    differential a ∈ grading.Piece (g + 1)
+  leibniz : ∀ a b,
+    differential (a * b) = differential a * b + a * differential b
+
+/-- The `q`-Leibniz form of an `N`-complex algebra. This belongs to the braided/Taft model;
+it is not the ordinary primitive truncated-polynomial Hopf algebra in characteristic zero. -/
+structure QNComplexDatum (k A : Type*) [Field k] [Ring A] [Algebra k A]
+    (N : ℕ) (q : k) where
+  order : 2 ≤ N
+  primitiveRoot : IsPrimitiveRoot q N
+  characteristic_not_dvd : ¬ ringChar k ∣ N
+  grading : InternalGrading ℤ k A
+  differential : A →ₗ[k] A
+  differential_pow : differential ^ N = 0
+  differential_degree : ∀ {g} {a : A}, a ∈ grading.Piece g →
+    differential a ∈ grading.Piece (g + 1)
+  leibniz : ∀ (g : ℤ) {a : A}, a ∈ grading.Piece g → ∀ b,
+    differential (a * b) =
+      differential a * b + (q ^ g) • (a * differential b)
+
+/-- The integral action in the exterior Hopf-superalgebra gives Qi's signed formula
+`d_N h + (-1)^(|h|+1) h d_M`. For a degree `-1` chain homotopy the sign is positive. -/
+def dgIntegralNullHomotopy {k M N : Type*} [Field k]
+    [AddCommGroup M] [Module k M] [AddCommGroup N] [Module k N]
+    (dM : M →ₗ[k] M) (dN : N →ₗ[k] N) (h : M →ₗ[k] N)
+    (degreeH : ℤ) : M →ₗ[k] N :=
+  dN.comp h + ((-1 : k) ^ (degreeH + 1)) • h.comp dM
+
+theorem dgIntegralNullHomotopy_degree_neg_one {k M N : Type*} [Field k]
+    [AddCommGroup M] [Module k M] [AddCommGroup N] [Module k N]
+    (dM : M →ₗ[k] M) (dN : N →ₗ[k] N) (h : M →ₗ[k] N) :
+    dgIntegralNullHomotopy dM dN h (-1) = dN.comp h + h.comp dM := by
+  simp [dgIntegralNullHomotopy]
+
+/-- The explicit `p`-complex null-homotopy operator
+`Σ_{i=0}^{p-1} d_N^i h d_M^(p-1-i)`. For the usual DG case `p = 2`, the
+super conventions turn this into the familiar signed chain-homotopy formula. -/
+def pNullHomotopy {k M N : Type*} [Field k]
+    [AddCommGroup M] [Module k M] [AddCommGroup N] [Module k N]
+    (p : ℕ) (dM : M →ₗ[k] M) (dN : N →ₗ[k] N) (h : M →ₗ[k] N) : M →ₗ[k] N :=
+  ∑ i ∈ Finset.range p, (dN ^ i).comp (h.comp (dM ^ (p - 1 - i)))
+
+theorem pNullHomotopy_two {k M N : Type*} [Field k]
+    [AddCommGroup M] [Module k M] [AddCommGroup N] [Module k N]
+    (dM : M →ₗ[k] M) (dN : N →ₗ[k] N) (h : M →ₗ[k] N) :
+    pNullHomotopy 2 dM dN h = h.comp dM + dN.comp h := by
+  ext m
+  simp [pNullHomotopy, Finset.sum_range_succ, add_comm]
+
+/-- Slash cycles `ker(d^(j+1))`. -/
+def slashCycles {k M : Type*} [Field k] [AddCommGroup M] [Module k M]
+    (d : M →ₗ[k] M) (j : ℕ) : Submodule k M :=
+  LinearMap.ker (d ^ (j + 1))
+
+/-- The slash denominator `im(d^(p-j-1)) + ker(d^j)`. -/
+def slashDenominator {k M : Type*} [Field k] [AddCommGroup M] [Module k M]
+    (p : ℕ) (d : M →ₗ[k] M) (j : ℕ) : Submodule k M :=
+  LinearMap.range (d ^ (p - j - 1)) ⊔ LinearMap.ker (d ^ j)
+
+/-- For `d^p=0` and `0≤j≤p-2`, the stated denominator lies in the slash cycles. -/
+theorem slashDenominator_le_cycles {k M : Type*} [Field k]
+    [AddCommGroup M] [Module k M] (p : ℕ) (d : M →ₗ[k] M)
+    (hd : d ^ p = 0) (j : ℕ) (hj : j ≤ p - 2) :
+    slashDenominator p d j ≤ slashCycles d j := by
+  sorry
+
+/-- `H^{/j}(M)=ker(d^(j+1))/(im(d^(p-j-1))+ker(d^j))`, represented as a quotient of
+the cycle submodule.  The nilpotence and range bound are inputs, so the `comap` is provably
+the entire stated denominator viewed inside cycles, not an accidental intersection. -/
+def SlashHomology {k M : Type*} [Field k] [AddCommGroup M] [Module k M]
+    (p : ℕ) (d : M →ₗ[k] M) (hd : d ^ p = 0)
+    (j : ℕ) (hj : j ≤ p - 2) : Type _ :=
+  let _denominator_le := slashDenominator_le_cycles p d hd j hj
+  (slashCycles d j) ⧸
+    (slashDenominator p d j).comap (slashCycles d j).subtype
+
+/-- If the structural differential has degree `delta`, a `p`-null-homotopy has degree
+`(1-p)delta`. -/
+def pNullHomotopyDegree (p : ℕ) (delta : ℤ) : ℤ := (1 - (p : ℤ)) * delta
+
+@[simp] theorem pNullHomotopyDegree_one (p : ℕ) :
+    pNullHomotopyDegree p 1 = 1 - p := by
+  simp [pNullHomotopyDegree]
+
+@[simp] theorem pNullHomotopyDegree_two (p : ℕ) :
+    pNullHomotopyDegree p 2 = 2 - 2 * p := by
+  simp [pNullHomotopyDegree]
+  ring
+
+/-- Equations for the ordinary characteristic-`p` truncated-primitive model. The roadmap
+separately requires constructing the quotient Hopf algebra when `p` is prime and `char k = p`. -/
+structure TruncatedPrimitiveDatum (k H : Type*) [Field k] [Ring H] [HopfAlgebra k H]
+    (p : ℕ) where
+  prime : p.Prime
+  characteristic : ringChar k = p
+  d : H
+  primitive : Coalgebra.comul (R := k) d = d ⊗ₜ[k] 1 + 1 ⊗ₜ[k] d
+  counit : Coalgebra.counit (R := k) d = 0
+  antipode : HopfAlgebra.antipode k d = -d
+  nilpotent : d ^ p = 0
+  generated : Algebra.adjoin k ({d} : Set H) = ⊤
+  /-- Recognition data for the quotient `k[d]/(d^p)`: these monomials are a basis, so the
+  zero generator/trivial algebra cannot masquerade as the example.  The construction theorem
+  must separately build this basis from the polynomial quotient. -/
+  monomialBasis : Module.Basis (Fin p) k H
+  monomialBasis_apply : ∀ i, monomialBasis i = d ^ (i : ℕ)
+
+/-- The differential on an `H=k[d]/(d^p)`-module is multiplication by its genuine
+primitive generator. -/
+noncomputable def TruncatedPrimitiveDatum.moduleDifferential
+    {k H M : Type*} [Field k] [Ring H] [HopfAlgebra k H]
+    [AddCommGroup M] [Module k M] [Module H M] [IsScalarTower k H M]
+    {p : ℕ} (P : TruncatedPrimitiveDatum k H p) : M →ₗ[k] M := by
+  sorry
+
+theorem TruncatedPrimitiveDatum.moduleDifferential_pow
+    {k H M : Type*} [Field k] [Ring H] [HopfAlgebra k H]
+    [AddCommGroup M] [Module k M] [Module H M] [IsScalarTower k H M]
+    {p : ℕ} (P : TruncatedPrimitiveDatum k H p) :
+    (P.moduleDifferential (M := M)) ^ p = 0 := by
+  sorry
+
+/-- Khovanov--Qi slash homology detects projectivity for finite-dimensional `p`-complexes:
+all `H^{/j}`, `0≤j≤p-2`, vanish iff the underlying truncated-Hopf module is projective. -/
+theorem slashHomology_zero_iff_projective
+    {k H M : Type*} [Field k] [Ring H] [HopfAlgebra k H]
+    [AddCommGroup M] [Module k M] [Module H M] [IsScalarTower k H M]
+    [FiniteDimensional k M] {p : ℕ} (P : TruncatedPrimitiveDatum k H p) :
+    (∀ j (hj : j ≤ p - 2),
+      Subsingleton (SlashHomology p (P.moduleDifferential (M := M))
+        P.moduleDifferential_pow j hj)) ↔
+      Module.Projective H M := by
+  sorry
+
+/-- A primitive truncated generator acts by the unsigned Leibniz rule. -/
+structure TruncatedPrimitiveModuleAlgebraEquations
+    (k H A : Type*) [Field k] [Ring H] [HopfAlgebra k H] [Ring A] [Algebra k A]
+    (X : LeftModuleAlgebra k H A) (p : ℕ) (P : TruncatedPrimitiveDatum k H p) : Prop where
+  d_leibniz : ∀ a b,
+    X.act P.d (a * b) = X.act P.d a * b + a * X.act P.d b
+
+/-- Equations for Sweedler's four-dimensional Hopf algebra. At `char k ≠ 2`, the skew
+primitive coproduct and `g d = -d g` are exactly the bosonized sign correction. -/
+structure SweedlerDatum (k H : Type*) [Field k] [Ring H] [HopfAlgebra k H] where
+  characteristic_ne_two : ringChar k ≠ 2
+  grading : InternalGrading (ZMod 2) k H
+  g : H
+  d : H
+  g_degree : g ∈ grading.Piece 0
+  d_degree : d ∈ grading.Piece 1
+  g_sq : g ^ 2 = 1
+  d_sq : d ^ 2 = 0
+  g_mul_d : g * d = -(d * g)
+  comul_g : Coalgebra.comul (R := k) g = g ⊗ₜ[k] g
+  comul_d : Coalgebra.comul (R := k) d = d ⊗ₜ[k] 1 + g ⊗ₜ[k] d
+  counit_g : Coalgebra.counit (R := k) g = 1
+  counit_d : Coalgebra.counit (R := k) d = 0
+  antipode_g : HopfAlgebra.antipode k g = g
+  antipode_d : HopfAlgebra.antipode k d = -(g * d)
+  generated : Algebra.adjoin k ({g, d} : Set H) = ⊤
+  /-- Recognition basis `g^i d^j`, enforcing dimension four.  A separate quotient
+  constructor proves that the usual presentation has this basis. -/
+  monomialBasis : Module.Basis (Fin 2 × Fin 2) k H
+  monomialBasis_apply : ∀ i,
+    monomialBasis i = g ^ (i.1 : ℕ) * d ^ (i.2 : ℕ)
+
+/-- The two middle terms in `Δ(d)²` cancel in the Sweedler/bosonized model. -/
+theorem SweedlerDatum.comul_d_sq_middle_cancel
+    {k H : Type*} [Field k] [Ring H] [HopfAlgebra k H] (X : SweedlerDatum k H) :
+    X.d * X.g + X.g * X.d = 0 := by
+  rw [X.g_mul_d]
+  simp
+
+/-- With a genuine internal `ℤ`-grading, the Sweedler action makes `g` literally the parity
+operator and `d` a degree-one `g`-skew derivation. -/
+structure SweedlerModuleAlgebraEquations (k H A : Type*) [Field k] [Ring H]
+    [HopfAlgebra k H] [Ring A] [Algebra k A]
+    (X : LeftModuleAlgebra k H A) (S : SweedlerDatum k H)
+    (grading : InternalGrading ℤ k A) : Prop where
+  g_multiplicative : ∀ a b, X.act S.g (a * b) = X.act S.g a * X.act S.g b
+  /-- `g` is literally the parity operator on the genuine internal `ℤ`-grading. -/
+  g_on_degree : ∀ {r} {a : A}, a ∈ grading.Piece r →
+    X.act S.g a = ((-1 : k) ^ r) • a
+  d_degree : ∀ {r} {a : A}, a ∈ grading.Piece r →
+    X.act S.d a ∈ grading.Piece (r + 1)
+  d_signedLeibniz : ∀ a b,
+    X.act S.d (a * b) = X.act S.d a * b + X.act S.g a * X.act S.d b
+
+/-- Equations for the Taft convention used here. `zeta` is required to be primitive of exact
+order `n` in the roadmap, and `n ≥ 2`, `char k ∤ n` are explicit hypotheses there. -/
+structure TaftDatum (k H : Type*) [Field k] [Ring H] [HopfAlgebra k H]
+    (n : ℕ) (zeta : k) where
+  order : 2 ≤ n
+  primitiveRoot : IsPrimitiveRoot zeta n
+  characteristic_not_dvd : ¬ ringChar k ∣ n
+  K : H
+  d : H
+  K_pow : K ^ n = 1
+  d_pow : d ^ n = 0
+  K_mul_d : K * d = algebraMap k H zeta * d * K
+  comul_K : Coalgebra.comul (R := k) K = K ⊗ₜ[k] K
+  comul_d : Coalgebra.comul (R := k) d = d ⊗ₜ[k] 1 + K ⊗ₜ[k] d
+  counit_K : Coalgebra.counit (R := k) K = 1
+  counit_d : Coalgebra.counit (R := k) d = 0
+  Kinv : H
+  Kinv_mul_K : Kinv * K = 1
+  K_mul_Kinv : K * Kinv = 1
+  antipode_K : HopfAlgebra.antipode k K = Kinv
+  antipode_d : HopfAlgebra.antipode k d = -(Kinv * d)
+  generated : Algebra.adjoin k ({K, d} : Set H) = ⊤
+  /-- Recognition basis `K^i d^j`, enforcing dimension `n^2`.  The quotient presentation
+  and proof of this basis are construction targets, not assumptions of that constructor. -/
+  monomialBasis : Module.Basis (Fin n × Fin n) k H
+  monomialBasis_apply : ∀ i,
+    monomialBasis i = K ^ (i.1 : ℕ) * d ^ (i.2 : ℕ)
+
+/-- The module-algebra equation forced by the Taft coproduct
+`Δ(d) = d ⊗ 1 + K ⊗ d`. -/
+structure TaftModuleAlgebraEquations (k H A : Type*) [Field k] [Ring H]
+    [HopfAlgebra k H] [Ring A] [Algebra k A]
+    (X : LeftModuleAlgebra k H A) (n : ℕ) (zeta : k)
+    (T : TaftDatum k H n zeta) : Prop where
+  K_multiplicative : ∀ a b, X.act T.K (a * b) = X.act T.K a * X.act T.K b
+  d_skewLeibniz : ∀ a b,
+    X.act T.d (a * b) = X.act T.d a * b + X.act T.K a * X.act T.d b
+
+/-- Complete distinct-prime factorization data `n = ∏ p_k^{a_k}`.  The equality, primality,
+positive exponents and pairwise distinctness jointly rule out an incomplete list of primes. -/
+structure CyclotomicFactorization (n t : ℕ) where
+  order : 2 ≤ n
+  nonempty : 0 < t
+  p : Fin t → ℕ
+  exponent : Fin t → ℕ
+  p_prime : ∀ i, (p i).Prime
+  exponent_pos : ∀ i, 0 < exponent i
+  p_distinct : ∀ i j, i ≠ j → p i ≠ p j
+  complete : ∏ i, p i ^ exponent i = n
+
+namespace CyclotomicFactorization
+
+variable {n t : ℕ}
+
+/-- `m = ∏ p_k`, the square-free radical of `n`. -/
+def radical (F : CyclotomicFactorization n t) : ℕ := ∏ i, F.p i
+
+/-- `N = n²/m`, the order of the bosonizing cyclic group. -/
+def ambientOrder (F : CyclotomicFactorization n t) : ℕ := n ^ 2 / F.radical
+
+/-- `n_k = n/p_k`. -/
+def nDivPrime (F : CyclotomicFactorization n t) (i : Fin t) : ℕ := n / F.p i
+
+/-- `m_k = m/p_k`. -/
+def radicalDivPrime (F : CyclotomicFactorization n t) (i : Fin t) : ℕ :=
+  F.radical / F.p i
+
+theorem prime_dvd_order (F : CyclotomicFactorization n t) (i : Fin t) :
+    F.p i ∣ n := by
+  sorry
+
+theorem radical_dvd_order (F : CyclotomicFactorization n t) : F.radical ∣ n := by
+  sorry
+
+theorem ambientOrder_pos (F : CyclotomicFactorization n t) : 0 < F.ambientOrder := by
+  sorry
+
+end CyclotomicFactorization
+
+/-- Root data derived from the factorization: `q` has order `N`,
+`ξ=q^(n/m)`, and `ξ_k=ξ^m_k=q^n_k`. -/
+structure CyclotomicRootData (k : Type*) [Field k] {n t : ℕ}
+    (F : CyclotomicFactorization n t) where
+  q : k
+  q_primitiveRoot : IsPrimitiveRoot q F.ambientOrder
+  characteristic_not_dvd : ¬ ringChar k ∣ F.ambientOrder
+
+namespace CyclotomicRootData
+
+variable {k : Type*} [Field k] {n t : ℕ} {F : CyclotomicFactorization n t}
+
+/-- `ξ=q^(n/m)`. -/
+def xi (R : CyclotomicRootData k F) : k := R.q ^ (n / F.radical)
+
+/-- `ξ_k=ξ^m_k`; arithmetic identifies this with `q^n_k`. -/
+def xiAt (R : CyclotomicRootData k F) (i : Fin t) : k :=
+  R.xi ^ F.radicalDivPrime i
+
+theorem q_ne_zero (R : CyclotomicRootData k F) : R.q ≠ 0 := by
+  sorry
+
+/-- The `ℤ`-graded bicharacter actually used by the Laugwitz--Qi braided algebra. -/
+noncomputable def braiding (R : CyclotomicRootData k F) : Bicharacter ℤ k :=
+  integerBicharacter k R.q R.q_ne_zero
+
+theorem xi_primitiveRoot (R : CyclotomicRootData k F) :
+    IsPrimitiveRoot R.xi n := by
+  sorry
+
+theorem xiAt_primitiveRoot (R : CyclotomicRootData k F) (i : Fin t) :
+    IsPrimitiveRoot (R.xiAt i) (F.p i) := by
+  sorry
+
+theorem xiAt_eq_q_pow_nDivPrime (R : CyclotomicRootData k F) (i : Fin t) :
+    R.xiAt i = R.q ^ F.nDivPrime i := by
+  sorry
+
+end CyclotomicRootData
+
+/-- The braided Hopf algebra `H_n` itself, in the general `ℤ`-graded bicharacter ambient.
+Its standard basis enforces dimension `m=∏p_k`; the ordinary bosonization below consumes this
+object rather than copying a disconnected list of generators. -/
+structure CyclotomicBraidedDatum (k : Type*) [Field k] {n t : ℕ}
+    (F : CyclotomicFactorization n t) (R : CyclotomicRootData k F)
+    extends BraidedHopfObject ℤ k R.braiding where
+  d : Fin t → Carrier
+  d_degree : ∀ i, d i ∈ Piece (F.nDivPrime i : ℤ)
+  d_pow : ∀ i, d i ^ F.p i = 0
+  d_comm : ∀ i j, d i * d j = d j * d i
+  comul_d : ∀ i, comul (d i) = d i ⊗ₜ[k] 1 + 1 ⊗ₜ[k] d i
+  counit_d : ∀ i, counit (d i) = 0
+  antipode_d : ∀ i, antipode (d i) = -d i
+  generated : Algebra.adjoin k (Set.range d) = ⊤
+  monomialBasis : Module.Basis (∀ i, Fin (F.p i)) k Carrier
+  monomialBasis_apply : ∀ a,
+    monomialBasis a = (List.ofFn fun i => d i ^ (a i : ℕ)).prod
+
+/-- The actual internal `ℤ`-grading carried by the cyclotomic braided algebra. -/
+def CyclotomicBraidedDatum.internalGrading
+    {k : Type*} [Field k] {n t : ℕ} {F : CyclotomicFactorization n t}
+    {R : CyclotomicRootData k F} (Br : CyclotomicBraidedDatum k F R) :
+    InternalGrading ℤ k Br.Carrier where
+  Piece := Br.Piece
+  decomposition := Br.toBraidedHopfObject.toGradedBicharacterDatum.decomposition
+  one_mem_degree := Br.one_mem_degree
+  mul_mem_degree := Br.mul_mem_degree
+
+/-- Recognition data for the Laugwitz--Qi bosonization attached to the *derived* arithmetic
+above. Each `d_k` is `K^n_k`-skew primitive and has nilpotence order `p_k`.  The monomial
+basis enforces dimension `N · ∏p_k`; a separate quotient constructor must prove this data. -/
+structure CyclotomicBosonizationDatum (k H : Type*) [Field k] [Ring H] [HopfAlgebra k H]
+    {n t : ℕ} (F : CyclotomicFactorization n t) (R : CyclotomicRootData k F)
+    (Br : CyclotomicBraidedDatum k F R) where
+  includeBraided :
+    letI := Br.toBraidedHopfObject.toGradedBicharacterDatum.instRing
+    letI := Br.toBraidedHopfObject.toGradedBicharacterDatum.instAlgebra
+    Br.Carrier →ₐ[k] H
+  K : H
+  d : Fin t → H
+  d_eq : ∀ i, d i = includeBraided (Br.d i)
+  K_pow : K ^ F.ambientOrder = 1
+  d_pow : ∀ i, d i ^ F.p i = 0
+  d_comm : ∀ i j, d i * d j = d j * d i
+  K_mul_d : ∀ i, K * d i = algebraMap k H (R.xiAt i) * d i * K
+  comul_K : Coalgebra.comul (R := k) K = K ⊗ₜ[k] K
+  comul_d : ∀ i,
+    Coalgebra.comul (R := k) (d i) =
+      d i ⊗ₜ[k] 1 + (K ^ F.nDivPrime i) ⊗ₜ[k] d i
+  counit_K : Coalgebra.counit (R := k) K = 1
+  counit_d : ∀ i, Coalgebra.counit (R := k) (d i) = 0
+  Kinv : H
+  Kinv_mul_K : Kinv * K = 1
+  K_mul_Kinv : K * Kinv = 1
+  antipode_K : HopfAlgebra.antipode k K = Kinv
+  antipode_d : ∀ i,
+    HopfAlgebra.antipode k (d i) = -((Kinv ^ F.nDivPrime i) * d i)
+  generated : Algebra.adjoin k ({K} ∪ Set.range d) = ⊤
+  monomialBasis :
+    Module.Basis (Fin F.ambientOrder × (∀ i, Fin (F.p i))) k H
+  monomialBasis_apply : ∀ a,
+    monomialBasis a = K ^ (a.1 : ℕ) *
+      (List.ofFn fun i => d i ^ (a.2 i : ℕ)).prod
+
+/-- Each Laugwitz--Qi differential is a `K^(n/pᵢ)`-skew derivation on a module algebra. -/
+structure CyclotomicModuleAlgebraEquations (k H A : Type*) [Field k] [Ring H]
+    [HopfAlgebra k H] [Ring A] [Algebra k A]
+    (X : LeftModuleAlgebra k H A) {n t : ℕ} (F : CyclotomicFactorization n t)
+    (R : CyclotomicRootData k F) (Br : CyclotomicBraidedDatum k F R)
+    (LQ : CyclotomicBosonizationDatum k H F R Br) : Prop where
+  K_multiplicative : ∀ a b, X.act LQ.K (a * b) = X.act LQ.K a * X.act LQ.K b
+  d_skewLeibniz : ∀ i a b,
+    X.act (LQ.d i) (a * b) =
+      X.act (LQ.d i) a * b +
+        X.act (LQ.K ^ F.nDivPrime i) a * X.act (LQ.d i) b
+
+end ExampleData
+
+/-! ## Relative hopfological homotopy and derived targets -/
+
+section RelativeTheory
+
+variable (k : Type u) (H : Type v) (A : Type w)
+variable [Field k] [Ring H] [HopfAlgebra k H] [FiniteDimensional k H]
+variable [Ring A] [Algebra k A]
+variable (X : LeftModuleAlgebra k H A)
+
+/-- An object of `C(A,H)` is genuinely a module over the chosen smash algebra `B=A#H`.
+The `A`- and `k`-module structures are recorded with their scalar towers, and the final
+equation pins the `A`-action to restriction along `A → B`. -/
+structure SmashModule (S : X.SmashProduct) where
+  Carrier : Type x
+  [instAddCommGroup : AddCommGroup Carrier]
+  [instModuleK : Module k Carrier]
+  [instModuleA : Module A Carrier]
+  [instModuleB : Module S.Carrier Carrier]
+  [instScalarTowerKA : IsScalarTower k A Carrier]
+  [instScalarTowerKB : IsScalarTower k S.Carrier Carrier]
+  restrict_smul : ∀ (a : A) (m : Carrier), a • m = S.includeA a • m
+
+attribute [instance] SmashModule.instAddCommGroup SmashModule.instModuleK
+  SmashModule.instModuleA SmashModule.instModuleB SmashModule.instScalarTowerKA
+  SmashModule.instScalarTowerKB
+
+/-- Restriction along `H → A#H` constructs the actual `H`-action on a smash module. -/
+noncomputable def SmashModule.hAction (S : X.SmashProduct)
+    (M : SmashModule k H A X S) :
+    LeftAction k H M.Carrier := by
+  sorry
+
+/-- On the genuine `Hom_A(M,N)`, Qi's convention uses the inverse antipode:
+`(h · f)(m) = Σ h₂ · f(S⁻¹(h₁) · m)`.  The invariant maps are exactly the maps linear over
+`B=A#H`; this prevents the relative layer from being populated without `C(A,H)` data. -/
+structure HomActionFormula (S : X.SmashProduct)
+    (M : SmashModule k H A X S) (N : SmashModule k H A X S) where
+  invAntipode : H →ₗ[k] H
+  invAntipode_left : invAntipode.comp (HopfAlgebra.antipode k) = LinearMap.id
+  invAntipode_right : (HopfAlgebra.antipode k).comp invAntipode = LinearMap.id
+  homAction : LeftAction k H (M.Carrier →ₗ[A] N.Carrier)
+  homAct_apply : ∀ h f m,
+    homAction.act h f m = ∑ i ∈ (ℛ k h).index,
+      S.includeH ((ℛ k h).right i) •
+        f (S.includeH (invAntipode ((ℛ k h).left i)) • m)
+  invariant_iff_bLinear : ∀ f : M.Carrier →ₗ[A] N.Carrier,
+    (∀ h m, homAction.act h f m =
+      Coalgebra.counit (R := k) h • f m) ↔
+    ∃ fB : M.Carrier →ₗ[S.Carrier] N.Carrier, ∀ m, fB m = f m
+
+/-- The integral formula for the hopfological null ideal: a `B = A # H`-linear map is
+null-homotopic exactly when it is `Λ · g` for an `A`-linear `g`. -/
+def IsIntegralNull {S : X.SmashProduct} {M N : SmashModule k H A X S}
+    (F : HomActionFormula k H A X S M N) (Λ : LeftIntegral k H)
+    (f : M.Carrier →ₗ[S.Carrier] N.Carrier) : Prop :=
+  ∃ g : M.Carrier →ₗ[A] N.Carrier,
+    ∀ m, f m = F.homAction.act (Λ : H) g m
+
+/-- An `A`-split short exact sequence. These are the conflations in the relative Frobenius
+exact structure underlying `C(A,H)`; ordinary stable categories instead use all short exact
+sequences in the abelian `A # H`-module category. -/
+structure ASplitConflation (S : X.SmashProduct)
+    (M E N : SmashModule k H A X S) where
+  inclusion : M.Carrier →ₗ[S.Carrier] E.Carrier
+  projection : E.Carrier →ₗ[S.Carrier] N.Carrier
+  exact : Function.Exact inclusion projection
+  inclusion_injective : Function.Injective inclusion
+  projection_surjective : Function.Surjective projection
+  /-- Only the chosen splitting is `A`-linear; the conflation maps above are `B`-linear. -/
+  retraction : E.Carrier →ₗ[A] M.Carrier
+  section_ : N.Carrier →ₗ[A] E.Carrier
+  retraction_inclusion : ∀ m, retraction (inclusion m) = m
+  projection_section : ∀ n, projection (section_ n) = n
+
+/-- A chosen cellular witness for property (P).  The filtration consists of `B`-submodules,
+so it is equivariant; its inclusions split only after restriction to `A`.  Each layer map is
+actually `B`-linear and its target has the pinned diagonal smash action on `A ⊗ V`. -/
+structure PropertyPData (S : X.SmashProduct) (P : SmashModule k H A X S) where
+  /-- We index the filtration with a zero initial stage; `Fil (r + 1)` corresponds to Qi's
+  `F_r`. -/
+  Fil : ℕ → Submodule S.Carrier P.Carrier
+  zero_stage : Fil 0 = ⊥
+  monotone : Monotone Fil
+  exhaustive : ⨆ r, Fil r = ⊤
+  /-- Every filtration inclusion splits by a `k`-linear map satisfying literal `A`-linearity
+  through `S.includeA`. -/
+  split : ∀ r, Fil (r + 1) →ₗ[k] Fil r
+  split_A_linear : ∀ r a z,
+    split r (S.includeA a • z) = S.includeA a • split r z
+  split_inclusion : ∀ r (z : Fil r),
+    split r ⟨z.1, monotone (Nat.le_succ r) z.2⟩ = z
+  /-- Using Qi's equivalent version of (P3), one arbitrary `H`-module records all cells in a
+  layer (and may itself be a direct sum of indecomposables). -/
+  Cell : ℕ → Type y
+  cellAddCommGroup : ∀ r, AddCommGroup (Cell r)
+  cellModule : ∀ r, letI := cellAddCommGroup r; Module k (Cell r)
+  cellAction : ∀ r,
+    letI := cellAddCommGroup r
+    letI := cellModule r
+    LeftAction k H (Cell r)
+  /-- A genuine `B`-module model for the layer. -/
+  cellSmashModule : ℕ → SmashModule.{u, v, w, x} k H A X S
+  /-- The underlying `k`-module of the model is `A ⊗ Cell r`. -/
+  cellEquiv : ∀ r,
+    letI := cellAddCommGroup r
+    letI := cellModule r
+    (cellSmashModule r).Carrier ≃ₗ[k] A ⊗[k] Cell r
+  /-- The equivalence exposes the smash action
+  `(a#h)(b⊗v)=Σ a(h₁·b)⊗h₂·v`; this is the equivariant content of (P3). -/
+  cell_action_pure : ∀ r,
+    letI := cellAddCommGroup r
+    letI := cellModule r
+    ∀ a h b v,
+      cellEquiv r
+          (S.pure a h • (cellEquiv r).symm (b ⊗ₜ[k] v)) =
+        ∑ i ∈ (ℛ k h).index,
+          (a * X.act ((ℛ k h).left i) b) ⊗ₜ[k]
+            (cellAction r).act ((ℛ k h).right i) v
+  /-- Exactness and surjectivity identify the quotient layer with that cell module using an
+  actual `B`-linear map. -/
+  layerProjection : ∀ r,
+    Fil (r + 1) →ₗ[S.Carrier] (cellSmashModule r).Carrier
+  layer_exact : ∀ r,
+    Function.Exact (Submodule.inclusion (monotone (Nat.le_succ r))) (layerProjection r)
+  layer_surjective : ∀ r,
+    Function.Surjective (layerProjection r)
+
+/-- Compactness uses Mathlib's actual categorical coproducts.  The preadditive representable
+`Hom(P,-) : C ⥤ AddCommGrpCat` must preserve every discrete colimit of the selected small
+universe; this packages the canonical comparison induced by the coproduct injections, rather
+than an arbitrary object-valued function and arbitrary bijection. -/
+def IsCompactObject (C : Type u) [Category.{v} C] [Preadditive C]
+    [HasCoproducts.{w} C] (P : C) : Prop :=
+  ∀ Index : Type w,
+    PreservesColimitsOfShape (Discrete Index)
+      (preadditiveCoyoneda.obj (Opposite.op P))
+
+/-! ### Laugwitz--Qi's filtered ideal (Definition 4.5 and Proposition 4.16) -/
+
+/-- The literal balanced induced module `H_n ⊗_{H_{n_k}} k`, characterized by its full
+bilinear balanced universal property and carrying the grading induced from `H_n`. -/
+structure LQInducedCell (Hn : Type x) [Ring Hn] [Algebra k Hn]
+    (HnGrading : InternalGrading ℤ k Hn)
+    (Hnk : Type y) [Ring Hnk] [Algebra k Hnk]
+    (incl : Hnk →ₐ[k] Hn) (augmentation : Hnk →ₐ[k] k) where
+  Carrier : Type x
+  [instAddCommGroup : AddCommGroup Carrier]
+  [instModuleK : Module k Carrier]
+  [instModuleHn : Module Hn Carrier]
+  [instScalarTower : IsScalarTower k Hn Carrier]
+  pure : Hn → k → Carrier
+  balanced : ∀ (h : Hn) (r : Hnk) (c : k),
+    pure (h * incl r) c = pure h (augmentation r * c)
+  pure_add_left : ∀ h₁ h₂ c, pure (h₁ + h₂) c = pure h₁ c + pure h₂ c
+  pure_add_right : ∀ h c₁ c₂, pure h (c₁ + c₂) = pure h c₁ + pure h c₂
+  pure_zero_left : ∀ c, pure 0 c = 0
+  pure_zero_right : ∀ h, pure h 0 = 0
+  pure_smul_right : ∀ h r c, pure h (r * c) = r • pure h c
+  pure_smul : ∀ h c, pure h c = h • pure 1 c
+  grading : GradedModuleDatum ℤ k Hn Carrier HnGrading
+  pure_mem_degree : ∀ {g} {h : Hn}, h ∈ HnGrading.Piece g → ∀ c,
+    pure h c ∈ grading.Piece g
+  /-- Universal property of the balanced tensor `H_n ⊗_{H_{n_k}} k`. -/
+  lift_unique : ∀ {Q : Type x} [AddCommGroup Q] [Module k Q]
+      [Module Hn Q] [IsScalarTower k Hn Q]
+      (f : Hn → k → Q)
+      (hbal : ∀ h r c, f (h * incl r) c = f h (augmentation r * c))
+      (haddl : ∀ h₁ h₂ c, f (h₁ + h₂) c = f h₁ c + f h₂ c)
+      (haddr : ∀ h c₁ c₂, f h (c₁ + c₂) = f h c₁ + f h c₂)
+      (hscale : ∀ h r c, f h (r * c) = r • f h c)
+      (hsmul : ∀ h c, f h c = h • f 1 c),
+    let _laws := And.intro hbal
+      (And.intro haddl (And.intro haddr (And.intro hscale hsmul)))
+    ∃! g : Carrier →ₗ[Hn] Q, ∀ h c, g (pure h c) = f h c
+
+attribute [instance] LQInducedCell.instAddCommGroup LQInducedCell.instModuleK
+  LQInducedCell.instModuleHn LQInducedCell.instScalarTower
+
+/-- The concrete generator subalgebras `H_{n_k}=k[d_k]/(d_k^{p_k})` inside the fixed
+cyclotomic braided algebra, together with their literal induced cells.  There is no independent
+choice of `H_n`, inclusion, or `W_k`. -/
+structure LQCellFamily {n t : ℕ} (F : CyclotomicFactorization n t)
+    (R : CyclotomicRootData k F) (Br : CyclotomicBraidedDatum k F R) where
+  Hnk : Fin t → Type y
+  [hnkRing : ∀ i, Ring (Hnk i)]
+  [hnkAlgebra : ∀ i, Algebra k (Hnk i)]
+  generator : ∀ i, Hnk i
+  generator_degree : Fin t → ℤ
+  generator_degree_eq : ∀ i, generator_degree i = F.nDivPrime i
+  generator_pow : ∀ i, generator i ^ F.p i = 0
+  monomialBasis : ∀ i, Module.Basis (Fin (F.p i)) k (Hnk i)
+  monomialBasis_apply : ∀ i j,
+    monomialBasis i j = generator i ^ (j : ℕ)
+  incl : ∀ i, Hnk i →ₐ[k] Br.Carrier
+  incl_injective : ∀ i, Function.Injective (incl i)
+  incl_generator : ∀ i, incl i (generator i) = Br.d i
+  incl_generator_degree : ∀ i,
+    incl i (generator i) ∈ Br.Piece (generator_degree i)
+  incl_range : ∀ i,
+    (incl i).range = Algebra.adjoin k ({Br.d i} : Set Br.Carrier)
+  augmentation : ∀ i, Hnk i →ₐ[k] k
+  augmentation_generator : ∀ i, augmentation i (generator i) = 0
+  induced : ∀ i,
+    LQInducedCell k Br.Carrier Br.internalGrading
+      (Hnk i) (incl i) (augmentation i)
+
+attribute [instance] LQCellFamily.hnkRing LQCellFamily.hnkAlgebra
+
+/-- A finite filtration whose layers are grading shifts of the fixed induced module `W_k`.
+Every filtration stage is a genuinely graded `H_n`-submodule, and every layer projection is
+a degree-zero `H_n`-linear map to the actual shift `W_k{r}`. -/
+structure LQFilteredByCell {n t : ℕ} {F : CyclotomicFactorization n t}
+    {R : CyclotomicRootData k F} {Br : CyclotomicBraidedDatum k F R}
+    (Cells : LQCellFamily k F R Br) (cell : Fin t)
+    (V : Type x) [AddCommGroup V] [Module k V] [Module Br.Carrier V]
+    [IsScalarTower k Br.Carrier V]
+    (VGrading : GradedModuleDatum ℤ k Br.Carrier V Br.internalGrading) where
+  length : ℕ
+  Fil : Fin (length + 1) → Submodule Br.Carrier V
+  FilGrading : ∀ r,
+    GradedModuleDatum ℤ k Br.Carrier (Fil r) Br.internalGrading
+  filtration_piece : ∀ r g (z : Fil r),
+    z ∈ (FilGrading r).Piece g ↔ (z : V) ∈ VGrading.Piece g
+  zero_stage : Fil ⟨0, Nat.zero_lt_succ _⟩ = ⊥
+  top_stage : Fil ⟨length, Nat.lt_succ_self _⟩ = ⊤
+  monotone : ∀ i : Fin length,
+    Fil i.castSucc ≤ Fil i.succ
+  shift : Fin length → ℤ
+  layerProjection : ∀ i : Fin length,
+    GradedLinearMap (FilGrading i.succ)
+      ((Cells.induced cell).grading.shift (shift i))
+  layer_exact : ∀ i : Fin length,
+    Function.Exact
+      (Submodule.inclusion (monotone i)) (layerProjection i).toLinearMap
+  layer_surjective : ∀ i : Fin length,
+    Function.Surjective (layerProjection i).toLinearMap
+
+/-- `I_k` recognition data: for `t>1`, a retract of a finite `W_k`-filtered module; for
+`t=1`, the separate constructor is a projective-injective module. -/
+inductive LQIdealPiece {n t : ℕ} {F : CyclotomicFactorization n t}
+    {R : CyclotomicRootData k F} {Br : CyclotomicBraidedDatum k F R}
+    (Cells : LQCellFamily k F R Br) (cell : Fin t)
+    (U : Type x) [AddCommGroup U] [Module k U] [Module Br.Carrier U]
+    [IsScalarTower k Br.Carrier U]
+    (UGrading : GradedModuleDatum ℤ k Br.Carrier U Br.internalGrading)
+  | multiplePrimes (ht : 1 < t)
+      (V : Type x) [AddCommGroup V] [Module k V] [Module Br.Carrier V]
+      [IsScalarTower k Br.Carrier V]
+      (VGrading : GradedModuleDatum ℤ k Br.Carrier V Br.internalGrading)
+      (filtered : LQFilteredByCell k Cells cell V VGrading)
+      (section_ : GradedLinearMap UGrading VGrading)
+      (retraction : GradedLinearMap VGrading UGrading)
+      (retract : retraction.toLinearMap.comp section_.toLinearMap = LinearMap.id)
+  | primePower (ht : t = 1)
+      (projective : Module.Projective Br.Carrier U)
+      (injective : Module.Injective Br.Carrier U)
+
+/-- A chosen representative of an object of `I` is the literal finite direct sum of one graded
+summand from every `I_k`; it is not an arbitrary carrier with an ungraded equivalence, nor a
+mere union of the pieces. -/
+structure LQIdealObject {n t : ℕ} {F : CyclotomicFactorization n t}
+    {R : CyclotomicRootData k F} {Br : CyclotomicBraidedDatum k F R}
+    (Cells : LQCellFamily k F R Br) where
+  Piece : Fin t → Type x
+  [pieceAddCommGroup : ∀ i, AddCommGroup (Piece i)]
+  [pieceModuleK : ∀ i, Module k (Piece i)]
+  [pieceModuleHn : ∀ i, Module Br.Carrier (Piece i)]
+  [pieceScalarTower : ∀ i, IsScalarTower k Br.Carrier (Piece i)]
+  pieceGrading : ∀ i,
+    GradedModuleDatum ℤ k Br.Carrier (Piece i) Br.internalGrading
+  piece_mem : ∀ i, LQIdealPiece k Cells i (Piece i) (pieceGrading i)
+
+attribute [instance] LQIdealObject.pieceAddCommGroup LQIdealObject.pieceModuleK
+  LQIdealObject.pieceModuleHn LQIdealObject.pieceScalarTower
+
+/-- The underlying module of the chosen `I`-object representative. -/
+abbrev LQIdealObject.Carrier {n t : ℕ} {F : CyclotomicFactorization n t}
+    {R : CyclotomicRootData k F} {Br : CyclotomicBraidedDatum k F R}
+    {Cells : LQCellFamily k F R Br} (I : LQIdealObject k Cells) :=
+  DirectSum (Fin t) I.Piece
+
+/-- A degree-zero map factors through a graded projective `H_n`-module. -/
+def LQFactorsThroughProjective {n t : ℕ} {F : CyclotomicFactorization n t}
+    {R : CyclotomicRootData k F} {Br : CyclotomicBraidedDatum k F R}
+    {U V : Type x} [AddCommGroup U] [Module k U] [Module Br.Carrier U]
+    [IsScalarTower k Br.Carrier U]
+    [AddCommGroup V] [Module k V] [Module Br.Carrier V]
+    [IsScalarTower k Br.Carrier V]
+    (UGrading : GradedModuleDatum ℤ k Br.Carrier U Br.internalGrading)
+    (VGrading : GradedModuleDatum ℤ k Br.Carrier V Br.internalGrading)
+    (f : GradedLinearMap UGrading VGrading) : Prop :=
+  ∃ (P : Type x) (_ : AddCommGroup P) (_ : Module k P)
+      (_ : Module Br.Carrier P) (_ : IsScalarTower k Br.Carrier P)
+      (PGrading : GradedModuleDatum ℤ k Br.Carrier P Br.internalGrading),
+    Module.Projective Br.Carrier P ∧
+      ∃ g : GradedLinearMap UGrading PGrading,
+        ∃ h : GradedLinearMap PGrading VGrading,
+          f.toLinearMap = h.toLinearMap.comp g.toLinearMap
+
+/-- The concrete cross-freeness input: for distinct prime generators, maps between shifts of
+the literal induced cells factor through projectives.  Its proof uses the standard multi-monomial
+basis of `Br`, the concrete subalgebra ranges, and distinctness of the primes in `F`. -/
+theorem lq_induced_cross_freeness {n t : ℕ} (F : CyclotomicFactorization n t)
+    (R : CyclotomicRootData k F) (Br : CyclotomicBraidedDatum k F R)
+    (Cells : LQCellFamily k F R Br) {i j : Fin t} (hij : i ≠ j) (r s : ℤ)
+    (f : GradedLinearMap ((Cells.induced i).grading.shift r)
+      ((Cells.induced j).grading.shift s)) :
+    LQFactorsThroughProjective k _ _ f := by
+  sorry
+
+/-- Laugwitz--Qi Proposition 4.16: maps between distinct filtered pieces are already null in
+the ordinary stable category.  Unlike an arbitrary-algebra statement, this theorem is indexed
+by the fixed cyclotomic presentation and is proved by devissage from
+`lq_induced_cross_freeness`. -/
+theorem lq_cross_piece_factors_through_projective
+    {n t : ℕ} (F : CyclotomicFactorization n t)
+    (R : CyclotomicRootData k F) (Br : CyclotomicBraidedDatum k F R)
+    (Cells : LQCellFamily k F R Br)
+    {U V : Type x} [AddCommGroup U] [Module k U] [Module Br.Carrier U]
+    [IsScalarTower k Br.Carrier U]
+    [AddCommGroup V] [Module k V] [Module Br.Carrier V]
+    [IsScalarTower k Br.Carrier V]
+    (UGrading : GradedModuleDatum ℤ k Br.Carrier U Br.internalGrading)
+    (VGrading : GradedModuleDatum ℤ k Br.Carrier V Br.internalGrading)
+    {i j : Fin t} (hij : i ≠ j)
+    (hU : LQIdealPiece k Cells i U UGrading)
+    (hV : LQIdealPiece k Cells j V VGrading)
+    (f : GradedLinearMap UGrading VGrading) :
+    LQFactorsThroughProjective k UGrading VGrading f := by
+  have crossFreeness :=
+    lq_induced_cross_freeness k F R Br Cells (i := i) (j := j) hij
+  sorry
+
+end RelativeTheory
+
+/-! ## Decategorified relation targets -/
+
+section GrothendieckTargets
+
+/-- For the characteristic-`p` primitive truncated Hopf algebra, with `p` prime and the
+differential placed in grading degree one, the free-module relation is `[p]_q`. -/
+noncomputable def primeStableRelation (p : ℕ) : Polynomial ℤ :=
+  ∑ i ∈ Finset.range p, Polynomial.X ^ i
+
+/-- Khovanov's Taft stable category has the geometric-sum relation for every `n`; for
+composite `n` this quotient is generally not the cyclotomic integer ring. -/
+noncomputable def taftStableRelation (n : ℕ) : Polynomial ℤ :=
+  ∑ i ∈ Finset.range n, Polynomial.X ^ i
+
+/-- Laugwitz--Qi's *Verdier quotient* imposes the exact cyclotomic relation. -/
+noncomputable def cyclotomicVerdierRelation (n : ℕ) : Polynomial ℤ :=
+  Polynomial.cyclotomic n ℤ
+
+theorem prime_relation_eq_cyclotomic (p : ℕ) (hp : p.Prime) :
+    primeStableRelation p = Polynomial.cyclotomic p ℤ := by
+  sorry
+
+end GrothendieckTargets
+
+end TauCetiRoadmap.HopfologicalAlgebra


### PR DESCRIPTION
## Summary

Adds a literature roadmap for finite Hopf algebras as Frobenius algebras, tensor-triangulated stable module categories, module/comodule algebras and smash products, the relative hopfological categories `C(A,H)` and `D(A,H)`, property-(P)/cofibrant/compact objects, Grothendieck theory, and the standard super, characteristic-`p`, Taft/Nichols, and characteristic-zero cyclotomic examples.

The bounded `Suggested.lean` exercises an action-dependent smash algebra, genuine `A#H`-linear relative data, integrals and handed Nakayama formulas, the characteristic-zero primitive-square obstruction, nondegenerate Sweedler/Taft recognition data, full Laugwitz–Qi factorization arithmetic, and the relevant stable/cyclotomic relations.

## Dependencies

This roadmap consumes #201, #212, and the forthcoming StablePeriodicCurved roadmap PR. Per the owner’s batching decision, it is opened from `main` before those roadmaps merge; review-driven interface changes will be rippled forward. Its Lean prototype remains standalone against the current Mathlib/Tau Ceti baseline, while the prose names the dependent published specifications.

## Sources and scope

Primary anchors include Larson–Sweedler and Montgomery; Khovanov; Qi; Qi–Sussan and Khovanov–Qi; Radford–Majid; Pareigis; and Laugwitz–Qi. The roadmap distinguishes large `H-StMod` from finite-dimensional `H-stmod`, ordinary stable quotients from the `A`-relative null ideal and later Verdier quotient, and ordinary, super, braided, and bosonized Hopf structures.

It deliberately does not select a Hopf algebra or action for an ADE/E8 construction, quotient an affine null root, assert E8 homological finiteness, or categorify a lattice.

## Verification

- `lake exe cache get`
- `lake env lean TauCetiRoadmap/HopfologicalAlgebra/Suggested.lean`
- `lake build` — succeeds (8746 jobs)
- `git diff --check`

The `sorry` declarations are intentional roadmap targets.

## Review provenance

The complete draft was written by `gpt-5.6-sol` and independently red-teamed by a fresh `gpt-5.6-sol` reviewer. A separate Sol correction pass replaced the carrier-only smash and weak relative signatures, encoded the full Laugwitz–Qi arithmetic and ideals, strengthened example presentations/bases, and corrected stable-size, slash-homology, Nakayama, compactness, and braided-grading interfaces. A further fresh Sol verification found three remaining overly general interfaces. A final bounded Sol correction tied the Laugwitz–Qi cross-piece theorem to its concrete induced cells and grading shifts, replaced stored grading/compactness results with genuine categorical structures, and added the inverse Nakayama-convention bridge. The corrected direct and full builds pass.

This is not a claim that a human subject expert has reviewed the mathematics. Review is especially wanted from a Hopf algebraist, a hopfological-categorification specialist, and Lean contributors familiar with monoidal module/comodule and stable/localization infrastructure.

Authored with Codex.
