### PR TITLE
docs(SpinRepresentations): split the Layer 7 dependencies

### DIFF
--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
@@ -320,8 +320,7 @@ module simple.
 - **The seed of periodicity.** Consume `CliffordAlgebra.equivEven`
   (`Cliff(Q) ≅ even(Q ⊕ ⟨-1⟩)`) and `CliffordAlgebra.prodEquiv` (the graded tensor product over a
   direct sum of forms); these are the algebraic inputs the complex structure theorem and the real Bott
-  periodicity of Layer 7 both rest on. The algebraic Bott recurrence consumes these inputs directly; it does
-  not consume the matrix-algebra conclusions of this layer.
+  periodicity of Layer 7 both rest on.
 
 ### Layer 2: the Pin and Spin groups and the double covers
 
@@ -506,8 +505,7 @@ representation landing in that group; it needs three explicit milestones per cas
   II.2.1 and II.2.5, supplies the split-matrix and orthogonal-sum mechanisms; II.2.9 fixes the real
   signature convention. Lawson–Michelsohn, *Spin Geometry*, Chapter I, §4, Theorem 4.1 and equation (4.3),
   constructs `Cliff(r+1,s+1) ≅ Cliff(r,s) ⊗ᵣ Cliff(1,1)` directly from the Clifford universal property,
-  and Theorem 4.3 derives the periodic classification. Thus this branch does not depend on Layer 1's
-  spin-module proof or Layer 2's double cover.
+  and Theorem 4.3 derives the periodic classification.
 - **The real spin groups.** `spinPQ p q := spinGroup (realCliffordForm p q)`, the double cover of
   `SO(p, q)` from Layer 2 applied to the real form; the compact `Spin(n) = spinPQ n 0` and the split and
   Lorentzian forms `Spin(p, q)`. The real double cover of `SO(p, q)` carries the component qualifications of
@@ -669,9 +667,8 @@ fundamental representation of `Bₗ`/`Dₗ`" precise, and completes
 [the classical-groups roadmap](../ClassicalGroups/README.md). Layer 6 (the exceptional isomorphisms) needs
 Layers 4-5 for the low-rank spin modules. Layer 7 has two dependency branches: its algebraic real forms,
 Bott recurrence, and classification table use Layer 0's Clifford-algebra interfaces and the stated real base
-entries, while its real Pin and Spin group theorems use Layer 2's double cover specialized to `ℝ`. The
-algebraic classification is the real analogue of Layer 1's complex structure theorem, not its consumer.
-Layer 8 (triality) needs Layer 5's half-spin identification and
+entries, while its real Pin and Spin group theorems use Layer 2's double cover specialized to `ℝ`. Layer 8
+(triality) needs Layer 5's half-spin identification and
 [the root-systems roadmap](../RootSystems/README.md)'s `D₄` diagram automorphism, and its group-level stage a
 further integration theorem; it is the summit. A contributor can complete Layers 0-3 (the structure theory
 and the double cover) and the `Spin₃` and real-form examples well before the highest-weight identification of

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
@@ -503,11 +503,11 @@ representation landing in that group; it needs three explicit milestones per cas
   square to `+1` index by `(p - q) mod 8` instead; the base-entry tests pin which is meant). This is the real
   refinement of Layer 1's complex structure theorem, where all forms of a rank are equivalent. This is an
   algebraic branch from Layer 0 and the base entries above. Chevalley, *The Algebraic Theory of Spinors*,
