### PR TITLE
progress: ReductiveGroups report for 2026-08-18

### DIFF
--- a/TauCetiRoadmap/ReductiveGroups/PROGRESS.md
+++ b/TauCetiRoadmap/ReductiveGroups/PROGRESS.md
@@ -161,3 +161,39 @@ kernel with its conormal exact sequence, and `Lie(GLₙ)` and `Lie(SLₙ)` ident
 trace-zero matrices. Elsewhere: normal Hopf ideals and the pointwise quotient presheaf, geometric
 connectedness and its stability under base field extension, faithfully flat descent for points, and
 base change of affine group schemes.
+
+<!--tauceti-progress:v1 {"from_sha":"f7aaa6df91011d8623d880c19e6cc3f69e1d46f4","prs":[2763,2766,2770,2829,2832,2864,2865,2868,2872,2882,2884,2891,2894,2897,2912,2919,2920,2932,2940,2943,2964,2977,2997,2998,2999,3001,3002,3004,3005,3007,3011,3012,3014,3015,3016,3020,3021,3022,3023,3027,3050,3061,3065,3087,3088,3090,3091,3097,3110,3114,3117,3118,3177,3193,3195,3206,3208,3211,3213,3220,3222,3227,3233,3234,3238,3239,3249,3256,3264,3280,3286,3290,3293,3294,3296,3303,3307,3308,3311,3325,3336,3338,3356,3360,3363,3367,3376,3380,3384,3386,3389,3399,3410,3413,3415,3416,3421,3434,3436,3441,3449,3450,3456,3463,3471,3472,3475,3476,3478,3486,3489,3490,3494,3496,3500,3502,3503,3504,3505,3512,3513,3515,3518,3519,3522,3523,3524,3527,3529,3530,3531,3533,3534,3535,3536,3537,3539,3540,3541,3542,3543,3553,3555,3558,3559,3576,3581,3582,3584,3587,3591,3592,3593,3595,3601,3605,3607,3608,3609,3613,3622,3626,3630,3633,3642,3643,3649,3652,3667,3673,3678,3679,3682,3683,3684,3686,3688,3689,3690,3692,3704,3708,3714,3717,3718],"roadmap":"ReductiveGroups","to_sha":"c4d7989a116c565aa558fb82c318ad7c651bf2f4"}-->
+## ReductiveGroups: 2026-08-12 to 2026-08-18 (`f7aaa6d` to `c4d7989`)
+
+Tannakian reconstruction is finished. Points of a commutative Hopf algebra over a field
+correspond exactly to tensor automorphisms of scalar extension on its finite-dimensional
+comodules
+([`fgPointTensorIsoEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.html#TauCeti.Tannaka.fgPointTensorIsoEquiv)),
+naturally in the value algebra, so the functor of points and the tensor-automorphism functor
+are isomorphic
+([`pointsFunctorIsoTensorAutFunctor`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/GroupFunctor.html#TauCeti.Tannaka.pointsFunctorIsoTensorAutFunctor)).
+On top of it sits the multiplicative Jordan decomposition of a point over a perfect extension
+field: commuting semisimple and unipotent factors with product the point, unique among such
+factorizations and compatible with homomorphisms of affine groups
+([`jordanDecomposition`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.html#TauCeti.HopfAlgebra.Point.jordanDecomposition),
+TauCeti#2964).
+
+Layer 3 got its missing pieces. The identity component is a closed subgroup scheme with
+connected carrier and normal defining Hopf ideal, and over an algebraically closed field the
+component group is finite and agrees with the connected components of the spectrum. Quotients
+became sheaves rather than presheaves: the affine fppf topology is subcanonical, points of an
+affine group form an fppf sheaf, and the quotient by a normal Hopf ideal is a group object in
+fppf sheaves
+([`fppfQuotientSheaf`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Basic.html#TauCeti.CommHopfAlgCat.fppfQuotientSheaf))
+whose projection is locally surjective with the expected torsor kernel pair. Cartier duality
+arrived as an anti-equivalence of finite locally free bicommutative Hopf algebras, and a
+finite-type Hopf algebra over a field is a torus exactly when it is of multiplicative type,
+geometrically connected and geometrically reduced.
+
+Layer 5 opened with the geometric definition of unipotence, verified for `𝔾ₐ` and the
+upper-unitriangular groups and stable under products, quotients and extensions; such a group
+has no nontrivial characters. Reductivity and
+semisimplicity exist only as properties so far: no group has been proved reductive, and there
+is no unipotent radical, no Lie-Kolchin theorem and no Borel theory beyond `GL₂`. Separately,
+the Chevalley lane built the Serre presentation of split semisimple Lie algebras, the rank-one
+Kostant form, and root subgroups of `GLₙ` and `SLₙ` satisfying the type-A commutator relations.

--- a/TauCetiRoadmap/ReductiveGroups/STATUS.md
+++ b/TauCetiRoadmap/ReductiveGroups/STATUS.md
@@ -1,93 +1,98 @@
-<!--tauceti-status:v1 {"roadmap":"ReductiveGroups","to_sha":"f7aaa6df91011d8623d880c19e6cc3f69e1d46f4","ts":"2026-08-12T11:39:43+10:00"}-->
+<!--tauceti-status:v1 {"roadmap":"ReductiveGroups","to_sha":"c4d7989a116c565aa558fb82c318ad7c651bf2f4","ts":"2026-08-18T20:34:58Z"}-->
 # Status: ReductiveGroups
 
-This file documents the status of the ReductiveGroups roadmap up until `f7aaa6d` (2026-08-12T11:39:43+10:00). There may have been subsequent updates.
+This file documents the status of the ReductiveGroups roadmap up until `c4d7989` (2026-08-18T20:34:58Z). There may have been subsequent updates.
 
 It is generated, and its prose is not security-validated; see
 https://github.com/TauCetiProject/TauCetiProgress for what that means.
 
 ## Where this roadmap stands
 
-**At a glance.** Layers 0 and 2 are done, and Layer 1 is done but for Tannakian reconstruction: an
-affine group scheme of finite type over a field provably embeds in a general linear group, and the
-tangent Lie algebra with its adjoint action exists. Layers 3 and 4 are partial, and Layers 5
-through 9 — unipotence, reductivity, root data, classification — have not begun.
+**At a glance.** Layers 0 through 4 are essentially done: an affine group scheme of finite type
+over a field embeds in a general linear group, is recovered from its tensor category of
+representations, and its points decompose into semisimple and unipotent parts. Layer 5 has
+started, Layer 6 exists only as definitions, and Layers 7 and 8 have not begun; of Layer 9 only
+Lie-algebra prerequisites and root subgroups of the classical groups are in place.
 
 ### Named results
 
+- **Tannakian reconstruction** — the points of a commutative Hopf algebra over a field are
+  exactly the tensor automorphisms of scalar extension on its finite-dimensional comodules
+  ([`fgPointTensorIsoEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.html#TauCeti.Tannaka.fgPointTensorIsoEquiv)),
+  naturally enough in the value algebra to be an isomorphism of group-valued functors
+  ([`pointsFunctorIsoTensorAutFunctor`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/GroupFunctor.html#TauCeti.Tannaka.pointsFunctorIsoTensorAutFunctor)).
+- **The multiplicative Jordan decomposition** — over a perfect extension field every point
+  factors uniquely as commuting semisimple and unipotent parts, compatibly with homomorphisms
+  ([`jordanDecomposition`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.html#TauCeti.HopfAlgebra.Point.jordanDecomposition),
+  [`isSemisimple_isUnipotent_unique`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/JordanDecomposition/Basic.html#TauCeti.HopfAlgebra.Point.isSemisimple_isUnipotent_unique)).
 - **The embedding theorem** — every affine group scheme of finite type over a field is a closed
   subgroup of some general linear group
   ([`exists_isClosedImmersion_generalLinear`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.html#TauCeti.AffineGroupSchemeCat.exists_isClosedImmersion_generalLinear)),
-  proved through finite-dimensional subcoalgebras rather than bare Noetherianity.
-- **Faithfulness is generation by matrix coefficients** — a finite free comodule gives a closed
-  immersion into `GLₙ` exactly when its matrix coefficients and their antipode images generate the
-  coordinate Hopf algebra
-  ([`isClosedImmersion_coordinateGroupSchemeHom_iff_matrixCoefficientSubalgebra_sup_antipode_eq_top`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Faithful.html#TauCeti.Comodule.isClosedImmersion_coordinateGroupSchemeHom_iff_matrixCoefficientSubalgebra_sup_antipode_eq_top)),
-  the roadmap's definition rather than injectivity of a coaction.
-- **The Hopf/affine-group-scheme anti-equivalence** — `Spec` is an anti-equivalence from commutative
-  `S`-Hopf algebras onto affine group schemes over `Spec S`
-  ([`commHopfAlgCatOpEquivAffineGroupSchemeCat`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/AffineGroupScheme/Equivalence.html#TauCeti.commHopfAlgCatOpEquivAffineGroupSchemeCat)),
-  restricting to the finite-type objects on both sides
-  ([`finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/AlgebraicGeometry/AffineGroupScheme/FiniteType.html#TauCeti.finiteTypeCommHopfAlgCatOpEquivFiniteTypeAffineGroupSchemeCat)),
-  smoothness matching likewise.
-- **The fundamental theorem of comodules** — every element of a coalgebra over a field lies in a
-  finite-dimensional subcoalgebra
-  ([`exists_finiteDimensional_subcoalgebra_mem`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Subcoalgebra/Finite.html#TauCeti.Subcoalgebra.exists_finiteDimensional_subcoalgebra_mem)),
-  now also over a principal ideal domain. It drives both the embedding theorem and reconstruction.
-- **Classification of closed subgroup schemes** — Hopf ideals of `H` under reverse inclusion are
-  order-isomorphic to closed subgroup schemes of `Spec H`
-  ([`hopfIdealOrderIsoClosedSubgroup`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Classification.html#TauCeti.CommHopfAlgCat.hopfIdealOrderIsoClosedSubgroup)),
-  kernels being the extended augmentation ideal.
+  proved through finite-dimensional subcoalgebras.
+- **Cartier duality** — finite dualization is an anti-equivalence of the category of finite
+  locally free bicommutative Hopf algebras over a commutative ring
+  ([`cartierDuality`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/HopfAlgebra/FiniteDual/CartierDuality/Basic.html#TauCeti.FiniteLocallyFreeBicommutativeHopfAlgCat.cartierDuality)),
+  and commuting with base change.
+- **The characterization of tori** — a finite-type commutative Hopf algebra over a field is a
+  torus exactly when it is of multiplicative type, geometrically connected and geometrically
+  reduced
+  ([`iff_multiplicativeType_and_geometricallyConnected_and_geometricallyReduced`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Torus/Characterization.html#TauCeti.torusCommHopfAlgProperty.iff_multiplicativeType_and_geometricallyConnected_and_geometricallyReduced)).
 
 ### Notable definitions and infrastructure
 
-- **The Lie algebra with its adjoint action.** Counit-valued derivations are dual to the cotangent
-  space at the identity
-  ([`CotangentSpace`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Tangent/Cotangent.html#TauCeti.Bialgebra.CotangentSpace)),
-  and points act on them by convolution conjugation, giving `Ad` both as a representation of the
-  functor of points and as a comodule
-  ([`adjointPointRepresentation`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Tangent/Representation.html#TauCeti.Derivation.adjointPointRepresentation)).
-  Closed subgroups have Lie algebras with an exact conormal sequence, and `Lie(GLₙ)`, `Lie(SLₙ)` are
-  the matrix and trace-zero matrix Lie algebras.
-- **Tensor automorphisms of scalar extension.** Scalar extension from finite comodules is strong
-  monoidal, and each point induces a tensor automorphism of it
-  ([`fgPointTensorIso`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Monoidal.html#TauCeti.Tannaka.fgPointTensorIso)).
-  Reconstruction is a statement about this object, where the semisimple and unipotent parts of a
-  point currently live.
-- **Normality and quotients at the presheaf level.** A Hopf ideal is normal when the conjugation
-  coordinate morphism carries it into `H ⊗ I`
-  ([`IsNormal`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Normal.html#TauCeti.HopfIdeal.IsNormal)),
-  equivalently when it cuts out a normal subgroup of `G(A)` for every `A`; the quotient
-  `A ↦ G(A)/V(I)(A)` is then a presheaf, awaiting sheafification.
+- **The fppf quotient sheaf.** The quotient of an affine group by a normal Hopf ideal is a group
+  object in fppf sheaves
+  ([`fppfQuotientSheaf`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Basic.html#TauCeti.CommHopfAlgCat.fppfQuotientSheaf)),
+  with a locally surjective projection whose kernel pair is the torsor square
+  ([`isPullback_fppfQuotientTorsor`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Fppf/Quotient/Torsor.html#TauCeti.CommHopfAlgCat.isPullback_fppfQuotientTorsor)).
+  This makes short exact sequences and the component group expressible; representability by a
+  scheme is not addressed.
+- **The identity component.** `G°` is a closed subgroup scheme with connected carrier
+  ([`identityComponentSpec`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Connected/GroupScheme.html#TauCeti.FiniteTypeCommHopfAlgCat.identityComponentSpec)),
+  cut out by a normal Hopf ideal, and over an algebraically closed field its component group is
+  finite
+  ([`instFiniteComponentGroupPoints`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Connected/ComponentGroup/Basic.html#TauCeti.FiniteTypeCommHopfAlgCat.instFiniteComponentGroupPoints)).
+- **Unipotence, geometrically.** A group is smooth unipotent when it is smooth and every
+  algebraically-closed-valued point acts unipotently in every finite-dimensional representation
+  ([`smoothUnipotentCommHopfAlgProperty_iff`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Unipotent/Basic.html#TauCeti.smoothUnipotentCommHopfAlgProperty_iff)),
+  the definition reductivity is stated against.
 
 ### Roadmap coverage
 
-Layer 0 is done, now with base change of Hopf algebras and of affine group schemes. Layer 1 is
-complete except Tannakian reconstruction, half proved: points act faithfully by tensor
-automorphisms and each tensor automorphism yields a point recovering it, but not conversely. Layer 2
-is done apart from the smoothness criterion through `Lie(G)`; smoothness exists only as a property
-matched across the anti-equivalence. Layer 3 has Hopf ideals, closed subgroups, kernels, normality,
-the presheaf quotient and geometric connectedness, but no sheaf quotient and no `G°` or `π₀`. Layer 4 has the diagonalizable anti-equivalence, `μ_n`, split tori with their perfect
-character-cocharacter pairing and Jordan–Chevalley decomposition of linear automorphisms, but no
-Jordan decomposition of group elements, no multiplicative type, no non-split tori, no Cartier
-duality. Layers 5 through 8 are untouched; of Layer 9 only the `p^n`-power Frobenius on points
-exists. The sheaves-and-descent lane has faithfully flat descent for the points of a Hopf algebra
-and nothing else. Worked examples cover `𝔾ₐ`, `𝔾ₘ`, `μ_n`, `αₚ`, split tori, `GLₙ` and `SLₙ`, but
-not `PGLₙ`, `SOₙ` or `Sp₂ₙ`. Almost everything is over a general commutative base.
+Layers 0 and 2 are done, as is Layer 1 now that reconstruction has closed. Layer 3 is done except
+that quotients are only fppf sheaves and the identity component and component group are currently
+developed over an algebraically closed field. Layer 4 is done: Jordan decomposition, groups of
+multiplicative type with their Galois module structure on characters and cocharacters, tori with
+a perfect character-cocharacter pairing, and Cartier duality. Layer 5 has the definition of
+unipotence with its closure properties, `𝔾ₐ` and the upper-unitriangular groups as examples,
+solvability of geometric points closed under extensions, and no unipotent radical. Layer 6 has
+reductive and semisimple as object properties
+([`reductiveCommHopfAlgProperty_iff`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Reductive/Basic.html#TauCeti.reductiveCommHopfAlgProperty_iff))
+and linear reductivity separately
+([`IsLinearlyReductive`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/LinearlyReductive.html#TauCeti.Coalgebra.IsLinearlyReductive)),
+but no theorem connecting them and no example of either beyond diagonalizable groups. Layers 7
+and 8 are untouched apart from a Borel subgroup of `GL₂` and the weight grading of the adjoint
+action. Layer 9 has root subgroups of `GLₙ` and `SLₙ` with the type-A Chevalley commutator
+relations, the Serre presentation of split semisimple Lie algebras, and the Kostant integral form
+in rank one. Worked examples now include the orthogonal and symplectic groups as Hopf-ideal
+quotients of `GLₙ` with their points identified.
 
 ## The frontier
 
-- **Tannakian reconstruction.** What remains is that a tensor automorphism agrees with the one
-  induced by its reconstructed point; the global functional, its multiplicativity and faithfulness
-  of the point action are in place, parts of them over a principal ideal domain with the Hopf
-  algebra free.
-- **Jordan decomposition of group elements.** The semisimple and unipotent parts of a point's
-  actions form commuting tensor automorphisms with product the point; turning them into points is
-  what the missing half of reconstruction supplies.
-- **Quotients `G/H`.** The pointwise quotient presheaf exists for a normal Hopf ideal; the fppf
-  topology, sheafification and the rest of the descent lane do not, and representability is a
-  theorem with hypotheses rather than a construction.
-- **The identity component and `π₀`.** Nothing splits the coordinate ring by idempotents to produce
-  `G°`, and finiteness of `π₀` under smoothness is untried.
-- **Unipotence and reductivity.** Layers 5 and 6 are empty; with the adjoint representation now
-  available, the unipotent radical is the next real obstacle.
+- **The unipotent radical.** Layer 5's hard core, and the reason reductivity is currently a
+  definition with no examples. Nothing constructs a maximal connected normal unipotent subgroup;
+  the closure properties of unipotence are the raw material.
+- **A group proved reductive.** `GLₙ`, `SLₙ` and tori are all present and none is known to be
+  reductive. The geometric definition requires ruling out unipotent normal subgroups of the base
+  change to an algebraic closure, which needs the previous item or a direct argument.
+- **Lie-Kolchin.** The flag machinery is conditional: if every nonzero finite-dimensional comodule
+  has a nonzero fixed vector then every one has an upper-unitriangular basis
+  ([`exists_basis_coefficientMatrix_isUpperUnitriangular_of_fixed_vectors`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Flag/Induction.html#TauCeti.Comodule.exists_basis_coefficientMatrix_isUpperUnitriangular_of_fixed_vectors)).
+  The fixed-vector hypothesis is undischarged for solvable or unipotent groups.
+- **Root data of a group.** The bracket of weight vectors multiplies weights
+  ([`lie_mem_adjointWeightSpace_mul`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Tangent/RootSpace.html#Derivation.lie_mem_adjointWeightSpace_mul)),
+  which is the grading a root datum would sit on, but there is no maximal torus inside a larger
+  group, no root set, and no Weyl group.
+- **Chevalley-Demazure over `ℤ`.** The Serre presentation and the rank-one Kostant form exist; the
+  general Kostant form, pinnings, the construction itself and the isomorphism theorem for pinned
+  groups do not.


### PR DESCRIPTION
<!--tauceti-progress-pr:v1 {"from_sha":"f7aaa6df91011d8623d880c19e6cc3f69e1d46f4","prs":[2763,2766,2770,2829,2832,2864,2865,2868,2872,2882,2884,2891,2894,2897,2912,2919,2920,2932,2940,2943,2964,2977,2997,2998,2999,3001,3002,3004,3005,3007,3011,3012,3014,3015,3016,3020,3021,3022,3023,3027,3050,3061,3065,3087,3088,3090,3091,3097,3110,3114,3117,3118,3177,3193,3195,3206,3208,3211,3213,3220,3222,3227,3233,3234,3238,3239,3249,3256,3264,3280,3286,3290,3293,3294,3296,3303,3307,3308,3311,3325,3336,3338,3356,3360,3363,3367,3376,3380,3384,3386,3389,3399,3410,3413,3415,3416,3421,3434,3436,3441,3449,3450,3456,3463,3471,3472,3475,3476,3478,3486,3489,3490,3494,3496,3500,3502,3503,3504,3505,3512,3513,3515,3518,3519,3522,3523,3524,3527,3529,3530,3531,3533,3534,3535,3536,3537,3539,3540,3541,3542,3543,3553,3555,3558,3559,3576,3581,3582,3584,3587,3591,3592,3593,3595,3601,3605,3607,3608,3609,3613,3622,3626,3630,3633,3642,3643,3649,3652,3667,3673,3678,3679,3682,3683,3684,3686,3688,3689,3690,3692,3704,3708,3714,3717,3718],"roadmap":"ReductiveGroups","to_sha":"c4d7989a116c565aa558fb82c318ad7c651bf2f4","version":"880e8b9737973bfbd8f1f214f4ac2ded67f5b856"}-->
This PR records progress on the ReductiveGroups roadmap for the window `f7aaa6d..c4d7989` of TauCeti `main`, covering 185 merged pull requests.

`STATUS.md` is rewritten as a snapshot at `c4d7989`; `PROGRESS.md` gains one appended section for the window. Both files are machine-owned and their prose is not security-validated.

Pull requests in the window: #2763, #2766, #2770, #2829, #2832, #2864, #2865, #2868, #2872, #2882, #2884, #2891, #2894, #2897, #2912, #2919, #2920, #2932, #2940, #2943, #2964, #2977, #2997, #2998, #2999, #3001, #3002, #3004, #3005, #3007, #3011, #3012, #3014, #3015, #3016, #3020, #3021, #3022, #3023, #3027, #3050, #3061, #3065, #3087, #3088, #3090, #3091, #3097, #3110, #3114, #3117, #3118, #3177, #3193, #3195, #3206, #3208, #3211, #3213, #3220, #3222, #3227, #3233, #3234, #3238, #3239, #3249, #3256, #3264, #3280, #3286, #3290, #3293, #3294, #3296, #3303, #3307, #3308, #3311, #3325, #3336, #3338, #3356, #3360, #3363, #3367, #3376, #3380, #3384, #3386, #3389, #3399, #3410, #3413, #3415, #3416, #3421, #3434, #3436, #3441, #3449, #3450, #3456, #3463, #3471, #3472, #3475, #3476, #3478, #3486, #3489, #3490, #3494, #3496, #3500, #3502, #3503, #3504, #3505, #3512, #3513, #3515, #3518, #3519, #3522, #3523, #3524, #3527, #3529, #3530, #3531, #3533, #3534, #3535, #3536, #3537, #3539, #3540, #3541, #3542, #3543, #3553, #3555, #3558, #3559, #3576, #3581, #3582, #3584, #3587, #3591, #3592, #3593, #3595, #3601, #3605, #3607, #3608, #3609, #3613, #3622, #3626, #3630, #3633, #3642, #3643, #3649, #3652, #3667, #3673, #3678, #3679, #3682, #3683, #3684, #3686, #3688, #3689, #3690, #3692, #3704, #3708, #3714, #3717, #3718

Generated by [TauCetiProgress](https://github.com/TauCetiProject/TauCetiProgress) at `880e8b9737973bfbd8f1f214f4ac2ded67f5b856`.

🤖 Prepared with Claude Code
