### PR TITLE
roadmap(Exchangeability): weaken conditional witness-uniqueness hypotheses

### DIFF
--- a/TauCetiRoadmap/Exchangeability/README.md
+++ b/TauCetiRoadmap/Exchangeability/README.md
@@ -665,8 +665,9 @@ The directing-measure theorem should expose a real API, not just an existence pr
 * **a.e.** uniqueness of `ν` **among directing measures**, i.e. among witnesses of
   `ConditionallyIIDWith` (`conditionallyIID_ae_unique`: equality of probability measures a.e.
   under the base law, tested against a determining class — not pointwise). Pin its hypotheses:
-  `[IsProbabilityMeasure μ] [StandardBorelSpace α] [Nonempty α]`, measurable `X`, and two
-  explicit `ConditionallyIIDWith μ X ν` / `ConditionallyIIDWith μ X ν'` hypotheses, concluding
+  `[IsProbabilityMeasure μ] [MeasurableSpace.CountablyGenerated α]`, a.e.-measurable coordinates
+  `∀ i, AEMeasurable (X i) μ`, and two explicit `ConditionallyIIDWith μ X ν` /
+  `ConditionallyIIDWith μ X ν'` hypotheses, concluding
   `ν =ᵐ[μ] ν'`. Mere mixing
   representatives (witnesses of `MixedIIDWith`) are **not** a.e. unique when the mixing law is
   nondegenerate — an independent copy of `ν` is one — so no witness-level a.e.-equality


### PR DESCRIPTION
Aligns the Layer 6 signature for `conditionallyIID_ae_unique` with the theorem that landed in Tau Ceti.

The roadmap currently assumes a standard Borel, nonempty state space and measurable coordinates. The implementation needs only a countably generated measurable space and a.e.-measurable coordinates; no measure on the state space is constructed, so `Nonempty α` is unnecessary.

This changes neither the conclusion nor the surrounding distinction between conditional witness-level a.e. uniqueness and mixture-side mixing-law uniqueness.

Roadmap: Exchangeability

🤖 Directed by Cameron Freer, written by GPT 5.6 Sol (xhigh reasoning)