-  II.2.1, II.2.5, and II.2.9, supplies the split-matrix, orthogonal-sum, and signature-reduction mechanisms.
-  Lawson–Michelsohn, *Spin Geometry*, Chapter I, §4, Theorem 4.1(4.3), constructs
-  `Cliff(r+1,s+1) ≅ Cliff(r,s) ⊗ᵣ Cliff(1,1)` directly from the Clifford universal property, and
-  Theorem 4.3 derives the periodic classification. Thus this branch does not depend on Layer 1's spin-module
-  proof or Layer 2's double cover.
+  II.2.1 and II.2.5, supplies the split-matrix and orthogonal-sum mechanisms; II.2.9 fixes the real
+  signature convention. Lawson–Michelsohn, *Spin Geometry*, Chapter I, §4, Theorem 4.1 and equation (4.3),
+  constructs `Cliff(r+1,s+1) ≅ Cliff(r,s) ⊗ᵣ Cliff(1,1)` directly from the Clifford universal property,
+  and Theorem 4.3 derives the periodic classification. Thus this branch does not depend on Layer 1's
+  spin-module proof or Layer 2's double cover.
 - **The real spin groups.** `spinPQ p q := spinGroup (realCliffordForm p q)`, the double cover of
   `SO(p, q)` from Layer 2 applied to the real form; the compact `Spin(n) = spinPQ n 0` and the split and
   Lorentzian forms `Spin(p, q)`. The real double cover of `SO(p, q)` carries the component qualifications of

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
@@ -502,11 +502,11 @@ representation landing in that group; it needs three explicit milestones per cas
   `(q - p) mod 8` **in the convention fixed by the four base entries above** (references that make generators
   square to `+1` index by `(p - q) mod 8` instead; the base-entry tests pin which is meant). This is the real
   refinement of Layer 1's complex structure theorem, where all forms of a rank are equivalent. This is an
-  algebraic branch from Layer 0 and the base entries above: Lawson–Michelsohn, *Spin Geometry*, Chapter I,
-  §4, Theorem 4.1(4.3), constructs `Cliff(r+1,s+1) ≅ Cliff(r,s) ⊗ᵣ Cliff(1,1)` directly from the
-  Clifford universal property, and Theorem 4.3 derives the periodic classification. Atiyah–Bott–Shapiro,
-  *Clifford Modules*, Part I, §4, Proposition 4.2 and Table 1, likewise derives the algebraic recurrence
-  and table before §5 introduces Clifford modules. Thus this branch does not depend on Layer 1's spin-module
+  algebraic branch from Layer 0 and the base entries above. Chevalley, *The Algebraic Theory of Spinors*,
+  II.2.1, II.2.5, and II.2.9, supplies the split-matrix, orthogonal-sum, and signature-reduction mechanisms.
+  Lawson–Michelsohn, *Spin Geometry*, Chapter I, §4, Theorem 4.1(4.3), constructs
+  `Cliff(r+1,s+1) ≅ Cliff(r,s) ⊗ᵣ Cliff(1,1)` directly from the Clifford universal property, and
+  Theorem 4.3 derives the periodic classification. Thus this branch does not depend on Layer 1's spin-module
   proof or Layer 2's double cover.
 - **The real spin groups.** `spinPQ p q := spinGroup (realCliffordForm p q)`, the double cover of
   `SO(p, q)` from Layer 2 applied to the real form; the compact `Spin(n) = spinPQ n 0` and the split and
@@ -701,8 +701,6 @@ the CAR instance is a self-contained claimable unit needing only the abstract re
 - H. B. Lawson, M.-L. Michelsohn, *Spin Geometry*, Princeton (1989), Chapter I - the definitive account of
   Clifford algebras `Cliff(p, q)`, their Bott-periodic classification (the eightfold table), the Pin and Spin
   groups as double covers, and the real and complex spinor representations.
-- M. F. Atiyah, R. Bott, A. Shapiro, *Clifford Modules*, Topology 3, Supplement 1 (1964), 3–38 - the
-  algebraic Clifford recurrence and periodic table precede its treatment of Clifford modules.
 - C. Chevalley, *The Algebraic Theory of Spinors*, Columbia (1954) - the algebraic construction of the spin
   representation from a maximal isotropic subspace, the even/odd decomposition into half-spinors, and the
   intrinsic (basis-free) development of the Clifford algebra used in Layer 4.

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
@@ -660,9 +660,10 @@ identification) needs Layers 3-4 and the highest-weight theory of
 [the root-systems roadmap](../RootSystems/README.md); it is stated at the Lie-algebra level, makes "the
 fundamental representation of `Bₗ`/`Dₗ`" precise, and completes
 [the classical-groups roadmap](../ClassicalGroups/README.md). Layer 6 (the exceptional isomorphisms) needs
