### PR TITLE
fix: keep review automation on protected main

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,24 +1,31 @@
 name: auto-merge
 
-# Queue every non-draft PR for GitHub-native auto-merge, using a tauceti-review-bot App token
-# (the org disables write GITHUB_TOKEN). Branch protection requires a roadmap-reviewers code-owner
-# approval plus the `build` check, so GitHub merges the PR automatically once a team member
-# approves and CI passes. Native auto-merge watches PR state directly, so this is unaffected by
-# the pull_request_review event-delivery issue.
+# Queue every non-draft PR targeting protected `main` for GitHub-native auto-merge, using a
+# tauceti-review-bot App token (the org disables write GITHUB_TOKEN). The `main` ruleset requires a
+# roadmap-reviewers code-owner approval plus the `build` check, so GitHub merges the PR
+# automatically once a team member approves and CI passes. PRs targeting feature branches must not
+# reach `gh pr merge --auto`: those branches have no merge requirements, so the command would merge
+# immediately instead of queueing. Native auto-merge watches PR state directly, so this is
+# unaffected by the pull_request_review event-delivery issue.
 
 # Use pull_request_target (not pull_request) so the tauceti-review-bot App secrets are available
 # for PRs opened from forks — the common case for external contributors. This job never checks out
 # or runs PR code (it only calls `gh pr merge`), so pull_request_target is safe here.
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review]
+    # `edited` reconsiders a stacked PR when its base is changed to `main`. The job condition below
+    # ignores title/body edits. GitHub disables existing auto-merge when a PR's base changes.
+    types: [opened, reopened, ready_for_review, edited]
+    branches: [main]
 
 permissions:
   contents: read
 
 jobs:
   enable:
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'edited' || github.event.changes.base != null)
     runs-on: ubuntu-latest
     steps:
       - name: Mint App token (pull-requests + contents write)
@@ -34,4 +41,33 @@ jobs:
       - name: Enable auto-merge
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: gh pr merge "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --auto --squash
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          PROTECTED_BASE: main
+        run: |
+          set -euo pipefail
+
+          # Re-read the live PR because a queued or re-run job may outlive its event payload.
+          current_base=$(gh pr view "$PR" --repo "$REPO" --json baseRefName --jq .baseRefName)
+          if [ "$current_base" != "$PROTECTED_BASE" ]; then
+            echo "::notice::PR #$PR now targets $current_base; auto-merge is only enabled for $PROTECTED_BASE"
+            exit 0
+          fi
+
+          # Fail closed if the repository rules drift away from the assumptions that make
+          # auto-merge safe. Merely naming `main` is not enough: `--auto` merges immediately when
+          # there are no unmet requirements.
+          rules=$(gh api "repos/$REPO/rules/branches/$PROTECTED_BASE")
+          if ! jq -e '
+              any(.[]; .type == "pull_request"
+                and .parameters.required_approving_review_count >= 1
+                and .parameters.require_code_owner_review == true)
+              and
+              any(.[]; .type == "required_status_checks"
+                and any(.parameters.required_status_checks[]?; .context == "build"))
+            ' <<<"$rules" >/dev/null; then
+            echo "::error::$PROTECTED_BASE lacks the required code-owner review or build rule"
+            exit 1
+          fi
+
+          gh pr merge "$PR" --repo "$REPO" --auto --squash

--- a/.github/workflows/promote-reviewers.yml
+++ b/.github/workflows/promote-reviewers.yml
@@ -1,10 +1,11 @@
 name: promote-reviewers
 
