### PR TITLE
chore: stop the roadmap index from conflicting between pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,16 @@ Apply the **`awaiting-review`** label when you open it. If you cannot apply labe
 [Permissions](#permissions) below, and in the meantime say so in the PR description or the
 [Zulip topic][zulip-topic] and someone will apply it.
 
+**A roadmap pull request touches only its own directory under `TauCetiRoadmap/`.** Four files
+list the roadmaps, and all four are derived from the set of directories that contain a
+`README.md`: the "Roadmaps" list in `README.md`, the `area` dropdown in each of the two issue
+templates, and the root `TauCetiRoadmap.lean`. The first three are regenerated and committed by
+the sync bot after your PR merges, and `TauCetiRoadmap.lean` carries no import list at all
+because `lakefile.toml` globs every module under `TauCetiRoadmap/`. Adding your roadmap to any
+of them by hand does nothing except conflict with every other open roadmap PR, so leave them
+alone; if you want to check what the generated list will look like, run
+`python3 .github/scripts/check_roadmap_areas.py --fix` locally and then discard the result.
+
 ## The review workflow: labels
 
 Two labels track whose turn it is. Keeping them accurate is the single most useful thing you

--- a/TauCetiRoadmap.lean
+++ b/TauCetiRoadmap.lean
@@ -3,38 +3,10 @@
 -- The per-topic `README.md` files are the definitive roadmaps. The Lean `Suggested.lean`
 -- files suggest declaration forms for particular milestones (with `sorry`, which is
 -- allowed here); they are not exhaustive, and discharging one does not finish its roadmap.
-import TauCetiRoadmap.RepresentationTheory.SemisimpleAlgebras.Suggested
-import TauCetiRoadmap.RepresentationTheory.CharacterTheory.Suggested
-import TauCetiRoadmap.RepresentationTheory.InductionRestriction.Suggested
-import TauCetiRoadmap.RepresentationTheory.RootSystems.Suggested
-import TauCetiRoadmap.RepresentationTheory.LieHighestWeight.Suggested
-import TauCetiRoadmap.RepresentationTheory.ClassicalGroups.Suggested
-import TauCetiRoadmap.RepresentationTheory.SchurWeyl.Suggested
-import TauCetiRoadmap.RepresentationTheory.CompactGroups.Suggested
-import TauCetiRoadmap.RepresentationTheory.LieGroups.Suggested
-import TauCetiRoadmap.RepresentationTheory.SpinRepresentations.Suggested
-import TauCetiRoadmap.RepresentationTheory.QuiverRepresentations.Suggested
-import TauCetiRoadmap.GrothendieckEulerForms.Suggested
-import TauCetiRoadmap.Multiquadratic.Suggested
-import TauCetiRoadmap.UniversalCovers.Suggested
-import TauCetiRoadmap.JacobianChallenge.Suggested
-import TauCetiRoadmap.ReductiveGroups.Suggested
-import TauCetiRoadmap.PDE.Suggested
-import TauCetiRoadmap.CombinatorialHeegaardFloer.Suggested
-import TauCetiRoadmap.HeegaardFloer.Suggested
-import TauCetiRoadmap.IntegralLattices.Suggested
-import TauCetiRoadmap.GeometricTopology.Suggested
-import TauCetiRoadmap.HopfRinow.Suggested
-import TauCetiRoadmap.Exchangeability.Suggested
-import TauCetiRoadmap.ContourIntegration.Suggested
-import TauCetiRoadmap.DGAInfinity.Suggested
-import TauCetiRoadmap.ConformalMapping.Suggested
-import TauCetiRoadmap.OptimalTransport.Suggested
-import TauCetiRoadmap.CFSGStatement.Suggested
-import TauCetiRoadmap.StandardDistributions.Suggested
-import TauCetiRoadmap.HodgeStructures.Suggested
-import TauCetiRoadmap.ProfiniteCohomology.Suggested
-import TauCetiRoadmap.AlgebraicCurves.Suggested
-import TauCetiRoadmap.DenseGraphLimits.Suggested
-import TauCetiRoadmap.ZigzagPreprojective.Suggested
-import TauCetiRoadmap.ArithmeticDirichletSeries.Suggested
+--
+-- This file deliberately carries no imports, and a roadmap must not add one. `lakefile.toml`
+-- globs every module under `TauCetiRoadmap/`, so `lake build` compiles each roadmap whether or
+-- not it is named here, and catches an orphaned or broken target either way. The list this file
+-- used to carry was appended to, so every concurrent roadmap pull request edited its last line
+-- and conflicted with every other. It had also silently drifted three roadmaps out of date
+-- without the `build` check noticing, which is what showed the list was not load-bearing.

--- a/TauCetiRoadmap/DenseGraphLimits/README.md
+++ b/TauCetiRoadmap/DenseGraphLimits/README.md
@@ -577,8 +577,8 @@ graphon modules consume them:
 
 ## Suggested signatures
 
-The compiled `sorry`-signatures live in [`Suggested.lean`](./Suggested.lean) (imported by the root
-`TauCetiRoadmap.lean`, so CI type-checks them). They pin the types — in particular that the cut
+The compiled `sorry`-signatures live in [`Suggested.lean`](./Suggested.lean) (globbed by
+`lakefile.toml`, so CI type-checks them). They pin the types — in particular that the cut
 norm acts on *kernels* (so `U − W` is well-typed), that `cutDist` is coupling-primary and
 cross-carrier, and that the constant-graphon and sampling targets share the `unitInterval` (`p : I`)
 convention with `SimpleGraph.binomialRandom`. Compiled there: `SymmKernel` / `Graphon`, `cutNorm`


### PR DESCRIPTION
This PR drops the hand-maintained import list from the root `TauCetiRoadmap.lean`, and states in
`CONTRIBUTING.md` that a roadmap pull request touches only its own directory under
`TauCetiRoadmap/`.

Of the 29 open pull requests that currently conflict with `main`, not one conflicts on roadmap
content. They conflict only on the four files that list the roadmaps: `TauCetiRoadmap.lean` (27
of them), the `README.md` list (10), and the two issue-template dropdowns (2). The last three are
already regenerated from the roadmap directories and pushed to `main` by the sync bot after every
merge, and `check_roadmap_areas.py` is not run as a pull-request check, so those hand edits were
never required in the first place. Contributors make them by copying earlier pull requests.

The import list was the dominant cause, and it was carrying no weight. `lakefile.toml` globs
`TauCetiRoadmap.*`, so `lake build` compiles every roadmap whether or not it is named in the root
file. AdicSpaces, EllipticCurves and ModularForms have been absent from the list since 1 and 7
August with the `build` check green throughout, and injecting a deliberate error into an unlisted
module still fails `lake build`. Because the list was appended to rather than sorted, every
concurrent roadmap pull request edited its last line, so each merge re-broke every other branch.

The file itself stays: it is the library root that `lakefile.toml` names, and deleting it fails the
build with `some modules have bad imports or could not be read`. With the list removed, `lake build`
completes the same 8774 jobs as before.

This does not by itself clear the 29 conflicting branches, since each still carries a diff against
the index files. Restoring those four files to the merge base on each branch clears all 29, and
that is being applied separately.

Written with Claude Opus 5, which also ran the build experiments quoted above.

🤖 Prepared with Claude Code