-Layers 4-5 for the low-rank spin modules. Layer 7’s real Clifford algebra classification uses the 
+Layers 4-5 for the low-rank spin modules. Layer 7's real Clifford algebra classification uses the
 Clifford-algebra constructions from Layer 0 and the real base entries above. The real Pin and Spin group results
-use the double cover from Layer 2. Layer 8 (triality) needs Layer 5's half-spin identification and
+use the double cover from Layer 2; both branches are independent of Layers 4-6. Layer 8 (triality) needs
+Layer 5's half-spin identification and
 [the root-systems roadmap](../RootSystems/README.md)'s `D₄` diagram automorphism, and its group-level stage a
 further integration theorem; it is the summit. A contributor can complete Layers 0-3 (the structure theory
 and the double cover) and the `Spin₃` and real-form examples well before the highest-weight identification of

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
@@ -660,8 +660,9 @@ identification) needs Layers 3-4 and the highest-weight theory of
 [the root-systems roadmap](../RootSystems/README.md); it is stated at the Lie-algebra level, makes "the
 fundamental representation of `Bₗ`/`Dₗ`" precise, and completes
 [the classical-groups roadmap](../ClassicalGroups/README.md). Layer 6 (the exceptional isomorphisms) needs
-Layers 4-5 for the low-rank spin modules. Layer 7’s real Clifford algebra classification uses the Clifford-algebra constructions from Layer 0 and the real base entries above. The real Pin and Spin group results use the double cover from Layer 2. Layer 8
-(triality) needs Layer 5's half-spin identification and
+Layers 4-5 for the low-rank spin modules. Layer 7’s real Clifford algebra classification uses the 
+Clifford-algebra constructions from Layer 0 and the real base entries above. The real Pin and Spin group results
+use the double cover from Layer 2. Layer 8 (triality) needs Layer 5's half-spin identification and
 [the root-systems roadmap](../RootSystems/README.md)'s `D₄` diagram automorphism, and its group-level stage a
 further integration theorem; it is the summit. A contributor can complete Layers 0-3 (the structure theory
 and the double cover) and the `Spin₃` and real-form examples well before the highest-weight identification of

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
@@ -320,7 +320,8 @@ module simple.
 - **The seed of periodicity.** Consume `CliffordAlgebra.equivEven`
   (`Cliff(Q) ≅ even(Q ⊕ ⟨-1⟩)`) and `CliffordAlgebra.prodEquiv` (the graded tensor product over a
   direct sum of forms); these are the algebraic inputs the complex structure theorem and the real Bott
-  periodicity of Layer 7 both rest on.
+  periodicity of Layer 7 both rest on. The algebraic Bott recurrence consumes these inputs directly; it does
+  not consume the matrix-algebra conclusions of this layer.
 
 ### Layer 2: the Pin and Spin groups and the double covers
 
@@ -500,7 +501,13 @@ representation landing in that group; it needs three explicit milestones per cas
   `Cliff(p, q)` as a matrix algebra over `ℝ`, `ℂ`, or `ℍ` (the eightfold way), stated as a function of
   `(q - p) mod 8` **in the convention fixed by the four base entries above** (references that make generators
   square to `+1` index by `(p - q) mod 8` instead; the base-entry tests pin which is meant). This is the real