-# Accrue reviewing rights to proven contributors automatically: when a roadmap PR merges, promote
-# its author to the `roadmap-reviewers` team once they have at least PROMOTE_THRESHOLD merged PRs in
-# this repo. A team member's approval (CODEOWNERS) plus the `build` check makes a roadmap PR
-# auto-mergeable, so this lets the reviewer pool grow itself from people who have demonstrably
-# landed roadmap work. `workflow_dispatch` runs a full sweep (backfill / catch-up).
+# Accrue reviewing rights to proven contributors automatically: when a roadmap PR merges into
+# protected `main`, promote its author to the `roadmap-reviewers` team once they have at least
+# PROMOTE_THRESHOLD PRs merged into `main`. A team member's approval (CODEOWNERS) plus the `build`
+# check makes a roadmap PR auto-mergeable, so this lets the reviewer pool grow itself from people
+# who have demonstrably landed reviewed roadmap work. `workflow_dispatch` runs a full sweep
+# (backfill / catch-up).
 #
 # Requires the tauceti-review-bot App to have the organization **Members: write** permission; the
 # repo-scoped pull-requests/contents grants are NOT enough to manage team membership. Grant it in
@@ -20,8 +21,12 @@ permissions:
 
 jobs:
   promote:
-    # On a merge event, only when the PR actually merged; always on a manual sweep.
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    # On a merge event, only when the PR actually merged into protected `main`; always on a manual
+    # sweep. Feature-branch merges have not passed the review and build gates and must not accrue
+    # reviewing rights.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main')
     runs-on: ubuntu-latest
     steps:
       - name: Mint App token (organization Members write)
@@ -40,34 +45,35 @@ jobs:
           TEAM: roadmap-reviewers
           THRESHOLD: "2"
           REPO: ${{ github.repository }}
+          BASE: main
           EVENT: ${{ github.event_name }}
           MERGED_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
 
-          # Promote $1 to the team iff they are not a bot and have >= THRESHOLD merged PRs here.
+          # Promote $1 iff they are not a bot and have >= THRESHOLD PRs merged into protected BASE.
           promote() {
             local user="$1"
             case "$user" in *"[bot]") return 0 ;; esac   # never promote a bot
             local count
-            count=$(gh pr list --repo "$REPO" --state merged --author "$user" \
+            count=$(gh pr list --repo "$REPO" --state merged --base "$BASE" --author "$user" \
               --limit 500 --json number --jq 'length')
             if [ "$count" -ge "$THRESHOLD" ]; then
               if gh api --silent -X PUT \
                   "/orgs/$ORG/teams/$TEAM/memberships/$user" -f role=member; then
-                echo "✓ $user ($count merged) → @$ORG/$TEAM"
+                echo "✓ $user ($count merged into $BASE) → @$ORG/$TEAM"
               else
                 echo "✗ could not add $user — does the App have org Members:write?" >&2
                 return 1
               fi
             else
-              echo "· $user ($count merged) below threshold $THRESHOLD"
+              echo "· $user ($count merged into $BASE) below threshold $THRESHOLD"
             fi
           }
 
           if [ "$EVENT" = "workflow_dispatch" ]; then
-            # Full sweep: every distinct author of a merged PR in this repo.
-            gh pr list --repo "$REPO" --state merged --limit 1000 --json author \
+            # Full sweep: every distinct author of a PR merged into protected BASE.
+            gh pr list --repo "$REPO" --state merged --base "$BASE" --limit 1000 --json author \
               --jq '.[].author.login' | sort -u | while read -r user; do
               [ -n "$user" ] && promote "$user"
             done


### PR DESCRIPTION
## Why

PR #233 targeted an unprotected feature branch, so the review bot command intended to enable auto-merge merged it immediately without a review or completed build. The reviewer-promotion workflow also counted feature-branch merges toward the two-merge promotion threshold.

## Changes

- run ordinary auto-merge only for pull requests targeting protected main
- reconsider stacked pull requests when they are later retargeted to main
- re-read the live base and verify that code-owner review and build remain required before enabling auto-merge
- count and react only to pull requests merged into main when promoting reviewers

## Validation

- actionlint 1.7.12 on both changed workflows
- live rules predicate accepts the current main ruleset and rejects an empty/unprotected rule set
- audited current reviewer membership; no corrective removal is needed

## AI assistance

Implemented with OpenAI Codex. The diagnosis and proposed controls received an independent Claude Opus review; each finding used here was checked against the repository and live GitHub state.