### PR TITLE
Add roadmap: counting totally ramified extensions of a local field

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If you want to write or review a roadmap, start with [CONTRIBUTING.md](CONTRIBUT
 - [Combinatorial Heegaard Floer and grid homology](TauCetiRoadmap/CombinatorialHeegaardFloer/README.md)
 - [Conformal mapping and the geometric theory of holomorphic functions](TauCetiRoadmap/ConformalMapping/README.md)
 - [Contour integration and the Hungerbühler–Wasem generalized residue theorem](TauCetiRoadmap/ContourIntegration/README.md)
+- [Counting totally ramified extensions of a local field, and Serre's mass formula](TauCetiRoadmap/TotallyRamified/README.md)
 - [Elliptic curves](TauCetiRoadmap/EllipticCurves/README.md)
 - [Exchangeability and de Finetti](TauCetiRoadmap/Exchangeability/README.md)
 - [Foundations of adic spaces](TauCetiRoadmap/AdicSpaces/README.md)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ If you want to write or review a roadmap, start with [CONTRIBUTING.md](CONTRIBUT
 - [Combinatorial Heegaard Floer and grid homology](TauCetiRoadmap/CombinatorialHeegaardFloer/README.md)
 - [Conformal mapping and the geometric theory of holomorphic functions](TauCetiRoadmap/ConformalMapping/README.md)
 - [Contour integration and the Hungerbühler–Wasem generalized residue theorem](TauCetiRoadmap/ContourIntegration/README.md)
-- [Counting totally ramified extensions of a local field, and Serre's mass formula](TauCetiRoadmap/TotallyRamified/README.md)
 - [Elliptic curves](TauCetiRoadmap/EllipticCurves/README.md)
 - [Exchangeability and de Finetti](TauCetiRoadmap/Exchangeability/README.md)
 - [Foundations of adic spaces](TauCetiRoadmap/AdicSpaces/README.md)

--- a/TauCetiRoadmap.lean
+++ b/TauCetiRoadmap.lean
@@ -29,4 +29,3 @@ import TauCetiRoadmap.OrthogonalL2Bases.Suggested
 import TauCetiRoadmap.OptimalTransport.Suggested
 import TauCetiRoadmap.CFSGStatement.Suggested
 import TauCetiRoadmap.HodgeStructures.Suggested
-import TauCetiRoadmap.TotallyRamified.Suggested

--- a/TauCetiRoadmap.lean
+++ b/TauCetiRoadmap.lean
@@ -29,3 +29,4 @@ import TauCetiRoadmap.OrthogonalL2Bases.Suggested
 import TauCetiRoadmap.OptimalTransport.Suggested
 import TauCetiRoadmap.CFSGStatement.Suggested
 import TauCetiRoadmap.HodgeStructures.Suggested
+import TauCetiRoadmap.TotallyRamified.Suggested

--- a/TauCetiRoadmap/TotallyRamified/README.md
+++ b/TauCetiRoadmap/TotallyRamified/README.md
@@ -1,0 +1,353 @@
+# Roadmap: counting totally ramified extensions of a local field, and Serre's mass formula
+
+The [local fields and ramification roadmap](../LocalFieldsRamification/README.md) builds the
+arithmetic of a finite extension of a non-archimedean local field: total ramification, Eisenstein
+generators, monogenicity, the different and the discriminant, and the tame criterion. This
+roadmap is that theory's first counting consumer. It asks how *many* such extensions there are,
+and proves the answer — the **mass formula** of [Serre 1978]: inside a fixed separable closure,
+the totally ramified extensions of degree `n` of a local field `K` satisfy
+
+```text
+∑_{L ∈ σ_K(n)} q^{-c(L)} = n,          c(L) = d(L) − n + 1
+```
+
+where `q` is the residue cardinality and `d(L)` the discriminant exponent, together with its
+isomorphism-class form `∑_{M} 1 / (#Aut_K(M) · q^{c(M)}) = 1`. It is the local counting statement
+behind mass heuristics for global field counting, and nothing like it is upstream.
+
+The machinery the count needs is not ramification theory, and that is what makes this a separate
+roadmap: a **quantitative Newton estimate** over a complete discrete valuation ring (Mathlib's
+`HenselianLocalRing` lifts a simple root but gives no distance bound, hence no count), the
+**lattice-index scaling law** for Haar measure over such a ring (Mathlib's
+`Measure.addHaar_image_linearMap` is real-vector-space only), and the parametrization of `σ_K(n)`
+by the **Eisenstein region** of coefficient space. The first two are stated over an arbitrary
+complete discrete valuation ring and are reusable well outside this roadmap.
+
+Suggested home: `TauCeti/NumberTheory/LocalField/MassFormula/`, with the two general layers
+placed by subject instead: quantitative Newton lifting in
+`TauCeti/RingTheory/DiscreteValuationRing/`, and the lattice scaling law in
+`TauCeti/MeasureTheory/Group/`.
+
+## Scope
+
+This roadmap owns the **counting** of totally ramified extensions of a local field: the set
+`σ_K(n)` as an object, the wild exponent `c` as its weight, the analytic and measure-theoretic
+machinery that evaluates the count, and the mass formulas with the finiteness, convergence and
+orbit statements that accompany them.
+
+It does not own the arithmetic of the individual extension. **Total ramification, Eisenstein
+generators, monogenicity, the different, the discriminant, and the tame criterion belong to the
+[local fields and ramification roadmap](../LocalFieldsRamification/README.md)**, which is where
+they are specified and where their API accrues; the contract this roadmap consumes from it is
+listed below. It also does not own higher ramification groups, Herbrand functions or Hasse–Arf
+(same roadmap); local class field theory; adic or Huber-theoretic geometry over `K`, which is the
+[adic spaces roadmap](../AdicSpaces/README.md); or archimedean local fields, which
+`IsNonarchimedeanLocalField` excludes and which never enter.
+
+## Standing conventions
+
+Pinning these matters more than usual: the objects are junk-tolerant by design, and an
+implementor who picks a different model will not be able to state the summit.
+
+- **The base field.** `K` carries
+  `[Field K] [ValuativeRel K] [UniformSpace K] [IsUniformAddGroup K] [IsNonarchimedeanLocalField K]`.
+  Spell the hypotheses out; do not bundle them. Mathlib's instances then supply
+  `IsDiscreteValuationRing 𝒪[K]`, `Finite 𝓀[K]`, `CompactSpace 𝒪[K]`, `CompleteSpace K` and
+  `IsAdicComplete 𝓂[K] 𝒪[K]` by `inferInstance`; consume them, never re-prove them.
+- **The residue cardinality is `q K := Nat.card 𝓀[K]`**, and the residue characteristic is written
+  inline as `ringChar 𝓀[K]`. Do not introduce a `p` abbreviation.
+- **Extensions live inside a separable closure.** An extension is a term of
+  `IntermediateField K (SeparableClosure K)`. This is Serre's setting and it is load-bearing: in
+  equal characteristic `p` the inseparable Eisenstein polynomials (`X^p − π`) must not be counted,
+  and working inside `SeparableClosure K` excludes them by construction rather than by a side
+  hypothesis. ⚠ The consumed roadmap states its ramification theory for a finite extension `L/K`
+  as such; the bridge to subextensions of `SeparableClosure K` is this roadmap's Layer 0.
+- **The discriminant exponent is the consumed one.** `d L` is the invariant the local fields and
+  ramification roadmap defines; for a totally ramified extension its different exponent `v_L(𝔡)`
+  and the valuation of its discriminant ideal in `K` agree, since the residue degree is `1`. Do
+  not introduce a second discriminant.
+- **Junk is tolerated, `0 < n` is not optional.** For `L` infinite over `K`, or for `n = 0`, these
+  definitions take junk values. Every statement about `σ_K n` therefore carries `0 < n`, and
+  membership in `σ_K n` is what makes a statement honest. Do not add finiteness hypotheses to
+  definitions to avoid junk; add them to theorems.
+- **Sums are in `ℝ≥0∞`.** Theorems 1 and 2 are stated with `∑'` valued in `ℝ≥0∞`, where the
+  possibly infinite sum needs no convergence side condition and equality with `n` (resp. `1`)
+  already encodes convergence. The convergence remark is a *separate* statement over `ℝ` as
+  `Summable`; state both and relate them, and do not merge them.
+- **Representative sets are a predicate, not a quotient.** `IsRepresentativeSet n R` says that
+  `R ⊆ σ_K n` and every `L ∈ σ_K n` is `K`-isomorphic to exactly one member of `R`; Theorem 2
+  quantifies over every such `R`. This is Serre's phrase verbatim and avoids `Quotient.lift`
+  well-definedness obligations for `c` and `#Aut`.
+- **The coefficient space and its measure.** A monic degree-`n` polynomial is its coefficient
+  vector `a : Fin n → K`, with `a i` the coefficient of `X ^ i`. The measure is the additive Haar
+  measure of `Fin n → K` normalized so that the integer box `Fin n → 𝒪[K]` has volume `1`; by
+  uniqueness of Haar measure this is the product of the normalized coordinate measures, but the
+  product structure is needed only inside proofs, so neither `Measure.pi` nor σ-finiteness appears
+  in any statement.
+- **Valuations in an extension are `IsDiscreteValuationRing.addVal`**, `ℕ∞`-valued. No topology on
+  `L` is used anywhere: completeness of the ring of integers of `L` is the algebraic
+  `IsAdicComplete`, and all estimates are `addVal` estimates. This keeps the count free of a
+  second uniform structure.
+
+## What this roadmap consumes
+
+### From the local fields and ramification roadmap
+
+Every item below is a target *there*, not here. This roadmap's milestones rest on them and add no
+independent development of the same material; if one of them is restated in `TauCeti/` by this
+roadmap's implementors, that is a duplicate to be deleted rather than a contribution.
+
+- **Total ramification** as a predicate, with `e · f = [L:K]` and the equivalence with residue
+  degree `1`.
+- **Totally ramified is equivalent to Eisenstein**, in both directions, with the uniformizer the
+  Eisenstein polynomial produces.
+- **Local monogenicity**, and in particular that a root of an Eisenstein polynomial generates the
+  ring of integers on its power basis.
+- **The different and the discriminant**, the exponent `d(L/K)`, and the comparison with Mathlib's
+  `differentIdeal`.
+- **The tame criterion** `d = e − 1 ⟺ tamely ramified`, and the wild lower bound `e ≤ d`. Together
+  these are exactly what makes `c(L) = d(L) − n + 1` a nonnegative integer, and what makes
+  `c(L) = 0` equivalent to `¬ (p ∣ n)`; both are consumed here rather than reproved.
+
+### From Mathlib
+
+- **Local fields:** `Mathlib/NumberTheory/LocalField/Basic.lean` — `IsNonarchimedeanLocalField`
+  and the instance package above, plus `valueGroupWithZeroIsoInt`.
+  ⚠ `IsAdicComplete 𝓂[K] 𝒪[K]` **is an instance there**; it is not a gap and must not be reproved.
+- **Notation and valuations:** `Mathlib/Topology/Algebra/Valued/ValuativeRel.lean`,
+  `Mathlib/RingTheory/Valuation/ValuativeRel/*`, and
+  `Mathlib/RingTheory/DiscreteValuationRing/Basic.lean` (`IsDiscreteValuationRing.addVal`,
+  `exists_irreducible`, `Irreducible.maximalIdeal_eq`).
+- **Eisenstein polynomials:** `Mathlib/RingTheory/Polynomial/Eisenstein/*`
+  (`Polynomial.IsEisensteinAt`, `IsEisensteinAt.irreducible`).
+- **Hensel's lemma, qualitatively:** `Mathlib/RingTheory/Henselian.lean` — `HenselianLocalRing`,
+  `HenselianRing`. This lifts a simple root *modulo the maximal ideal*; it gives no distance
+  estimate and no count, which is why Layer 1 exists.
+- **Separable degree and embeddings:** `Mathlib/FieldTheory/SeparableDegree.lean` —
+  `Field.embEquivOfAdjoinSplits`, `Field.finSepDegree_eq_finrank_of_isSeparable`.
+- **Smith normal form:** `Mathlib/LinearAlgebra/FreeModule/IdealQuotient.lean` and
+  `…/Finite/Quotient.lean` — `Submodule.quotientEquivPiSpan`, the input to the lattice index.
+- **Haar measure:** `Mathlib/MeasureTheory/Group/Measure.lean` — `IsAddHaarMeasure` and the
+  existence of Haar measure on a locally compact group. ⚠ The determinant scaling law
+  `Measure.addHaar_image_linearMap` (`Mathlib/MeasureTheory/Measure/Lebesgue/EqHaar.lean`) is
+  stated for **real** vector spaces only; the non-archimedean analogue is Layer 2.
+
+## What is missing (build here)
+
+The set `σ_K(n)` and the wild exponent as a counting weight, with its invariance under
+`K`-isomorphism; the orthogonality of a power basis at an Eisenstein generator; quantitative
+Newton lifting over a complete discrete valuation ring and the local constancy of root counts it
+yields; the lattice-index formula and the Haar scaling law over such a ring with finite residue
+field; the measure of the Eisenstein region and the parametrization it carries; and the two mass
+formulas with their finiteness, convergence and orbit-counting companions. None of this is
+upstream, and none of it is claimed by the roadmap this one consumes.
+
+---
+
+## The build, in layers
+
+The ordering is the dependency order. As each layer makes the next layer's *types* expressible in
+`TauCeti/`, its milestones go into `Suggested.lean` (with `sorry`).
+
+### Layer 0: the counting invariants
+
+- **`σ_K(n)`**, the set of subextensions of `SeparableClosure K` that are totally ramified of
+  degree `n` over `K`, built on the consumed total-ramification predicate. With the bridge lemmas
+  the count needs: `σ_K(1) = {K}`; membership is preserved by the image of any `K`-embedding into
+  `SeparableClosure K`; and every member is `K⟮x⟯` for `x` a root of an Eisenstein polynomial of
+  degree `n`, which is the consumed equivalence transported to this setting.
+- **The wild exponent `c L := d L + 1 − n`** in truncated `ℕ`-subtraction, where `d` is the
+  consumed discriminant exponent. The consumed bounds make the truncation faithful, so `c` is
+  Serre's nonnegative integer and `c L = 0 ⟺ ¬ (ringChar 𝓀[K] ∣ n)`; state both here as the
+  corollaries of the consumed facts that they are, not as fresh developments.
+- **Invariance of `c` under `K`-isomorphism.** A `K`-isomorphism carries integral bases to
+  integral bases with the same discriminant, so `d`, hence `c`, is an invariant of the class.
+  ⚠ Not covered by the consumed contract, which states `d` for a fixed extension; Theorem 2 is
+  exactly a regrouping along this invariance, so it is a target here.
+- **Orthogonality of the power basis.** In the ring of integers generated by an Eisenstein
+  generator `ξ` of degree `n`, the terms of `∑_{i<n} c_i ξ^i` have pairwise distinct valuations —
+  the `i`-th is `n · addVal(c_i) + i`, distinct modulo `n` — so no cancellation is possible and
+  the valuation of the sum is the minimum of the terms'. Consequences: a ball of the ring of
+  integers is a box in power-basis coordinates, and at a radius divisible by `n` it is a cube.
+  ⚠ Also not covered by the consumed contract, which gives the monogenic basis but not the
+  valuations of a combination in it. This is the workhorse of Layers 2 and 3 and deserves its own
+  name and API.
+
+### Layer 1: quantitative Newton lifting over a complete discrete valuation ring
+
+Stated for an arbitrary complete (`IsAdicComplete`) discrete valuation ring, since nothing here
+uses the local field; the local-field case is an instance.
+
+- **Newton iteration with an estimate.** If `addVal (F y₀) > 2 · addVal (F' y₀)`, the iteration
+  `y ↦ y − F y / F' y` converges to a root `z` of `F` with
+  `addVal (z − y₀) ≥ addVal (F y₀) − addVal (F' y₀)`, and `z` is the unique root in that ball.
+  ⚠ This strictly refines Mathlib's `HenselianLocalRing`, which lifts a simple root modulo the
+  maximal ideal and yields no distance bound; the estimate, not the existence, is what Layer 3
+  consumes.
+- **Local constancy of the root count.** For a monic `f` over `𝒪[K]`, separable over `K`, there is
+  a threshold `T` such that every monic `g` with `g.coeff i − f.coeff i ∈ 𝓂[K]^T` for all `i` has
+  exactly as many roots in `L` as `f` does, for every `L ∈ σ_K n`. The route is a Bézout
+  certificate `U · f + V · f' = β` over `𝒪[K]` bounding the order of `f'` at every near-root
+  uniformly, then Newton lifting in both directions.
+- ⚠ **Not Krasner's lemma.** Mathlib's Krasner (`Analysis/Normed/Field/Krasner.lean`) is a
+  normed-field statement about a *single* root generating an extension; what Layer 3 needs is a
+  *count* that is uniform on a coefficient ball, which Krasner does not give. Keep the two apart
+  and do not route this layer through the normed setting.
+
+### Layer 2: lattices, index, and the Haar scaling law
+
+Stated for a complete discrete valuation ring with finite residue field of cardinality `q`, for
+the same reason.
+
+- **The index of an image lattice.** For a matrix `M` over `𝒪[K]` with `Associated M.det (π^k)`,
+  the quotient of the integer box `Fin n → 𝒪[K]` by its image under `M` has exactly `q^k`
+  elements. Via `Submodule.quotientEquivPiSpan` (Smith normal form over the principal ideal ring
+  `𝒪[K]`), the quotient splits into residue rings of the diagonal coefficients, whose product is
+  associated to `M.det`.
+- **The scaling law.** For the Haar measure of `Fin n → K` normalized on the integer box,
+  `μ (M · S) = q^{−k} · μ S` for `S` the box or any ball — the non-archimedean analogue of
+  `Measure.addHaar_image_linearMap`. ⚠ Prove it through lattice indices, not through uniqueness
+  of Haar measure: the index route needs no second-countability or regularity side conditions, and
+  the general-set form is not needed.
+- **Boxes and balls.** The image lattice of a diagonal matrix is the coordinate box with `i`-th
+  factor `π^{e i} · 𝒪[K]`, of volume `q^{−∑ e i}`; a ball is a translate of the lattice of a
+  constant-radius box. With Layer 0's orthogonality this computes the volume of a ball of the ring
+  of integers of `L` in power-basis coordinates, which is the only other volume the summit needs.
+
+### Layer 3: the Eisenstein region and the parametrization
+
+- **The Eisenstein region** `E_n ⊆ (Fin n → K)`: every coefficient in `𝓂[K]`, with the constant
+  term of valuation exactly that of a uniformizer. Its measure is `q^{−n} · (1 − q^{−1})`.
+- **Almost every Eisenstein polynomial is separable** ([Serre 1978, eq. (3)]): the non-separable
+  locus is null. In equal characteristic this is where the inseparable polynomials are discarded,
+  and it is the reason the count is over subextensions of `SeparableClosure K`.
+- **The root count.** For `L ∈ σ_K n`, `rootCount L a` is the number of roots of the monic
+  polynomial with coefficient vector `a` lying in `L`, counted with multiplicity. On the
+  full-measure separable locus all multiplicities are `1`. Almost everywhere on `E_n`,
+  `∑_{L ∈ σ_K n} rootCount L a = n`: an Eisenstein polynomial is irreducible, and each of its `n`
+  roots generates exactly one member of `σ_K n`.
+- **The local fibre count** ([Serre 1978, Lemma 1]): the cube of radius `π^ρ` around an Eisenstein
+  generator `ξ` contains exactly one root of each nearby Eisenstein polynomial — Layer 1 applied
+  on the region.
+- **The integral of the root count** ([Serre 1978, Lemmas 2 and 3, eqs. (5)–(13)]): for each
+  `L ∈ σ_K n`, `∫_{E_n} rootCount L = q^{−(d L + 1)} · (1 − q^{−1})`. The change of variables runs
+  in power-basis coordinates: a ball of the ring of integers is the ideal generated by a suitable
+  element, in coordinates the image lattice of the matrix of multiplication by it, whose
+  determinant is that element's norm — so Layer 2 supplies the factor `q^{−d L}` with no Jacobian,
+  no conjugates and no Vandermonde.
+
+### Layer 4: the mass formulas
+
+- **Theorem 1** ([Serre 1978, Thm. 1]): for `0 < n`, `∑' L : σ_K n, 1 / (q K) ^ c L = n` in
+  `ℝ≥0∞`. Integrate the root-count identity of Layer 3 over `E_n` and divide by the measure of the
+  region.
+- **The finiteness dichotomy** ([Serre 1978, Rmk. 1°]): `σ_K n` is infinite if and only if `K` has
+  equal characteristic `p` and `p ∣ n`. Both directions are targets. The forward direction follows
+  from Theorem 1 together with the uniform bound `c L ≤ n · addVal(n)` outside the asserted case;
+  the converse is an explicit family — the Eisenstein polynomials `X^n + π^m X + π` for `m ≥ 1`
+  have `d = n · m`, pairwise distinct, hence generate infinitely many distinct members.
+- **Convergence** ([Serre 1978, Rmk. 1°]): `Summable fun L : σ_K n => 1 / (q K : ℝ) ^ c L`, the
+  real-valued restatement, meaningful precisely in the infinite case.
+- **The orbit count** ([Serre 1978, Rmk. 3°]): for `L ∈ σ_K n`, the number of `M ∈ σ_K n` that are
+  `K`-isomorphic to `L`, times `#Aut_K(L)`, is `n`. `L / K` is separable of degree `n`, so it has
+  exactly `n` embeddings into `SeparableClosure K`; each image lies in `σ_K n` by Layer 0; and the
+  embeddings with a given image form a torsor under `Aut_K(L)`.
+- **Theorem 2** ([Serre 1978, Thm. 2]): for every `R` with `IsRepresentativeSet n R`,
+  `∑' M : R, 1 / (#Aut_K(M) · (q K) ^ c M) = 1` in `ℝ≥0∞`. Theorem 1 regrouped along isomorphism
+  classes, using the invariance of `c` from Layer 0 and the orbit count.
+- **The tame count**, as a corollary worth stating: when `¬ (ringChar 𝓀[K] ∣ n)`, every `c L = 0`,
+  so `σ_K n` is finite with exactly `n` elements.
+
+## Worked examples (acceptance criteria, keeping the definitions honest)
+
+Discharge these alongside the layers; they catch a vacuous `σ`, a wrong normalization of the
+measure, and an off-by-one in `c`.
+
+- **`n = 1`:** `σ_K 1 = {K}` with `d = c = 0`, and Theorem 1 reads `1 = 1`.
+- **Tame:** for `K = ℚ_p` with `p` odd and `n = 2`, `σ_K 2` has exactly two elements (`ℚ_p(√p)`
+  and `ℚ_p(√(u p))` for `u` a non-residue unit), both with `c = 0`, so the sum is `2`. This is the
+  tame count above in its smallest instance.
+- **Wild, and the sharpest test of `c`:** for `K = ℚ_2` and `n = 2`, `σ_K 2` has six elements —
+  `ℚ_2(√−1)` and `ℚ_2(√−5)` with `d = 2`, hence `c = 1`; and `ℚ_2(√±2)`, `ℚ_2(√±10)` with `d = 3`,
+  hence `c = 2`. Theorem 1 reads `2 · 2^{−1} + 4 · 2^{−2} = 2`. An implementation that gets `c`
+  off by one fails here and nowhere earlier. ⚠ Those two discriminant values are the `ℚ_2(i)` and
+  `ℚ_2(√2)` cases of the consumed roadmap's own worked examples; agreeing with them is the check
+  that the consumed `d` and the `c` here are the same invariant.
+- **Equal characteristic:** for `K = 𝔽_p((t))` and `n = p`, `σ_K n` is infinite, yet the real
+  series converges — the two halves of Remark 1° on the same example.
+- **The measure of the Eisenstein region** is `q^{−n}(1 − q^{−1})`, and the integral of
+  `rootCount L` over it is `q^{−(d L + 1)}(1 − q^{−1})`; summing over `L` recovers `n` times the
+  measure of the region. Checking the two constants against each other catches a misnormalized
+  Haar measure, which is otherwise invisible until the summit.
+- **Galois case of the orbit count:** for `L / K` Galois in `σ_K n`, `#Aut_K(L) = n` and the
+  isomorphism class of `L` inside `σ_K n` is `{L}`.
+
+## Ordering
+
+Layer 0 comes first and rests on the consumed contract. Layers 1 and 2 are independent of Layer 0
+and of each other — quantitative Newton lifting and the lattice scaling law are general statements
+about complete discrete valuation rings — so all three are parallel lanes, and the two general
+ones can be built before any of the consumed material lands. Layer 3 needs 0–2; Layer 4 needs
+Layer 3, except for the orbit count, which needs only Layer 0 and can be built early.
+
+## Long horizon (a roadmap for a future roadmap; do not attempt it here)
+
+Serre's formula was refined by Krasner into a count of the totally ramified extensions of given
+degree *and* given discriminant, and generalized by Bhargava into a mass formula over all étale
+extensions of a local field, which is the local input to the conjectured densities of number-field
+discriminants. Both are natural continuations and neither is specified here; they are named to
+mark the direction, not to be worked on under this roadmap.
+
+## References
+
+- J-P. Serre, *Une «formule de masse» pour les extensions totalement ramifiées de degré donné
+  d'un corps local*, C. R. Acad. Sci. Paris **286** (1978), Série A, 1031–1036 — the summit:
+  Thm. 1, Thm. 2, Remarks 1° and 3°, Lemmas 1–3 and the change of variables of §3.
+- J-P. Serre, *Local Fields*, Graduate Texts in Mathematics **67**, Springer (1979) — Chap. I §6
+  (Eisenstein polynomials and monogenicity, Prop. 17), Chap. III §3 (the different and the
+  discriminant), Chap. III §6 (the valuation of the different, tameness, Prop. 13). Consumed
+  through the local fields and ramification roadmap rather than developed here.
+- M. Krasner, *Nombre des extensions d'un degré donné d'un corps p-adique*, in *Les tendances
+  géométriques en algèbre et théorie des nombres*, CNRS (1966), 143–169 — the
+  discriminant-refined count that Serre's formula summarizes.
+- M. Bhargava, *Mass formulae for extensions of local fields, and conjectures on the density of
+  number field discriminants*, IMRN (2007) — the étale generalization.
+
+## Acknowledgements
+
+The mathematics of every layer has been formalized, `sorry`-free, in
+[0stellensatz/MassFormula](https://github.com/0stellensatz/MassFormula) (Apache-2.0), by the
+proposer of this roadmap; the provenance map below records where each layer's proof can be read.
+That project is a **cited source, not the specification**: this roadmap states the mathematics
+intrinsically, hands the ramification-theoretic half to the roadmap that owns it, and asks for the
+two general layers at a generality the source did not need.
+
+### Provenance (secondary; the layers above are definitive)
+
+File map, relative to that project's `MassFormula/`:
+
+| Layer | Files |
+| --- | --- |
+| 0 | `Defs.lean`, `UniformizerParam.lean` (orthogonality), `Second.lean` (invariance of `c`) |
+| 1 | `RootLifting.lean` |
+| 2 | `HaarScaling.lean` |
+| 3 | `First.lean`, `UniformizerParam.lean` (the fibre count) |
+| 4 | `First.lean`, `Second.lean`, `Finiteness.lean`, `Convergence.lean`, `Orbit.lean` |
+
+The source's `EisensteinMonogenic.lean`, `Discriminant.lean` and `Tame.lean` prove material this
+roadmap consumes rather than owns; they are evidence that the consumed contract is provable in
+this setting, and belong with the roadmap that specifies it, not here.
+
+Where this roadmap departs from the source:
+
+- The source proves `IsAdicComplete 𝓂[K] 𝒪[K]` itself; that instance is now in Mathlib and is to
+  be consumed, not carried.
+- The source wraps `integralClosure ↥𝒪[K] ↥L` and its maximal ideal in project abbreviations; use
+  Mathlib's spelling, and the consumed roadmap's, so the lemmas land where the rest of the
+  integral-closure API lives.
+- Layers 1 and 2 are stated in the source only for the local-field case they were needed in; this
+  roadmap asks for them over an arbitrary complete discrete valuation ring (with finite residue
+  field, for Layer 2), which is the generality their proofs already have.
+- The source is organized as a frozen specification file paired with a development file that
+  discharges it. That device does not transfer: in Tau Ceti the roadmap is what commits to a
+  statement before its proof exists, and no `sorry` may land in `TauCeti/`.

--- a/TauCetiRoadmap/TotallyRamified/README.md
+++ b/TauCetiRoadmap/TotallyRamified/README.md
@@ -61,10 +61,13 @@ implementor who picks a different model will not be able to state the summit.
   equal characteristic `p` the inseparable Eisenstein polynomials (`X^p − π`) must not be counted,
   and working inside `SeparableClosure K` excludes them by construction rather than by a side
   hypothesis. ⚠ The consumed roadmap states its ramification theory for a finite extension `L/K`
-  as such; the bridge to subextensions of `SeparableClosure K` is this roadmap's Layer 0.
-- **The discriminant exponent is the consumed one.** `d L` is the invariant the local fields and
-  ramification roadmap defines; for a totally ramified extension its different exponent `v_L(𝔡)`
-  and the valuation of its discriminant ideal in `K` agree, since the residue degree is `1`. Do
+  as such; the bridge to subextensions of `SeparableClosure K` is this roadmap's Layer 0, which
+  installs the consumed `finiteIntermediateField*` adapters.
+- **The discriminant exponent is the consumed one.** `d L` is the consumed
+  `discriminantExponent`, totalized over arbitrary subextensions by the wrapper
+  `intermediateFieldDiscriminantExponent`; for a totally ramified extension its different
+  exponent `v_L(𝔡)` and the valuation of its discriminant ideal in `K` agree, since the residue
+  degree is `1` (the consumed `discriminantExponent_eq_inertiaDegree_mul_differentExponent`). Do
   not introduce a second discriminant.
 - **Junk is tolerated, `0 < n` is not optional.** For `L` infinite over `K`, or for `n = 0`, these
   definitions take junk values. Every statement about `σ_K n` therefore carries `0 < n`, and
@@ -85,17 +88,21 @@ implementor who picks a different model will not be able to state the summit.
   product structure is needed only inside proofs, so neither `Measure.pi` nor σ-finiteness appears
   in any statement.
 - **Valuations in an extension are `IsDiscreteValuationRing.addVal`**, `ℕ∞`-valued. No topology on
-  `L` is used anywhere: completeness of the ring of integers of `L` is the algebraic
-  `IsAdicComplete`, and all estimates are `addVal` estimates. This keeps the count free of a
-  second uniform structure.
+  `L` enters any counting statement or estimate: completeness of the ring of integers of `L` is
+  the algebraic `IsAdicComplete`, and all estimates are `addVal` estimates — the spelling the
+  consumed `addVal_sum_eisenstein_powerBasis` exports. The consumed structure adapters put the
+  canonical topology and valuation on a subextension carrier only inside the Layer 0 wrappers;
+  no statement here hypothesizes a second uniform structure.
 
 ## What this roadmap consumes
 
 ### From the local fields and ramification roadmap
 
-Every item below is a target *there*, not here. This roadmap's milestones rest on them and add no
-independent development of the same material; if one of them is restated in `TauCeti/` by this
-roadmap's implementors, that is a duplicate to be deleted rather than a contribution.
+Every item below is specified there and is imported here from that roadmap's `Suggested.lean` by
+exact name; the table at the end of this section is the map. This roadmap's milestones rest on
+them and add no independent development of the same material; if one of them is restated in
+`TauCeti/` by this roadmap's implementors, that is a duplicate to be deleted rather than a
+contribution.
 
 - **Total ramification** as a predicate, with `e · f = [L:K]` and the equivalence with residue
   degree `1`.
@@ -108,6 +115,34 @@ roadmap's implementors, that is a duplicate to be deleted rather than a contribu
 - **The tame criterion** `d = e − 1 ⟺ tamely ramified`, and the wild lower bound `e ≤ d`. Together
   these are exactly what makes `c(L) = d(L) − n + 1` a nonnegative integer, and what makes
   `c(L) = 0` equivalent to `¬ (p ∣ n)`; both are consumed here rather than reproved.
+- **Invariance under `K`-isomorphism** of the different and discriminant exponents, the
+  arithmetic fact beneath this roadmap's family-level invariance of `c`.
+- **Orthogonality of the Eisenstein power basis**, in the `IsDiscreteValuationRing.addVal`
+  spelling; this roadmap owns only its box and cube corollaries (Layer 0).
+- **The structure adapters for a finite intermediate-field carrier**, which put the canonical
+  normed, valuative and topological structure on a subextension without a postulated topology or
+  valuation.
+
+Each consumed item and the declaration (in namespace `TauCetiRoadmap.LocalFieldsRamification`)
+that supplies it:
+
+| Consumed item | Supplier declaration |
+| --- | --- |
+| total ramification, and the residue-degree criterion | `IsTotallyRamified`, `isTotallyRamified_iff_inertiaDegree_eq_one` |
+| `e · f = [L:K]` | `ramificationIndex_mul_inertiaDegree` |
+| totally ramified ⟺ Eisenstein | `isTotallyRamified_iff_exists_eisenstein_generator` |
+| local monogenicity | `exists_integerRing_adjoin_eq_top` |
+| the different and discriminant exponents | `differentExponent`, `discriminantExponent`, with `localDiscriminantIdeal` and `discriminantExponent_eq_inertiaDegree_mul_differentExponent` |
+| the tame criterion and the wild lower bound | `differentExponent_eq_ramificationIndex_sub_one_iff`, `differentExponent_bounds_of_wild` |
+| invariance under `K`-isomorphism | `differentExponent_eq_of_algEquiv`, `discriminantExponent_eq_of_algEquiv` |
+| Eisenstein power-basis orthogonality | `addVal_sum_eisenstein_powerBasis` |
+| structure on a finite intermediate-field carrier | `finiteIntermediateFieldNormedField`, `finiteIntermediateFieldValuativeRel`, `finiteIntermediateFieldTopology`, `finiteIntermediateField_valuativeExtension`, `finiteIntermediateField_isValuativeTopology`, `finiteIntermediateField_isNonarchimedeanLocalField` |
+
+`Suggested.lean` imports these and consumes them by name. Its wrappers
+`intermediateFieldIsTotallyRamified` and `intermediateFieldDiscriminantExponent` — the
+junk-tolerant totalizations that roadmap's consumer contract permits — install the adapters and
+reduce to the canonical invariants through comparison theorems; they define no ramification
+theory of their own.
 
 ### From Mathlib
 
@@ -135,12 +170,13 @@ roadmap's implementors, that is a duplicate to be deleted rather than a contribu
 ## What is missing (build here)
 
 The set `σ_K(n)` and the wild exponent as a counting weight, with its invariance under
-`K`-isomorphism; the orthogonality of a power basis at an Eisenstein generator; quantitative
-Newton lifting over a complete discrete valuation ring and the local constancy of root counts it
-yields; the lattice-index formula and the Haar scaling law over such a ring with finite residue
-field; the measure of the Eisenstein region and the parametrization it carries; and the two mass
-formulas with their finiteness, convergence and orbit-counting companions. None of this is
-upstream, and none of it is claimed by the roadmap this one consumes.
+`K`-isomorphism derived from the consumed exponent invariance; the box and cube descriptions
+that follow from the consumed power-basis orthogonality; quantitative Newton lifting over a
+complete discrete valuation ring and the local constancy of root counts it yields; the
+lattice-index formula and the Haar scaling law over such a ring with finite residue field; the
+measure of the Eisenstein region and the parametrization it carries; and the two mass formulas
+with their finiteness, convergence and orbit-counting companions. None of this is upstream, and
+none of it is claimed by the roadmap this one consumes.
 
 ---
 
@@ -152,26 +188,31 @@ The ordering is the dependency order. As each layer makes the next layer's *type
 ### Layer 0: the counting invariants
 
 - **`σ_K(n)`**, the set of subextensions of `SeparableClosure K` that are totally ramified of
-  degree `n` over `K`, built on the consumed total-ramification predicate. With the bridge lemmas
-  the count needs: `σ_K(1) = {K}`; membership is preserved by the image of any `K`-embedding into
-  `SeparableClosure K`; and every member is `K⟮x⟯` for `x` a root of an Eisenstein polynomial of
-  degree `n`, which is the consumed equivalence transported to this setting.
+  degree `n` over `K`, built on the consumed `IsTotallyRamified` through the wrapper
+  `intermediateFieldIsTotallyRamified`, which installs the consumed `finiteIntermediateField*`
+  adapters and carries the comparison theorem the consumer contract requires. With the bridge
+  lemmas the count needs: `σ_K(1) = {K}`; membership is preserved by the image of any
+  `K`-embedding into `SeparableClosure K`; and every member is `K⟮x⟯` for `x` a root of an
+  Eisenstein polynomial of degree `n`, which is the consumed
+  `isTotallyRamified_iff_exists_eisenstein_generator` transported to this setting.
 - **The wild exponent `c L := d L + 1 − n`** in truncated `ℕ`-subtraction, where `d` is the
-  consumed discriminant exponent. The consumed bounds make the truncation faithful, so `c` is
-  Serre's nonnegative integer and `c L = 0 ⟺ ¬ (ringChar 𝓀[K] ∣ n)`; state both here as the
-  corollaries of the consumed facts that they are, not as fresh developments.
+  consumed `discriminantExponent` through its wrapper `intermediateFieldDiscriminantExponent`.
+  The consumed bounds make the truncation faithful, so `c` is Serre's nonnegative integer and
+  `c L = 0 ⟺ ¬ (ringChar 𝓀[K] ∣ n)`; state both here as the corollaries of the consumed facts
+  that they are, not as fresh developments.
 - **Invariance of `c` under `K`-isomorphism.** A `K`-isomorphism carries integral bases to
   integral bases with the same discriminant, so `d`, hence `c`, is an invariant of the class.
-  ⚠ Not covered by the consumed contract, which states `d` for a fixed extension; Theorem 2 is
-  exactly a regrouping along this invariance, so it is a target here.
-- **Orthogonality of the power basis.** In the ring of integers generated by an Eisenstein
-  generator `ξ` of degree `n`, the terms of `∑_{i<n} c_i ξ^i` have pairwise distinct valuations —
-  the `i`-th is `n · addVal(c_i) + i`, distinct modulo `n` — so no cancellation is possible and
-  the valuation of the sum is the minimum of the terms'. Consequences: a ball of the ring of
-  integers is a box in power-basis coordinates, and at a radius divisible by `n` it is a cube.
-  ⚠ Also not covered by the consumed contract, which gives the monogenic basis but not the
-  valuations of a combination in it. This is the workhorse of Layers 2 and 3 and deserves its own
-  name and API.
+  The arithmetic invariance is the consumed `discriminantExponent_eq_of_algEquiv` (with
+  `differentExponent_eq_of_algEquiv` beside it); the target here is only its transport through
+  the wrapper to `wildExponent`, junk case included, which is the regrouping Theorem 2 runs
+  along.
+- **The box and cube corollaries of the power-basis orthogonality.** The consumed
+  `addVal_sum_eisenstein_powerBasis` gives, at an Eisenstein generator `ξ` of degree `n`, that
+  the terms of `∑_{i<n} c_i ξ^i` have pairwise distinct valuations — the `i`-th is
+  `n · addVal(c_i) + i`, distinct modulo `n` — so no cancellation is possible and the valuation
+  of the sum is the minimum of the terms'. The targets here are its family-level consequences: a
+  ball of the ring of integers is a box in power-basis coordinates, and at a radius divisible by
+  `n` it is a cube. These are the workhorse of Layers 2 and 3.
 
 ### Layer 1: quantitative Newton lifting over a complete discrete valuation ring
 
@@ -328,15 +369,16 @@ File map, relative to that project's `MassFormula/`:
 
 | Layer | Files |
 | --- | --- |
-| 0 | `Defs.lean`, `UniformizerParam.lean` (orthogonality), `Second.lean` (invariance of `c`) |
+| 0 | `Defs.lean`, `UniformizerParam.lean` (the box and cube corollaries), `Second.lean` (invariance of `c`) |
 | 1 | `RootLifting.lean` |
 | 2 | `HaarScaling.lean` |
 | 3 | `First.lean`, `UniformizerParam.lean` (the fibre count) |
 | 4 | `First.lean`, `Second.lean`, `Finiteness.lean`, `Convergence.lean`, `Orbit.lean` |
 
-The source's `EisensteinMonogenic.lean`, `Discriminant.lean` and `Tame.lean` prove material this
-roadmap consumes rather than owns; they are evidence that the consumed contract is provable in
-this setting, and belong with the roadmap that specifies it, not here.
+The source's `EisensteinMonogenic.lean`, `Discriminant.lean` and `Tame.lean`, and the
+orthogonality half of `UniformizerParam.lean`, prove material this roadmap consumes rather than
+owns; they are evidence that the consumed contract is provable in this setting, and belong with
+the roadmap that specifies it, not here.
 
 Where this roadmap departs from the source:
 

--- a/TauCetiRoadmap/TotallyRamified/README.md
+++ b/TauCetiRoadmap/TotallyRamified/README.md
@@ -3,9 +3,9 @@
 The [local fields and ramification roadmap](../LocalFieldsRamification/README.md) builds the
 arithmetic of a finite extension of a non-archimedean local field: total ramification, Eisenstein
 generators, monogenicity, the different and the discriminant, and the tame criterion. This
-roadmap is that theory's first counting consumer. It asks how *many* such extensions there are,
-and proves the answer — the **mass formula** of [Serre 1978]: inside a fixed separable closure,
-the totally ramified extensions of degree `n` of a local field `K` satisfy
+roadmap is that theory's counting consumer. It asks how *many* such extensions there are, and
+proves the answer — the **mass formula** of [Serre 1978]: inside a fixed separable closure, the
+totally ramified extensions of degree `n` of a local field `K` satisfy
 
 ```text
 ∑_{L ∈ σ_K(n)} q^{-c(L)} = n,          c(L) = d(L) − n + 1

--- a/TauCetiRoadmap/TotallyRamified/README.md
+++ b/TauCetiRoadmap/TotallyRamified/README.md
@@ -267,6 +267,16 @@ the same reason.
   full-measure separable locus all multiplicities are `1`. Almost everywhere on `E_n`,
   `∑_{L ∈ σ_K n} rootCount L a = n`: an Eisenstein polynomial is irreducible, and each of its `n`
   roots generates exactly one member of `σ_K n`.
+- **Almost-everywhere measurability of the root count.** For each `L ∈ σ_K n`, state
+  `AEMeasurable (fun a => (rootCount L a : ℝ≥0∞)) (μ.restrict (eisensteinSet K n))`.
+  Layer 1 makes the root count locally constant on the separable Eisenstein locus; the
+  non-separable locus is null, giving measurability for the restricted measure.
+- **Countability of the family.** For `0 < n`, state
+  `(totallyRamifiedOfDegree K n).Countable`. At the coefficient vector of an Eisenstein generator
+  of each `L`, local constancy gives an open piece of `E_n` of positive Haar measure on which
+  `rootCount L` is positive. For any finite subfamily, the sum of the root-count integrals is at
+  most `n · μ(E_n)`, by the almost-everywhere root-count identity. This finite bound forces the
+  family of positive integrals, hence `σ_K n`, to be countable, without using Theorem 1.
 - **The local fibre count** ([Serre 1978, Lemma 1]): the cube of radius `π^ρ` around an Eisenstein
   generator `ξ` contains exactly one root of each nearby Eisenstein polynomial — Layer 1 applied
   on the region.
@@ -280,8 +290,9 @@ the same reason.
 ### Layer 4: the mass formulas
 
 - **Theorem 1** ([Serre 1978, Thm. 1]): for `0 < n`, `∑' L : σ_K n, 1 / (q K) ^ c L = n` in
-  `ℝ≥0∞`. Integrate the root-count identity of Layer 3 over `E_n` and divide by the measure of the
-  region.
+  `ℝ≥0∞`. Integrate the root-count identity of Layer 3 over `E_n`, interchange the sum and
+  integral using `MeasureTheory.lintegral_tsum` with Layer 3's countability and
+  almost-everywhere measurability targets, and divide by the measure of the region.
 - **The finiteness dichotomy** ([Serre 1978, Rmk. 1°]): `σ_K n` is infinite if and only if `K` has
   equal characteristic `p` and `p ∣ n`. Both directions are targets. The forward direction follows
   from Theorem 1 together with the uniform bound `c L ≤ n · addVal(n)` outside the asserted case;

--- a/TauCetiRoadmap/TotallyRamified/Suggested.lean
+++ b/TauCetiRoadmap/TotallyRamified/Suggested.lean
@@ -1,4 +1,5 @@
 import Mathlib
+import TauCetiRoadmap.LocalFieldsRamification.Suggested
 
 /-!
 # Totally ramified extensions of a local field: target signatures
@@ -21,11 +22,20 @@ mass formula counting the totally ramified extensions of given degree ([Serre 19
 ⚠ **The ramification-theoretic substrate is consumed, not built here.** Total ramification,
 Eisenstein generators, monogenicity, the different and the discriminant, the exponent `d`, and
 the tame criterion are targets of the *local fields and ramification* roadmap
-(`../LocalFieldsRamification/README.md`). The `def`s below marked *consumed* record the shape this
-roadmap needs them in, so that its own statements are expressible before that roadmap lands; when
-it lands they are deleted here and its definitions are used instead. Do not treat them as targets.
+(`../LocalFieldsRamification/README.md`), imported above and used by exact name:
+`LocalFieldsRamification.IsTotallyRamified` (with `isTotallyRamified_iff_inertiaDegree_eq_one`
+and `isTotallyRamified_iff_exists_eisenstein_generator`), `exists_integerRing_adjoin_eq_top`,
+`differentExponent` and `discriminantExponent` with their invariance theorems
+`differentExponent_eq_of_algEquiv` and `discriminantExponent_eq_of_algEquiv`,
+`addVal_sum_eisenstein_powerBasis`, and the intermediate-field structure adapters
+`finiteIntermediateFieldNormedField` / `finiteIntermediateFieldValuativeRel` /
+`finiteIntermediateFieldTopology` with the three compatibility theorems beside them. The
+junk-tolerant wrappers below install those adapters and reduce to those declarations through
+comparison theorems, as that roadmap's consumer contract prescribes; no ramification-theoretic
+notion is defined independently here.
 
-This file pins the roadmap's load-bearing **definitions** (`residueCard`,
+This file pins the roadmap's load-bearing **definitions** (`residueCard`, the consumed-substrate
+wrappers `intermediateFieldIsTotallyRamified` and `intermediateFieldDiscriminantExponent`,
 `totallyRamifiedOfDegree`, `wildExponent`, `IsRepresentativeSet`, and the coefficient-space
 objects `toPoly`, `eisensteinSet`, `integerBox`) and its **named milestones** as `sorry`-targets
 (`sorry` is allowed in this human-owned roadmap library — these are goals, not proofs).
@@ -52,9 +62,12 @@ variable (K : Type*) [Field K] [ValuativeRel K] [UniformSpace K] [IsUniformAddGr
 
 /-! ## Layer 0: the counting invariants
 
-`maximalIdealAbove`, `ramificationIdx`, `IsTotallyRamified`, `discriminantIdeal` and
-`discExponent` are *consumed* shapes (see the header): the local fields and ramification roadmap
-owns total ramification, the discriminant, and its exponent. `residueCard`,
+The ramification-theoretic substrate is imported (see the header): total ramification and the
+discriminant exponent are `LocalFieldsRamification.IsTotallyRamified` and
+`LocalFieldsRamification.discriminantExponent`. The wrappers
+`intermediateFieldIsTotallyRamified` and `intermediateFieldDiscriminantExponent` totalize them
+over arbitrary subextensions by installing the consumed `finiteIntermediateField*` adapters, and
+each carries the comparison theorem the consumer contract requires. `residueCard`,
 `totallyRamifiedOfDegree`, `wildExponent` and `IsRepresentativeSet` are this roadmap's own. -/
 
 /-- The residue cardinality of a non-archimedean local field — Serre's `q`. -/
@@ -63,49 +76,105 @@ noncomputable def residueCard : ℕ :=
 
 variable {K}
 
-/-- The maximal ideal of the ring of integers of a subextension `L` of `SeparableClosure K` / `K`,
-described instance-freely as the radical of `𝓂[K]` extended along the structure map. For `L / K`
-finite this is the maximal ideal of the local ring `integralClosure ↥𝒪[K] ↥L`; the definition
-itself carries no such obligation, and is junk for `L` infinite over `K`. -/
-noncomputable def maximalIdealAbove (L : IntermediateField K (SeparableClosure K)) :
-    Ideal ↥(integralClosure ↥𝒪[K] ↥L) :=
-  (Ideal.map (algebraMap ↥𝒪[K] ↥(integralClosure ↥𝒪[K] ↥L)) 𝓂[K]).radical
+/-- Total ramification for a subextension `L` of `SeparableClosure K` / `K`: the consumed
+`LocalFieldsRamification.IsTotallyRamified`, totalized over an arbitrary `L` by existentially
+quantifying finiteness and installing the consumed `finiteIntermediateField*` structures. For `L`
+infinite over `K` this is `False` — junk in the direction the count tolerates. No independent
+total-ramification predicate is defined here; the residue-degree and Eisenstein characterizations
+are the consumed `isTotallyRamified_iff_inertiaDegree_eq_one` and
+`isTotallyRamified_iff_exists_eisenstein_generator`. -/
+def intermediateFieldIsTotallyRamified (L : IntermediateField K (SeparableClosure K)) : Prop :=
+  ∃ hfin : Module.Finite K ↥L,
+    haveI := hfin
+    letI : ValuativeRel ↥L :=
+      LocalFieldsRamification.finiteIntermediateFieldValuativeRel K (SeparableClosure K) L
+    letI : TopologicalSpace ↥L :=
+      LocalFieldsRamification.finiteIntermediateFieldTopology K (SeparableClosure K) L
+    haveI : IsNonarchimedeanLocalField ↥L :=
+      LocalFieldsRamification.finiteIntermediateField_isNonarchimedeanLocalField K
+        (SeparableClosure K) L
+    haveI : ValuativeExtension K ↥L :=
+      LocalFieldsRamification.finiteIntermediateField_valuativeExtension K (SeparableClosure K) L
+    LocalFieldsRamification.IsTotallyRamified K ↥L
 
-/-- The ramification index of a subextension `L` / `K`, through Mathlib's junk-tolerant
-`Ideal.ramificationIdx'`. -/
-noncomputable def ramificationIdx (L : IntermediateField K (SeparableClosure K)) : ℕ :=
-  Ideal.ramificationIdx' 𝓂[K] (maximalIdealAbove L)
-
-/-- `L / K` is *totally ramified* when its ramification index equals its degree. -/
-def IsTotallyRamified (L : IntermediateField K (SeparableClosure K)) : Prop :=
-  ramificationIdx L = Module.finrank K ↥L
+omit [IsUniformAddGroup K] in
+/-- The comparison theorem the consumer contract requires: on a finite subextension the wrapper
+is exactly the consumed predicate at the consumed adapter structures. A closed proof, so the
+contract is type-checked rather than promised. -/
+theorem intermediateFieldIsTotallyRamified_iff (L : IntermediateField K (SeparableClosure K))
+    [hfin : Module.Finite K ↥L] :
+    intermediateFieldIsTotallyRamified L ↔
+      (letI : ValuativeRel ↥L :=
+        LocalFieldsRamification.finiteIntermediateFieldValuativeRel K (SeparableClosure K) L
+      letI : TopologicalSpace ↥L :=
+        LocalFieldsRamification.finiteIntermediateFieldTopology K (SeparableClosure K) L
+      haveI : IsNonarchimedeanLocalField ↥L :=
+        LocalFieldsRamification.finiteIntermediateField_isNonarchimedeanLocalField K
+          (SeparableClosure K) L
+      haveI : ValuativeExtension K ↥L :=
+        LocalFieldsRamification.finiteIntermediateField_valuativeExtension K
+          (SeparableClosure K) L
+      LocalFieldsRamification.IsTotallyRamified K ↥L) :=
+  ⟨fun ⟨_, h⟩ => h, fun h => ⟨hfin, h⟩⟩
 
 variable (K)
 
 /-- Serre's `σ_K(n)`: the subextensions of `SeparableClosure K` that are totally ramified of
 degree `n` over `K`. -/
 def totallyRamifiedOfDegree (n : ℕ) : Set (IntermediateField K (SeparableClosure K)) :=
-  {L | Module.finrank K ↥L = n ∧ IsTotallyRamified L}
+  {L | Module.finrank K ↥L = n ∧ intermediateFieldIsTotallyRamified L}
 
 variable {K}
 
-/-- The discriminant ideal of a subextension: the ideal of `𝒪[K]` generated by the elements whose
-image in `K` is `Algebra.discr K b` for a `K`-basis `b` of `L` with integral entries. In the finite
-separable case this is the classical discriminant ideal; the span form needs neither freeness nor
-Dedekind-domain instances, and is `⊥` — junk — for `L` infinite over `K`. -/
-noncomputable def discriminantIdeal (L : IntermediateField K (SeparableClosure K)) :
-    Ideal ↥𝒪[K] :=
-  Ideal.span {x : ↥𝒪[K] | ∃ b : Module.Basis (Fin (Module.finrank K ↥L)) K ↥L,
-    (∀ i, IsIntegral 𝒪[K] (b i)) ∧ algebraMap 𝒪[K] K x = Algebra.discr K ⇑b}
+open scoped Classical in
+/-- The discriminant exponent `d L` of a subextension: the consumed
+`LocalFieldsRamification.discriminantExponent`, totalized over an arbitrary `L` by installing the
+consumed `finiteIntermediateField*` structures on the finite branch, with junk value `0` for `L`
+infinite over `K`. No independent different, discriminant ideal, or exponent is defined here; the
+consumed `localDiscriminantIdeal`, `differentExponent` and
+`discriminantExponent_eq_inertiaDegree_mul_differentExponent` relate this exponent to the
+different. -/
+noncomputable def intermediateFieldDiscriminantExponent
+    (L : IntermediateField K (SeparableClosure K)) : ℕ :=
+  if hfin : Module.Finite K ↥L then
+    haveI := hfin
+    letI : ValuativeRel ↥L :=
+      LocalFieldsRamification.finiteIntermediateFieldValuativeRel K (SeparableClosure K) L
+    letI : TopologicalSpace ↥L :=
+      LocalFieldsRamification.finiteIntermediateFieldTopology K (SeparableClosure K) L
+    haveI : IsNonarchimedeanLocalField ↥L :=
+      LocalFieldsRamification.finiteIntermediateField_isNonarchimedeanLocalField K
+        (SeparableClosure K) L
+    haveI : ValuativeExtension K ↥L :=
+      LocalFieldsRamification.finiteIntermediateField_valuativeExtension K (SeparableClosure K) L
+    LocalFieldsRamification.discriminantExponent K ↥L
+  else 0
 
-/-- The discriminant exponent `d L`: the multiplicity of `𝓂[K]` in `discriminantIdeal L`. -/
-noncomputable def discExponent (L : IntermediateField K (SeparableClosure K)) : ℕ :=
-  multiplicity 𝓂[K] (discriminantIdeal L)
+omit [IsUniformAddGroup K] in
+/-- The comparison theorem the consumer contract requires: on a finite subextension the wrapper
+is exactly the consumed exponent at the consumed adapter structures. A closed proof, so the
+contract is type-checked rather than promised. -/
+theorem intermediateFieldDiscriminantExponent_eq (L : IntermediateField K (SeparableClosure K))
+    [hfin : Module.Finite K ↥L] :
+    intermediateFieldDiscriminantExponent L =
+      (letI : ValuativeRel ↥L :=
+        LocalFieldsRamification.finiteIntermediateFieldValuativeRel K (SeparableClosure K) L
+      letI : TopologicalSpace ↥L :=
+        LocalFieldsRamification.finiteIntermediateFieldTopology K (SeparableClosure K) L
+      haveI : IsNonarchimedeanLocalField ↥L :=
+        LocalFieldsRamification.finiteIntermediateField_isNonarchimedeanLocalField K
+          (SeparableClosure K) L
+      haveI : ValuativeExtension K ↥L :=
+        LocalFieldsRamification.finiteIntermediateField_valuativeExtension K
+          (SeparableClosure K) L
+      LocalFieldsRamification.discriminantExponent K ↥L) :=
+  dite_eq_left hfin
 
-/-- The wild exponent `c L = d L − n + 1`, in the truncation-safe form `d L + 1 − n`. The bound
-`n − 1 ≤ d L` that makes the truncated subtraction faithful is `sub_one_le_discExponent`. -/
+/-- The wild exponent `c L = d L − n + 1`, in the truncation-safe form `d L + 1 − n`, over the
+consumed discriminant exponent through its wrapper. The bound `n − 1 ≤ d L` that makes the
+truncated subtraction faithful is `sub_one_le_intermediateFieldDiscriminantExponent`. -/
 noncomputable def wildExponent (L : IntermediateField K (SeparableClosure K)) : ℕ :=
-  discExponent L + 1 - Module.finrank K ↥L
+  intermediateFieldDiscriminantExponent L + 1 - Module.finrank K ↥L
 
 /-- Serre's "set of representatives of the isomorphism classes", as a predicate rather than a
 quotient: `R` consists of members of `totallyRamifiedOfDegree K n`, and every member is
@@ -115,13 +184,14 @@ def IsRepresentativeSet (n : ℕ) (R : Set (IntermediateField K (SeparableClosur
     ∀ L ∈ totallyRamifiedOfDegree K n, ∃! M, M ∈ R ∧ Nonempty (↥L ≃ₐ[K] ↥M)
 
 /- Eisenstein monogenicity ([Serre 1979, Chap. I, §6, Prop. 17]) and the statement that an
-Eisenstein root generates a totally ramified extension are milestones of the *local fields and
-ramification* roadmap, not of this one, and are deliberately not restated here. -/
+Eisenstein root generates a totally ramified extension are the consumed
+`exists_integerRing_adjoin_eq_top` and `isTotallyRamified_iff_exists_eisenstein_generator`, and
+are deliberately not restated here. -/
 
 /-- The **bridge**, and the target that turns a statement about `totallyRamifiedOfDegree K n` into
-a computation: the consumed equivalence "totally ramified ⟺ Eisenstein", transported into
-`IntermediateField K (SeparableClosure K)` and packaged with the degree, which is the form every
-later layer applies. -/
+a computation: the consumed equivalence `isTotallyRamified_iff_exists_eisenstein_generator`,
+transported into `IntermediateField K (SeparableClosure K)` and packaged with the degree, which is
+the form every later layer applies. -/
 theorem exists_eisenstein_generator (n : ℕ) (hn : 0 < n)
     (L : IntermediateField K (SeparableClosure K)) (hL : L ∈ totallyRamifiedOfDegree K n) :
     ∃ (x : SeparableClosure K) (π : ↥𝒪[K]), Irreducible π ∧ IsIntegral 𝒪[K] x ∧
@@ -133,16 +203,19 @@ variable (K)
 
 /-- `c L` is a nonnegative integer ([Serre 1978, p.1031, footnote 1]): in the `ℕ`-model, the bound
 `n − 1 ≤ d L`, which is what makes the truncated subtraction defining `wildExponent` faithful.
-This is a **corollary of the consumed contract** — the tame equality `d = e − 1` together with the
-wild lower bound `e ≤ d` — restated here in the form the count applies, not a fresh development. -/
-theorem sub_one_le_discExponent (n : ℕ) (hn : 0 < n)
+This is a **corollary of the consumed contract** — the tame equality
+`differentExponent_eq_ramificationIndex_sub_one_iff` together with the wild lower bound of
+`differentExponent_bounds_of_wild` — restated here in the form the count applies, not a fresh
+development. -/
+theorem sub_one_le_intermediateFieldDiscriminantExponent (n : ℕ) (hn : 0 < n)
     (L : IntermediateField K (SeparableClosure K)) (hL : L ∈ totallyRamifiedOfDegree K n) :
-    n - 1 ≤ discExponent L :=
+    n - 1 ≤ intermediateFieldDiscriminantExponent L :=
   sorry
 
 /-- **The tame criterion, as the count uses it** ([Serre 1978, p.1031]): `c L = 0` exactly when `n`
-is prime to the residue characteristic. Again a corollary of the consumed `d = e − 1 ⟺ tame`,
-rephrased in terms of `c`; the ramification-theoretic content belongs to that roadmap. -/
+is prime to the residue characteristic. Again a corollary of the consumed
+`differentExponent_eq_ramificationIndex_sub_one_iff`, rephrased in terms of `c`; the
+ramification-theoretic content belongs to that roadmap. -/
 theorem wildExponent_eq_zero_iff (n : ℕ) (hn : 0 < n)
     (L : IntermediateField K (SeparableClosure K)) (hL : L ∈ totallyRamifiedOfDegree K n) :
     wildExponent L = 0 ↔ ¬ ringChar 𝓀[K] ∣ n :=
@@ -151,14 +224,19 @@ theorem wildExponent_eq_zero_iff (n : ℕ) (hn : 0 < n)
 variable {K}
 
 /-- `d`, hence `c`, is an invariant of the `K`-isomorphism class — the fact along which Theorem 1
-is regrouped into Theorem 2. -/
-theorem discExponent_eq_of_algEquiv {L M : IntermediateField K (SeparableClosure K)}
-    (e : ↥L ≃ₐ[K] ↥M) : discExponent L = discExponent M :=
+is regrouped into Theorem 2. The arithmetic invariance is the consumed
+`discriminantExponent_eq_of_algEquiv` (with `differentExponent_eq_of_algEquiv` beside it); the
+target here is only its transport through the wrapper, junk case included. -/
+theorem intermediateFieldDiscriminantExponent_eq_of_algEquiv
+    {L M : IntermediateField K (SeparableClosure K)} (e : ↥L ≃ₐ[K] ↥M) :
+    intermediateFieldDiscriminantExponent L = intermediateFieldDiscriminantExponent M :=
   sorry
 
 /- **The comparison with the different** ([Serre 1979, Chap. III, §3]) — the discriminant ideal is
-the relative norm of Mathlib's `differentIdeal` — belongs to the *local fields and ramification*
-roadmap, which owns the different and the discriminant alike, and is not a target here. -/
+the relative norm of Mathlib's `differentIdeal` — is the consumed `localDiscriminantIdeal` with
+`discriminantExponent_eq_inertiaDegree_mul_differentExponent`, owned by the *local fields and
+ramification* roadmap, which owns the different and the discriminant alike; it is not a target
+here. -/
 
 /-! ## Layer 1: quantitative Newton lifting over a complete discrete valuation ring
 
@@ -267,7 +345,8 @@ theorem lintegral_rootCount (n : ℕ) (hn : 0 < n)
     (μ : MeasureTheory.Measure (Fin n → K)) [μ.IsAddHaarMeasure] (hμ : μ (integerBox K n) = 1)
     (L : IntermediateField K (SeparableClosure K)) (hL : L ∈ totallyRamifiedOfDegree K n) :
     ∫⁻ a in eisensteinSet K n, (rootCount L a : ℝ≥0∞) ∂μ =
-      (residueCard K : ℝ≥0∞)⁻¹ ^ (discExponent L + 1) * (1 - (residueCard K : ℝ≥0∞)⁻¹) :=
+      (residueCard K : ℝ≥0∞)⁻¹ ^ (intermediateFieldDiscriminantExponent L + 1) *
+        (1 - (residueCard K : ℝ≥0∞)⁻¹) :=
   sorry
 
 /-! ## Layer 4: the mass formulas -/

--- a/TauCetiRoadmap/TotallyRamified/Suggested.lean
+++ b/TauCetiRoadmap/TotallyRamified/Suggested.lean
@@ -1,0 +1,315 @@
+import Mathlib
+
+/-!
+# Totally ramified extensions of a local field: target signatures
+
+**This file is not the roadmap and is not exhaustive.** The definitive document is
+`README.md`. The statements here suggest Lean forms for particular milestones, so that
+contributors and reviewers converge on names and signatures; discharging all of them
+finishes neither a layer nor the roadmap.
+
+The narrative roadmap (the standing conventions, the consumed contract, the layer-by-layer build
+plan Layers 0–4, the worked examples, and the references) is in `README.md`. Mathlib has the local
+field itself — `IsNonarchimedeanLocalField` (`Mathlib/NumberTheory/LocalField/Basic.lean`), with
+`𝒪[K]` a complete discrete valuation ring, `𝓀[K]` finite, and `IsAdicComplete 𝓂[K] 𝒪[K]` all
+available by `inferInstance` — together with Eisenstein polynomials, `Algebra.discr`,
+`differentIdeal`, `Ideal.ramificationIdx'`, `HenselianLocalRing`, and Haar measure on a locally
+compact group. It has **no** quantitative Newton estimate (only qualitative Hensel), **no**
+non-archimedean analogue of `Measure.addHaar_image_linearMap`, and — the ultimate target — **no**
+mass formula counting the totally ramified extensions of given degree ([Serre 1978]).
+
+⚠ **The ramification-theoretic substrate is consumed, not built here.** Total ramification,
+Eisenstein generators, monogenicity, the different and the discriminant, the exponent `d`, and
+the tame criterion are targets of the *local fields and ramification* roadmap
+(`../LocalFieldsRamification/README.md`). The `def`s below marked *consumed* record the shape this
+roadmap needs them in, so that its own statements are expressible before that roadmap lands; when
+it lands they are deleted here and its definitions are used instead. Do not treat them as targets.
+
+This file pins the roadmap's load-bearing **definitions** (`residueCard`,
+`totallyRamifiedOfDegree`, `wildExponent`, `IsRepresentativeSet`, and the coefficient-space
+objects `toPoly`, `eisensteinSet`, `integerBox`) and its **named milestones** as `sorry`-targets
+(`sorry` is allowed in this human-owned roadmap library — these are goals, not proofs).
+
+⚠ The definitions are **junk-tolerant on purpose**: for `L` infinite over `K`, or for `n = 0`,
+they take junk values. That is why every milestone carries `0 < n` and membership in
+`totallyRamifiedOfDegree K n`. Do not repair the junk by adding finiteness hypotheses to the
+definitions.
+
+Two layers are stated over an arbitrary complete discrete valuation ring rather than over a local
+field, because that is the generality their proofs have: `exists_isRoot` and `card_aroots_eq`
+(Layer 1, `TauCeti/RingTheory/DiscreteValuationRing/`) and `card_quotient_range` (Layer 2,
+`TauCeti/MeasureTheory/Group/`). Everything else belongs in
+`TauCeti/NumberTheory/LocalField/MassFormula/`.
+-/
+
+open ValuativeRel
+open scoped ENNReal
+
+namespace TauCetiRoadmap.TotallyRamified
+
+variable (K : Type*) [Field K] [ValuativeRel K] [UniformSpace K] [IsUniformAddGroup K]
+  [IsNonarchimedeanLocalField K]
+
+/-! ## Layer 0: the counting invariants
+
+`maximalIdealAbove`, `ramificationIdx`, `IsTotallyRamified`, `discriminantIdeal` and
+`discExponent` are *consumed* shapes (see the header): the local fields and ramification roadmap
+owns total ramification, the discriminant, and its exponent. `residueCard`,
+`totallyRamifiedOfDegree`, `wildExponent` and `IsRepresentativeSet` are this roadmap's own. -/
+
+/-- The residue cardinality of a non-archimedean local field — Serre's `q`. -/
+noncomputable def residueCard : ℕ :=
+  Nat.card 𝓀[K]
+
+variable {K}
+
+/-- The maximal ideal of the ring of integers of a subextension `L` of `SeparableClosure K` / `K`,
+described instance-freely as the radical of `𝓂[K]` extended along the structure map. For `L / K`
+finite this is the maximal ideal of the local ring `integralClosure ↥𝒪[K] ↥L`; the definition
+itself carries no such obligation, and is junk for `L` infinite over `K`. -/
+noncomputable def maximalIdealAbove (L : IntermediateField K (SeparableClosure K)) :
+    Ideal ↥(integralClosure ↥𝒪[K] ↥L) :=
+  (Ideal.map (algebraMap ↥𝒪[K] ↥(integralClosure ↥𝒪[K] ↥L)) 𝓂[K]).radical
+
+/-- The ramification index of a subextension `L` / `K`, through Mathlib's junk-tolerant
+`Ideal.ramificationIdx'`. -/
+noncomputable def ramificationIdx (L : IntermediateField K (SeparableClosure K)) : ℕ :=
+  Ideal.ramificationIdx' 𝓂[K] (maximalIdealAbove L)
+
+/-- `L / K` is *totally ramified* when its ramification index equals its degree. -/
+def IsTotallyRamified (L : IntermediateField K (SeparableClosure K)) : Prop :=
+  ramificationIdx L = Module.finrank K ↥L
+
+variable (K)
+
+/-- Serre's `σ_K(n)`: the subextensions of `SeparableClosure K` that are totally ramified of
+degree `n` over `K`. -/
+def totallyRamifiedOfDegree (n : ℕ) : Set (IntermediateField K (SeparableClosure K)) :=
+  {L | Module.finrank K ↥L = n ∧ IsTotallyRamified L}
+
+variable {K}
+
+/-- The discriminant ideal of a subextension: the ideal of `𝒪[K]` generated by the elements whose
+image in `K` is `Algebra.discr K b` for a `K`-basis `b` of `L` with integral entries. In the finite
+separable case this is the classical discriminant ideal; the span form needs neither freeness nor
+Dedekind-domain instances, and is `⊥` — junk — for `L` infinite over `K`. -/
+noncomputable def discriminantIdeal (L : IntermediateField K (SeparableClosure K)) :
+    Ideal ↥𝒪[K] :=
+  Ideal.span {x : ↥𝒪[K] | ∃ b : Module.Basis (Fin (Module.finrank K ↥L)) K ↥L,
+    (∀ i, IsIntegral 𝒪[K] (b i)) ∧ algebraMap 𝒪[K] K x = Algebra.discr K ⇑b}
+
+/-- The discriminant exponent `d L`: the multiplicity of `𝓂[K]` in `discriminantIdeal L`. -/
+noncomputable def discExponent (L : IntermediateField K (SeparableClosure K)) : ℕ :=
+  multiplicity 𝓂[K] (discriminantIdeal L)
+
+/-- The wild exponent `c L = d L − n + 1`, in the truncation-safe form `d L + 1 − n`. The bound
+`n − 1 ≤ d L` that makes the truncated subtraction faithful is `sub_one_le_discExponent`. -/
+noncomputable def wildExponent (L : IntermediateField K (SeparableClosure K)) : ℕ :=
+  discExponent L + 1 - Module.finrank K ↥L
+
+/-- Serre's "set of representatives of the isomorphism classes", as a predicate rather than a
+quotient: `R` consists of members of `totallyRamifiedOfDegree K n`, and every member is
+`K`-isomorphic to exactly one element of `R`. -/
+def IsRepresentativeSet (n : ℕ) (R : Set (IntermediateField K (SeparableClosure K))) : Prop :=
+  R ⊆ totallyRamifiedOfDegree K n ∧
+    ∀ L ∈ totallyRamifiedOfDegree K n, ∃! M, M ∈ R ∧ Nonempty (↥L ≃ₐ[K] ↥M)
+
+/- Eisenstein monogenicity ([Serre 1979, Chap. I, §6, Prop. 17]) and the statement that an
+Eisenstein root generates a totally ramified extension are milestones of the *local fields and
+ramification* roadmap, not of this one, and are deliberately not restated here. -/
+
+/-- The **bridge**, and the target that turns a statement about `totallyRamifiedOfDegree K n` into
+a computation: the consumed equivalence "totally ramified ⟺ Eisenstein", transported into
+`IntermediateField K (SeparableClosure K)` and packaged with the degree, which is the form every
+later layer applies. -/
+theorem exists_eisenstein_generator (n : ℕ) (hn : 0 < n)
+    (L : IntermediateField K (SeparableClosure K)) (hL : L ∈ totallyRamifiedOfDegree K n) :
+    ∃ (x : SeparableClosure K) (π : ↥𝒪[K]), Irreducible π ∧ IsIntegral 𝒪[K] x ∧
+      (minpoly 𝒪[K] x).IsEisensteinAt (Submodule.span 𝒪[K] {π}) ∧
+      IntermediateField.adjoin K {x} = L ∧ (minpoly 𝒪[K] x).natDegree = n :=
+  sorry
+
+variable (K)
+
+/-- `c L` is a nonnegative integer ([Serre 1978, p.1031, footnote 1]): in the `ℕ`-model, the bound
+`n − 1 ≤ d L`, which is what makes the truncated subtraction defining `wildExponent` faithful.
+This is a **corollary of the consumed contract** — the tame equality `d = e − 1` together with the
+wild lower bound `e ≤ d` — restated here in the form the count applies, not a fresh development. -/
+theorem sub_one_le_discExponent (n : ℕ) (hn : 0 < n)
+    (L : IntermediateField K (SeparableClosure K)) (hL : L ∈ totallyRamifiedOfDegree K n) :
+    n - 1 ≤ discExponent L :=
+  sorry
+
+/-- **The tame criterion, as the count uses it** ([Serre 1978, p.1031]): `c L = 0` exactly when `n`
+is prime to the residue characteristic. Again a corollary of the consumed `d = e − 1 ⟺ tame`,
+rephrased in terms of `c`; the ramification-theoretic content belongs to that roadmap. -/
+theorem wildExponent_eq_zero_iff (n : ℕ) (hn : 0 < n)
+    (L : IntermediateField K (SeparableClosure K)) (hL : L ∈ totallyRamifiedOfDegree K n) :
+    wildExponent L = 0 ↔ ¬ ringChar 𝓀[K] ∣ n :=
+  sorry
+
+variable {K}
+
+/-- `d`, hence `c`, is an invariant of the `K`-isomorphism class — the fact along which Theorem 1
+is regrouped into Theorem 2. -/
+theorem discExponent_eq_of_algEquiv {L M : IntermediateField K (SeparableClosure K)}
+    (e : ↥L ≃ₐ[K] ↥M) : discExponent L = discExponent M :=
+  sorry
+
+/- **The comparison with the different** ([Serre 1979, Chap. III, §3]) — the discriminant ideal is
+the relative norm of Mathlib's `differentIdeal` — belongs to the *local fields and ramification*
+roadmap, which owns the different and the discriminant alike, and is not a target here. -/
+
+/-! ## Layer 1: quantitative Newton lifting over a complete discrete valuation ring
+
+Stated for an arbitrary complete discrete valuation ring; the local-field case is an instance.
+This strictly refines Mathlib's `HenselianLocalRing`, which lifts a simple root modulo the maximal
+ideal and gives no distance bound. -/
+
+/-- **Newton iteration with an estimate.** If the order of `F` at `y₀` exceeds twice that of its
+derivative, the iteration converges to a root `z` whose distance to `y₀` has order at least the
+difference. Uniqueness of the root in that ball is a companion target. -/
+theorem exists_isRoot {A : Type*} [CommRing A] [IsDomain A] [IsDiscreteValuationRing A]
+    [IsAdicComplete (IsLocalRing.maximalIdeal A) A] (F : Polynomial A) (y₀ : A)
+    (hlt : IsDiscreteValuationRing.addVal A (Polynomial.eval y₀ (Polynomial.derivative F)) +
+        IsDiscreteValuationRing.addVal A (Polynomial.eval y₀ (Polynomial.derivative F)) <
+      IsDiscreteValuationRing.addVal A (Polynomial.eval y₀ F)) :
+    ∃ z : A, F.IsRoot z ∧
+      IsDiscreteValuationRing.addVal A (Polynomial.eval y₀ F) ≤
+        IsDiscreteValuationRing.addVal A (Polynomial.eval y₀ (Polynomial.derivative F)) +
+          IsDiscreteValuationRing.addVal A (z - y₀) :=
+  sorry
+
+/-- **Local constancy of the root count**, the form Layer 3 consumes: for a monic `f` over `𝒪[K]`,
+separable over `K`, coefficientwise closeness forces equality of root counts in every member of
+`totallyRamifiedOfDegree K n`. -/
+theorem card_aroots_eq (n : ℕ) (hn : 0 < n) (L : IntermediateField K (SeparableClosure K))
+    (hL : L ∈ totallyRamifiedOfDegree K n) {f : Polynomial ↥𝒪[K]} (hfm : f.Monic)
+    (hfsep : (f.map (algebraMap ↥𝒪[K] K)).Separable) :
+    ∃ T : ℕ, 0 < T ∧ ∀ g : Polynomial ↥𝒪[K], g.Monic →
+      (∀ i, g.coeff i - f.coeff i ∈ 𝓂[K] ^ T) →
+      ((g.map (algebraMap ↥𝒪[K] K)).aroots ↥L).card =
+        ((f.map (algebraMap ↥𝒪[K] K)).aroots ↥L).card :=
+  sorry
+
+/-! ## Layer 2: the lattice index and the Haar scaling law
+
+Also stated over an arbitrary complete discrete valuation ring, with finite residue field. -/
+
+/-- **The index of an image lattice.** For an integral matrix whose determinant is associated to
+`π ^ k`, the integer box modulo its image has exactly `q ^ k` elements — Smith normal form over the
+principal ideal ring `A`. This is the arithmetic half of the scaling law; the measure-theoretic
+half (`μ (M · S) = q ^ (−k) · μ S` for the box and for balls, the non-archimedean analogue of
+`Measure.addHaar_image_linearMap`) is the other Layer-2 target. -/
+theorem card_quotient_range {A : Type*} [CommRing A] [IsDomain A] [IsDiscreteValuationRing A]
+    [Finite (IsLocalRing.ResidueField A)] {n : ℕ} (M : Matrix (Fin n) (Fin n) A)
+    (hdet : M.det ≠ 0) {π : A} (hπ : Irreducible π) {k : ℕ} (hk : Associated M.det (π ^ k)) :
+    Nat.card ((Fin n → A) ⧸ LinearMap.range (Matrix.mulVecLin M)) =
+      Nat.card (IsLocalRing.ResidueField A) ^ k :=
+  sorry
+
+/-! ## Layer 3: the coefficient space, the Eisenstein region, and its measure -/
+
+variable (K)
+
+/-- A monic polynomial of degree `n` *is* its coefficient vector, with `a i` the coefficient of
+`X ^ i`. -/
+noncomputable def toPoly {n : ℕ} (a : Fin n → K) : Polynomial K :=
+  Polynomial.X ^ n + ∑ i : Fin n, Polynomial.C (a i) * Polynomial.X ^ (i : ℕ)
+
+/-- The Eisenstein region ([Serre 1978, eq. (1)]): every coefficient in the open unit ball, with
+the constant term of the largest valuation below `1` — that of a uniformizer. -/
+def eisensteinSet (n : ℕ) : Set (Fin n → K) :=
+  {a | (∀ i, valuation K (a i) < 1) ∧
+    ∀ y : K, valuation K y < 1 → valuation K y ≤ valuation K ((toPoly K a).coeff 0)}
+
+/-- The integer box of the coefficient space: the set on which the measure is normalized. It is
+compact with nonempty interior, so `Measure.addHaarMeasure` on it is the paper's measure; the
+statements below take the normalization as a hypothesis instead, which keeps them free of a
+bespoke measure definition. -/
+def integerBox (n : ℕ) : Set (Fin n → K) :=
+  Set.univ.pi fun _ => (𝒪[K] : Set K)
+
+/-- **The measure of the Eisenstein region** is `q ^ (−n) · (1 − q ^ (−1))` — the normalization
+check that catches a misnormalized Haar measure long before the summit. -/
+theorem measure_eisensteinSet (n : ℕ) (hn : 0 < n)
+    [MeasurableSpace (Fin n → K)] [BorelSpace (Fin n → K)]
+    (μ : MeasureTheory.Measure (Fin n → K)) [μ.IsAddHaarMeasure] (hμ : μ (integerBox K n) = 1) :
+    μ (eisensteinSet K n) =
+      (residueCard K : ℝ≥0∞)⁻¹ ^ n * (1 - (residueCard K : ℝ≥0∞)⁻¹) :=
+  sorry
+
+variable {K}
+
+/-- The root count of Lemma 1: the number of roots of `toPoly a` lying in `L`, with multiplicity.
+On the full-measure separable locus every multiplicity is `1`. -/
+noncomputable def rootCount (L : IntermediateField K (SeparableClosure K)) {n : ℕ}
+    (a : Fin n → K) : ℕ :=
+  ((toPoly K a).aroots ↥L).card
+
+variable (K)
+
+/-- Almost everywhere on the Eisenstein region, the root counts over
+`totallyRamifiedOfDegree K n` sum to `n`: an Eisenstein polynomial is irreducible, and each of its
+`n` roots generates exactly one member. -/
+theorem tsum_rootCount (n : ℕ) (hn : 0 < n)
+    [MeasurableSpace (Fin n → K)] [BorelSpace (Fin n → K)]
+    (μ : MeasureTheory.Measure (Fin n → K)) [μ.IsAddHaarMeasure] (hμ : μ (integerBox K n) = 1) :
+    ∀ᵐ a ∂μ.restrict (eisensteinSet K n),
+      ∑' L : totallyRamifiedOfDegree K n, (rootCount L.1 a : ℝ≥0∞) = n :=
+  sorry
+
+/-- **The integral of the root count** ([Serre 1978, Lemmas 2 and 3, eqs. (5)–(13)]): the change of
+variables in power-basis coordinates, with Layer 2 supplying the factor `q ^ (−d L)`. Summing this
+over `L` against `tsum_rootCount` is Theorem 1. -/
+theorem lintegral_rootCount (n : ℕ) (hn : 0 < n)
+    [MeasurableSpace (Fin n → K)] [BorelSpace (Fin n → K)]
+    (μ : MeasureTheory.Measure (Fin n → K)) [μ.IsAddHaarMeasure] (hμ : μ (integerBox K n) = 1)
+    (L : IntermediateField K (SeparableClosure K)) (hL : L ∈ totallyRamifiedOfDegree K n) :
+    ∫⁻ a in eisensteinSet K n, (rootCount L a : ℝ≥0∞) ∂μ =
+      (residueCard K : ℝ≥0∞)⁻¹ ^ (discExponent L + 1) * (1 - (residueCard K : ℝ≥0∞)⁻¹) :=
+  sorry
+
+/-! ## Layer 4: the mass formulas -/
+
+/-- **Theorem 1, the first mass formula** ([Serre 1978, Thm. 1]). -/
+theorem tsum_one_div_residueCard_pow_wildExponent (n : ℕ) (hn : 0 < n) :
+    ∑' L : totallyRamifiedOfDegree K n, 1 / (residueCard K : ℝ≥0∞) ^ wildExponent L.1 = n :=
+  sorry
+
+/-- **The finiteness dichotomy** ([Serre 1978, Rmk. 1°]): infinite exactly in equal characteristic
+`p` with `p ∣ n`. -/
+theorem totallyRamifiedOfDegree_infinite_iff (n : ℕ) (hn : 0 < n) :
+    (totallyRamifiedOfDegree K n).Infinite ↔ ringChar K = ringChar 𝓀[K] ∧ ringChar 𝓀[K] ∣ n :=
+  sorry
+
+/-- **Convergence** ([Serre 1978, Rmk. 1°]): the real-valued restatement, meaningful precisely in
+the infinite case, where the `ℝ≥0∞` sum asserts nothing about summability. -/
+theorem summable_one_div_residueCard_pow_wildExponent (n : ℕ) (hn : 0 < n) :
+    Summable fun L : totallyRamifiedOfDegree K n => 1 / (residueCard K : ℝ) ^ wildExponent L.1 :=
+  sorry
+
+/-- **The orbit count** ([Serre 1978, Rmk. 3°]): the isomorphism class of `L` inside
+`totallyRamifiedOfDegree K n` has `n / #Aut_K(L)` members, in multiplied form. -/
+theorem ncard_isomorphic_mul_natCard_algEquiv (n : ℕ) (hn : 0 < n)
+    (L : IntermediateField K (SeparableClosure K)) (hL : L ∈ totallyRamifiedOfDegree K n) :
+    {M ∈ totallyRamifiedOfDegree K n | Nonempty (↥L ≃ₐ[K] ↥M)}.ncard *
+      Nat.card (↥L ≃ₐ[K] ↥L) = n :=
+  sorry
+
+/-- **Theorem 2, the mass formula proper** ([Serre 1978, Thm. 2]): Theorem 1 regrouped along
+isomorphism classes, over any set of representatives. -/
+theorem tsum_one_div_natCard_algEquiv_mul_residueCard_pow_wildExponent (n : ℕ) (hn : 0 < n)
+    (R : Set (IntermediateField K (SeparableClosure K))) (hR : IsRepresentativeSet n R) :
+    ∑' M : R, 1 / ((Nat.card (↥M.1 ≃ₐ[K] ↥M.1) : ℝ≥0∞) *
+      (residueCard K : ℝ≥0∞) ^ wildExponent M.1) = 1 :=
+  sorry
+
+/-- **The tame count**, the corollary that makes the formula concrete: away from the residue
+characteristic every `c L` vanishes, so there are exactly `n` totally ramified extensions of
+degree `n`. -/
+theorem ncard_totallyRamifiedOfDegree_of_not_dvd (n : ℕ) (hn : 0 < n)
+    (hp : ¬ ringChar 𝓀[K] ∣ n) : (totallyRamifiedOfDegree K n).ncard = n :=
+  sorry
+
+end TauCetiRoadmap.TotallyRamified

--- a/TauCetiRoadmap/TotallyRamified/Suggested.lean
+++ b/TauCetiRoadmap/TotallyRamified/Suggested.lean
@@ -327,6 +327,17 @@ noncomputable def rootCount (L : IntermediateField K (SeparableClosure K)) {n : 
 
 variable (K)
 
+/-- **Almost-everywhere measurability of the root count on the Eisenstein region.** Layer 1
+makes the root count locally constant on the separable Eisenstein locus, whose complement in the
+region is null. This supplies the summand hypothesis for `MeasureTheory.lintegral_tsum`. -/
+theorem aemeasurable_rootCount (n : ℕ) (hn : 0 < n)
+    [MeasurableSpace (Fin n → K)] [BorelSpace (Fin n → K)]
+    (μ : MeasureTheory.Measure (Fin n → K)) [μ.IsAddHaarMeasure]
+    (L : IntermediateField K (SeparableClosure K)) (hL : L ∈ totallyRamifiedOfDegree K n) :
+    AEMeasurable (fun a : Fin n → K => (rootCount L a : ℝ≥0∞))
+      (μ.restrict (eisensteinSet K n)) :=
+  sorry
+
 /-- Almost everywhere on the Eisenstein region, the root counts over
 `totallyRamifiedOfDegree K n` sum to `n`: an Eisenstein polynomial is irreducible, and each of its
 `n` roots generates exactly one member. -/
@@ -335,6 +346,15 @@ theorem tsum_rootCount (n : ℕ) (hn : 0 < n)
     (μ : MeasureTheory.Measure (Fin n → K)) [μ.IsAddHaarMeasure] (hμ : μ (integerBox K n) = 1) :
     ∀ᵐ a ∂μ.restrict (eisensteinSet K n),
       ∑' L : totallyRamifiedOfDegree K n, (rootCount L.1 a : ℝ≥0∞) = n :=
+  sorry
+
+/-- **Countability of the family.** Local constancy at an Eisenstein generator gives each member
+a positive root-count integral. The almost-everywhere root-count identity bounds the sum of these
+integrals over every finite subfamily by `n * μ (eisensteinSet K n)`, a finite value. Thus only
+countably many members occur. This supplies the countable index type for
+`MeasureTheory.lintegral_tsum` without using the mass formula. -/
+theorem countable_totallyRamifiedOfDegree (n : ℕ) (hn : 0 < n) :
+    (totallyRamifiedOfDegree K n).Countable :=
   sorry
 
 /-- **The integral of the root count** ([Serre 1978, Lemmas 2 and 3, eqs. (5)–(13)]): the change of


### PR DESCRIPTION
## Summary

This roadmap owns the **counting** of totally ramified extensions of a non-archimedean local
field: the set `σ_K(n)`, the wild exponent `c(L) = d(L) − n + 1` as its weight, the machinery that
evaluates the count, and the two mass formulas of [Serre 1978] with the finiteness, convergence
and orbit statements that accompany them.

```text
∑_{L ∈ σ_K(n)} q^{-c(L)} = n            ∑_{M} 1 / (#Aut_K(M) · q^{c(M)}) = 1
```

The directory is `TauCetiRoadmap/MassFormula/`, renamed from `TotallyRamified` during review: the
old name claimed the arithmetic of total ramification, which this roadmap does not own — #189
does — and `MassFormula` matches the suggested Tau Ceti home. The predicate `IsTotallyRamified`
and the set `totallyRamifiedOfDegree` keep their names, which describe mathematics rather than
this roadmap. The five references to the old directory name in #189's prose are updated here.

The machinery the count needs is not ramification theory, which is what makes it a roadmap rather
than a section of one: a **quantitative Newton estimate** over a complete DVR (Mathlib's
`hensels_lemma` is that estimate over `ℤ_[p]` only, and `HenselianLocalRing` lifts a simple root
with no distance bound, hence no count), the
**lattice-index scaling law** for Haar measure over such a ring (`Measure.addHaar_image_linearMap`
is real-vector-space only), and the parametrization of `σ_K(n)` by the **Eisenstein region** of
coefficient space. The first two are specified over an arbitrary complete DVR and are reusable
well outside this roadmap; they are placed by subject, in
`TauCeti/RingTheory/DiscreteValuationRing/` (the Newton estimate and the uniqueness of the lifted
root), `TauCeti/LinearAlgebra/FreeModule/` (the lattice index, beside Mathlib's `ℤ` analogue
`AddSubgroup.index_eq_natAbs_det`) and `TauCeti/MeasureTheory/Group/` (the Haar scaling law).

The PR contains the normative `README.md` and target signatures in `Suggested.lean`: seven
definitions of its own, two junk-tolerant wrappers around the consumed substrate, twenty-two
milestones as `sorry`-targets, and two closed comparison theorems that type-check the adapter
contract described below.

## Ownership

This roadmap does **not** own the arithmetic of the individual extension. Total ramification,
Eisenstein generators, monogenicity, the different, the discriminant and the tame criterion belong
to **Local Fields and Ramification (#189)**, whose Layer 3 specifies all of them; this roadmap
consumes that contract and is, as far as I can tell, its first counting consumer. The README lists
the consumed items explicitly and says that restating any of them in `TauCeti/` is a duplicate to
be deleted rather than a contribution.

That contract is now consumed **by name**. `Suggested.lean` imports
`TauCetiRoadmap.LocalFieldsRamification.Suggested` and uses #189's declarations directly:
`IsTotallyRamified` with `isTotallyRamified_iff_inertiaDegree_eq_one` and
`isTotallyRamified_iff_exists_eisenstein_generator`, `exists_integerRing_adjoin_eq_top`,
`localDiscriminantIdeal`, `differentExponent` and `discriminantExponent` with
`differentExponent_eq_of_algEquiv` and `discriminantExponent_eq_of_algEquiv`, and
`addVal_sum_eisenstein_powerBasis`. The README carries the full consumed-item → supplier-
declaration table.

Where this roadmap's carrier is an arbitrary `L : IntermediateField K (SeparableClosure K)` rather
than a finite extension as such, Layer 0 defines two junk-tolerant wrappers,
`intermediateFieldIsTotallyRamified` and `intermediateFieldDiscriminantExponent`. Each installs
#189's `finiteIntermediateField*` structure adapters and reduces to the canonical invariant
through a comparison theorem with a **closed proof**, exactly as #189's *Consumer contract:
Counting Totally Ramified Extensions* section prescribes. No ramification-theoretic notion —
index, different, discriminant ideal, or exponent — is defined independently here.

The two items an earlier revision of this description listed as unclaimed by the contract —
invariance of `d` (hence `c`) under `K`-isomorphism, and orthogonality of a power basis at an
Eisenstein generator — are now #189 exports (`discriminantExponent_eq_of_algEquiv` and
`addVal_sum_eisenstein_powerBasis`). This roadmap owns only their family-level consequences:
invariance of `wildExponent`, along which Theorem 2 regroups, and the coordinate-box and
coordinate-cube descriptions that carry the volume computation.

The two roadmaps agree on their shared example: the `d = 2` and `d = 3` values this roadmap's
`ℚ_2`, `n = 2` acceptance test needs are #189's own `ℚ_2(i)` and `ℚ_2(√2)` worked examples.
Concretely, `σ_{ℚ_2}(2)` has six members, two with `c = 1` and four with `c = 2`, and Theorem 1
reads `2·2^{-1} + 4·2^{-2} = 2`. That is the test that catches an off-by-one in `c`, and it also
checks that the consumed `d` and the `c` here are the same invariant.

The supplier chain has landed — #188, #244 and #189 are all merged — and this branch is updated
from `main`, so `build` is green and the relative link to `../LocalFieldsRamification/README.md`
resolves. The red-by-design state this description previously described is over.

## Coordination

I am the author of [0stellensatz/MassFormula](https://github.com/0stellensatz/MassFormula)
(Apache-2.0), where every layer is formalized `sorry`-free, so there is no third-party
coordination outstanding. The roadmap treats it as a cited source rather than a specification: it
states the mathematics intrinsically, hands the ramification half to #189, and asks for the two
general layers at a generality the source did not need. Its provenance section records where the
roadmap departs from the source — including dropping the source's own proof of
`IsAdicComplete 𝓂[K] 𝒪[K]`, which Mathlib now carries as an instance, and dropping the source's
comparator-pair device, which does not transfer to a repository where no `sorry` may land.

## Human review priorities

- **the two Layer 0 wrappers** — whether junk-tolerant totalization over
  `IntermediateField K (SeparableClosure K)` is the right carrier choice, given that the
  alternative is to carry a finiteness hypothesis in every statement downstream;
- the decision to state quantitative Newton lifting over an arbitrary complete DVR and the
  lattice index over an arbitrary DVR, rather than over a local field, and their suggested homes
  outside `NumberTheory/LocalField/`;
- the `ℝ≥0∞` convention for both mass formulas, with the convergence remark kept separate over
  `ℝ` as `Summable`, rather than a single real-valued statement carrying a summability
  hypothesis;
- representative sets as a predicate quantified over, rather than a quotient;
- whether the Eisenstein-region measure `q^{-n}(1 - q^{-1})` and the root-count integral
  `q^{-(d+1)}(1 - q^{-1})` are the right pair of acceptance constants to pin, given that a
  misnormalized Haar measure is otherwise invisible until the summit.

## Checks

`lake build TauCetiRoadmap.MassFormula.Suggested` passes on `lean-toolchain` v4.34.0-rc2 against
the pinned Mathlib, on this branch merged with `main`: rc=0, 8868 jobs, no errors, 22 `sorry`
warnings. The two comparison theorems are closed and do not count as milestones. The count rose
from sixteen in response to review: two targets for the countability and measurability behind
Theorem 1, and four more that the review showed were being assumed in prose rather than stated —
`adjoin_mem_totallyRamifiedOfDegree`, `le_addVal_sum_eisenstein_powerBasis_iff`,
`eq_of_isRoot_of_addVal_lt` and `mem_eisensteinSet_iff`. On GitHub the `build` check is green.

The pin files are untouched, and so are the issue-template `area` dropdowns — the sync bot
regenerates those on merge, so this PR leaves them alone.

## Follow-up

Serre's formula is a *mass* formula and does not by itself count extensions. A follow-up PR will
extend this roadmap to the actual counts: Krasner's count of totally ramified extensions of given
degree and given discriminant, Monge's determination of the number of isomorphism classes, and
Bhargava's mass formula over étale algebras. Kedlaya 2007 and Wood–Yasuda 2015/2017 stay out of
scope and remain named in `## Long horizon`.

## :robot: AI assistance

Drafted with Claude Opus 5, under my direction. I have read the roadmap carefully myself. The
consumption commit is David Roe's, adopted from his suggestion branch with authorship preserved.