-  refinement of Layer 1's complex structure theorem, where all forms of a rank are equivalent.
+  refinement of Layer 1's complex structure theorem, where all forms of a rank are equivalent. This is an
+  algebraic branch from Layer 0 and the base entries above: Lawson–Michelsohn, *Spin Geometry*, Chapter I,
+  §4, Theorem 4.1(4.3), constructs `Cliff(r+1,s+1) ≅ Cliff(r,s) ⊗ᵣ Cliff(1,1)` directly from the
+  Clifford universal property, and Theorem 4.3 derives the periodic classification. Atiyah–Bott–Shapiro,
+  *Clifford Modules*, Part I, §4, Proposition 4.2 and Table 1, likewise derives the algebraic recurrence
+  and table before §5 introduces Clifford modules. Thus this branch does not depend on Layer 1's spin-module
+  proof or Layer 2's double cover.
 - **The real spin groups.** `spinPQ p q := spinGroup (realCliffordForm p q)`, the double cover of
   `SO(p, q)` from Layer 2 applied to the real form; the compact `Spin(n) = spinPQ n 0` and the split and
   Lorentzian forms `Spin(p, q)`. The real double cover of `SO(p, q)` carries the component qualifications of
@@ -660,9 +667,11 @@ identification) needs Layers 3-4 and the highest-weight theory of
 [the root-systems roadmap](../RootSystems/README.md); it is stated at the Lie-algebra level, makes "the
 fundamental representation of `Bₗ`/`Dₗ`" precise, and completes
 [the classical-groups roadmap](../ClassicalGroups/README.md). Layer 6 (the exceptional isomorphisms) needs
-Layers 4-5 for the low-rank spin modules. Layer 7 (the real forms and Bott periodicity) needs Layer 1's
-structure theory and Layer 2's double cover, specialized to `ℝ`, and is independent of Layers 4-6. Layer 8
-(triality) needs Layer 5's half-spin identification and
+Layers 4-5 for the low-rank spin modules. Layer 7 has two dependency branches: its algebraic real forms,
+Bott recurrence, and classification table use Layer 0's Clifford-algebra interfaces and the stated real base
+entries, while its real Pin and Spin group theorems use Layer 2's double cover specialized to `ℝ`. The
+algebraic classification is the real analogue of Layer 1's complex structure theorem, not its consumer.
+Layer 8 (triality) needs Layer 5's half-spin identification and
 [the root-systems roadmap](../RootSystems/README.md)'s `D₄` diagram automorphism, and its group-level stage a
 further integration theorem; it is the summit. A contributor can complete Layers 0-3 (the structure theory
 and the double cover) and the `Spin₃` and real-form examples well before the highest-weight identification of
@@ -692,6 +701,8 @@ the CAR instance is a self-contained claimable unit needing only the abstract re
 - H. B. Lawson, M.-L. Michelsohn, *Spin Geometry*, Princeton (1989), Chapter I - the definitive account of
   Clifford algebras `Cliff(p, q)`, their Bott-periodic classification (the eightfold table), the Pin and Spin
   groups as double covers, and the real and complex spinor representations.
+- M. F. Atiyah, R. Bott, A. Shapiro, *Clifford Modules*, Topology 3, Supplement 1 (1964), 3–38 - the
+  algebraic Clifford recurrence and periodic table precede its treatment of Clifford modules.
 - C. Chevalley, *The Algebraic Theory of Spinors*, Columbia (1954) - the algebraic construction of the spin
   representation from a maximal isotropic subspace, the even/odd decomposition into half-spinors, and the
   intrinsic (basis-free) development of the Clifford algebra used in Layer 4.

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md
@@ -500,12 +500,7 @@ representation landing in that group; it needs three explicit milestones per cas
   `Cliff(p, q)` as a matrix algebra over `ℝ`, `ℂ`, or `ℍ` (the eightfold way), stated as a function of
   `(q - p) mod 8` **in the convention fixed by the four base entries above** (references that make generators
   square to `+1` index by `(p - q) mod 8` instead; the base-entry tests pin which is meant). This is the real
-  refinement of Layer 1's complex structure theorem, where all forms of a rank are equivalent. This is an
-  algebraic branch from Layer 0 and the base entries above. Chevalley, *The Algebraic Theory of Spinors*,
-  II.2.1 and II.2.5, supplies the split-matrix and orthogonal-sum mechanisms; II.2.9 fixes the real
-  signature convention. Lawson–Michelsohn, *Spin Geometry*, Chapter I, §4, Theorem 4.1 and equation (4.3),
-  constructs `Cliff(r+1,s+1) ≅ Cliff(r,s) ⊗ᵣ Cliff(1,1)` directly from the Clifford universal property,
-  and Theorem 4.3 derives the periodic classification.
+  refinement of Layer 1's complex structure theorem, where all forms of a rank are equivalent.
 - **The real spin groups.** `spinPQ p q := spinGroup (realCliffordForm p q)`, the double cover of
   `SO(p, q)` from Layer 2 applied to the real form; the compact `Spin(n) = spinPQ n 0` and the split and
   Lorentzian forms `Spin(p, q)`. The real double cover of `SO(p, q)` carries the component qualifications of
@@ -665,9 +660,7 @@ identification) needs Layers 3-4 and the highest-weight theory of
 [the root-systems roadmap](../RootSystems/README.md); it is stated at the Lie-algebra level, makes "the
 fundamental representation of `Bₗ`/`Dₗ`" precise, and completes
 [the classical-groups roadmap](../ClassicalGroups/README.md). Layer 6 (the exceptional isomorphisms) needs
-Layers 4-5 for the low-rank spin modules. Layer 7 has two dependency branches: its algebraic real forms,
-Bott recurrence, and classification table use Layer 0's Clifford-algebra interfaces and the stated real base
-entries, while its real Pin and Spin group theorems use Layer 2's double cover specialized to `ℝ`. Layer 8
+Layers 4-5 for the low-rank spin modules. Layer 7’s real Clifford algebra classification uses the Clifford-algebra constructions from Layer 0 and the real base entries above. The real Pin and Spin group results use the double cover from Layer 2. Layer 8
 (triality) needs Layer 5's half-spin identification and
 [the root-systems roadmap](../RootSystems/README.md)'s `D₄` diagram automorphism, and its group-level stage a
 further integration theorem; it is the summit. A contributor can complete Layers 0-3 (the structure theory

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
@@ -314,9 +314,9 @@ theorem cliff_one_one_equiv_matrix :
 /-- **Bott periodicity** `Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)`, built from
 `CliffordAlgebra.equivEven` and `CliffordAlgebra.prodEquiv`; iterating gives the mod-`8` table, indexed by
 `(q - p) mod 8` in the convention fixed by the base entries above. This algebraic branch consumes Layer 0
-and the real base entries, not the Layer 1 structure theorem or Layer 2 double cover; see
-Lawson–Michelsohn, *Spin Geometry*, Chapter I, §4, Theorems 4.1 and 4.3, and Atiyah–Bott–Shapiro,
-*Clifford Modules*, Part I, §4, Proposition 4.2 and Table 1. -/
+and the real base entries, not the Layer 1 structure theorem or Layer 2 double cover; see Chevalley,
+*The Algebraic Theory of Spinors*, II.2.1, II.2.5, and II.2.9, and Lawson–Michelsohn,
+*Spin Geometry*, Chapter I, §4, Theorems 4.1 and 4.3. -/
 theorem cliff_bott (p q : ℕ) :
     Nonempty (CliffordAlgebra (realCliffordForm (p + 1) (q + 1)) ≃ₐ[ℝ]
       TensorProduct ℝ (CliffordAlgebra (realCliffordForm p q)) (Matrix (Fin 2) (Fin 2) ℝ)) := sorry

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
@@ -313,7 +313,10 @@ theorem cliff_one_one_equiv_matrix :
 
 /-- **Bott periodicity** `Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)`, built from
 `CliffordAlgebra.equivEven` and `CliffordAlgebra.prodEquiv`; iterating gives the mod-`8` table, indexed by
-`(q - p) mod 8` in the convention fixed by the base entries above. -/
+`(q - p) mod 8` in the convention fixed by the base entries above. This algebraic branch consumes Layer 0
+and the real base entries, not the Layer 1 structure theorem or Layer 2 double cover; see
+Lawson–Michelsohn, *Spin Geometry*, Chapter I, §4, Theorems 4.1 and 4.3, and Atiyah–Bott–Shapiro,
+*Clifford Modules*, Part I, §4, Proposition 4.2 and Table 1. -/
 theorem cliff_bott (p q : ℕ) :
     Nonempty (CliffordAlgebra (realCliffordForm (p + 1) (q + 1)) ≃ₐ[ℝ]
       TensorProduct ℝ (CliffordAlgebra (realCliffordForm p q)) (Matrix (Fin 2) (Fin 2) ℝ)) := sorry

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
@@ -311,9 +311,9 @@ sign/indexing convention of the mod-`8` table (`Cliff(1,0) ≅ ℝ × ℝ`, `Cli
 theorem cliff_one_one_equiv_matrix :
     Nonempty (CliffordAlgebra (realCliffordForm 1 1) ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ) := sorry
 
-/-- **Bott periodicity** `Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)`, built from
-`CliffordAlgebra.equivEven` and `CliffordAlgebra.prodEquiv`; together with the recurrences for Cliff(p,0)
-and Cliff(0,q) and the base entries above, this gives the mod-8 classification indexed by (q-p) mod 8. -/
+/-- **Bott periodicity** `Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)`, built from `CliffordAlgebra.equivEven`
+and `CliffordAlgebra.prodEquiv`; together with the recurrences for `Cliff(p,0)` and `Cliff(0,q)`
+and the base entries above, this gives the mod-`8` classification indexed by `(q-p) mod 8`. -/
 theorem cliff_bott (p q : ℕ) :
     Nonempty (CliffordAlgebra (realCliffordForm (p + 1) (q + 1)) ≃ₐ[ℝ]
       TensorProduct ℝ (CliffordAlgebra (realCliffordForm p q)) (Matrix (Fin 2) (Fin 2) ℝ)) := sorry

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
@@ -312,9 +312,9 @@ theorem cliff_one_one_equiv_matrix :
     Nonempty (CliffordAlgebra (realCliffordForm 1 1) ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ) := sorry
 
 /-- **Bott periodicity** `Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)`, built from
-`CliffordAlgebra.equivEven` and `CliffordAlgebra.prodEquiv`; iterating gives the mod-`8` table, indexed by
-`(q - p) mod 8` in the convention fixed by the base entries above. This algebraic branch consumes Layer 0
-and the real base entries, not the Layer 1 structure theorem or Layer 2 double cover; see Chevalley,
+`CliffordAlgebra.equivEven` and `CliffordAlgebra.prodEquiv`; together with the pure-axis recurrences and
+base entries above, this gives the mod-`8` table, indexed by `(q - p) mod 8`. This algebraic branch consumes
+Layer 0 and the real base entries, not the Layer 1 structure theorem or Layer 2 double cover; see Chevalley,
 *The Algebraic Theory of Spinors*, II.2.1, II.2.5, and II.2.9, and Lawson–Michelsohn,
 *Spin Geometry*, Chapter I, §4, Theorems 4.1 and 4.3. -/
 theorem cliff_bott (p q : ℕ) :

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
@@ -312,11 +312,8 @@ theorem cliff_one_one_equiv_matrix :
     Nonempty (CliffordAlgebra (realCliffordForm 1 1) ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ) := sorry
 
 /-- **Bott periodicity** `Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)`, built from
-`CliffordAlgebra.equivEven` and `CliffordAlgebra.prodEquiv`; together with the pure-axis recurrences and
-base entries above, this gives the mod-`8` table, indexed by `(q - p) mod 8`. This algebraic branch consumes
-Layer 0 and the real base entries; see Chevalley,
-*The Algebraic Theory of Spinors*, II.2.1, II.2.5, and II.2.9, and Lawson–Michelsohn,
-*Spin Geometry*, Chapter I, §4, Theorems 4.1 and 4.3. -/
+`CliffordAlgebra.equivEven` and `CliffordAlgebra.prodEquiv`; together with the recurrences for Cliff(p,0)
+and Cliff(0,q) and the base entries above, this gives the mod-8 classification indexed by (q-p) mod 8. -/
 theorem cliff_bott (p q : ℕ) :
     Nonempty (CliffordAlgebra (realCliffordForm (p + 1) (q + 1)) ≃ₐ[ℝ]
       TensorProduct ℝ (CliffordAlgebra (realCliffordForm p q)) (Matrix (Fin 2) (Fin 2) ℝ)) := sorry

--- a/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
+++ b/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean
@@ -314,7 +314,7 @@ theorem cliff_one_one_equiv_matrix :
 /-- **Bott periodicity** `Cliff(p+1, q+1) ≅ Cliff(p, q) ⊗ M₂(ℝ)`, built from
 `CliffordAlgebra.equivEven` and `CliffordAlgebra.prodEquiv`; together with the pure-axis recurrences and
 base entries above, this gives the mod-`8` table, indexed by `(q - p) mod 8`. This algebraic branch consumes
-Layer 0 and the real base entries, not the Layer 1 structure theorem or Layer 2 double cover; see Chevalley,
+Layer 0 and the real base entries; see Chevalley,
 *The Algebraic Theory of Spinors*, II.2.1, II.2.5, and II.2.9, and Lawson–Michelsohn,
 *Spin Geometry*, Chapter I, §4, Theorems 4.1 and 4.3. -/
 theorem cliff_bott (p q : ℕ) :


### PR DESCRIPTION
## Summary

Layer 7 has two dependency branches:

- the real Clifford recurrence and mod-8 classification consume Layer 0, the pure-axis recurrences, and the real base entries;
- the real Pin and Spin group branch consumes the Layer 2 double cover.

Chevalley supplies the split-matrix, orthogonal-sum, and signature-convention inputs. Lawson–Michelsohn supplies the mixed recurrence and periodic classification. This edit records that split in the Layer 7 description, Ordering paragraph, and matching `cliff_bott` documentation without changing a target or signature.

## Lean impact

The algebraic branch is represented by merged [TauCeti#2550](https://github.com/TauCetiProject/TauCeti/pull/2550), [#2524](https://github.com/TauCetiProject/TauCeti/pull/2524), and [#2804](https://github.com/TauCetiProject/TauCeti/pull/2804). Under literal scope enforcement, the blanket ordering currently blocks review of these next Lean slices:

- the quaternion recurrence `Cliff(p,q+2) ≃ Cliff(q,p) ⊗ ℍ`;
- its eight-step consumer `Cliff(p+8,q) ≃ Cliff(p,q) ⊗ M₁₆(ℝ)`;
- the full matrix/complex/quaternionic classification indexed by `(q-p) mod 8`.

All three compile locally against the merged recurrence chain. This PR states their dependency boundary; it does not waive their code review.

## Audits and validation

A source-dependency audit checked the quaternion recurrence and its eight-step consumer against their exact imports and declarations; their dependency closure ends at Layer 0, the real base entries, and the algebraic recurrence chain. A roadmap audit identified the blanket Ordering sentence as the scope blocker.

The literature audit used locally available literature and the periodicity convention audit. It verified TauCeti's signature swap, generator equations, and recurrence direction, rejected a locally unavailable Atiyah–Bott–Shapiro citation, and corrected the exact roles of Chevalley and Lawson–Michelsohn.

The branch is rebased on current `main`; README/`Suggested.lean` consistency, whitespace, identity, and metadata checks pass. An earlier independent review approved the source roles, convention bridge, and dependency split; this revision removes only redundant negative explanations.

## AI assistance

Prepared with GPT-5.6 Sol high; the author checked the sources, convention bridge, dependency split, and wording.
