### PR TITLE
fix: point the Lax-Milgram link at the current declaration path

### DIFF
--- a/TauCetiRoadmap/PDE/STATUS.md
+++ b/TauCetiRoadmap/PDE/STATUS.md
@@ -22,7 +22,7 @@ https://github.com/TauCetiProject/TauCetiProgress for what that means.
 
 - [`energyIntegrand`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Analysis/PDE/EnergyForm/Basic.html#TauCeti.PDE.energyIntegrand) bundles the weak-form integrand of `L u = -∂ⱼ(aⁱʲ ∂ᵢu) + bⁱ ∂ᵢu + cu` as a continuous bilinear form on value-gradient jets, coefficients kept as separate, explicit data. Symmetry, linearity in the coefficient triple, the operator-norm bound `Λ + β + γ` and `L²`-integrated forms for constant and variable coefficients are in place.
 - [`planarNewtonianKernel`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Analysis/PDE/FundamentalSolution/Planar.html#TauCeti.planarNewtonianKernel) is the logarithmic kernel on `ℂ`, harmonic off its pole, with its gradient computed and outward flux `-1` through every circle about the pole. That flux is the normalisation a Green's function and a representation formula will consume.
-- [`IsCoercive.solutionOfFunctional`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Analysis/InnerProductSpace/LaxMilgram.html#TauCeti.IsCoercive.solutionOfFunctional) names the Lax-Milgram solution for a continuous linear functional and characterises it by the variational equation, turning Mathlib's equivalence into the existence-and-uniqueness interface Lane D will call.
+- [`IsCoercive.solutionOfFunctional`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Analysis/InnerProductSpace/LaxMilgram.html#IsCoercive.solutionOfFunctional) names the Lax-Milgram solution for a continuous linear functional and characterises it by the variational equation, turning Mathlib's equivalence into the existence-and-uniqueness interface Lane D will call.
 
 ### Roadmap coverage
 


### PR DESCRIPTION
`PDE/STATUS.md:25` links to `…/LaxMilgram.html#TauCeti.IsCoercive.solutionOfFunctional`. That anchor no longer exists: https://github.com/TauCetiProject/TauCeti/pull/3071 moved the Lax-Milgram API out of the enclosing `namespace TauCeti` and into `IsCoercive`, so that `hB.solutionOfFunctional ℓ` elaborates as dot notation on Mathlib's `IsCoercive`. The declaration is now `IsCoercive.solutionOfFunctional`, confirmed against `Analysis/InnerProductSpace/LaxMilgram.lean` on current `main`, where `namespace IsCoercive` opens at the root.

Only the URL fragment changes; the link text already read `IsCoercive.solutionOfFunctional`.

I checked whether the other four namespaces moved in the same series (`YoungDiagram`, `SemistandardYoungTableau`, `AbstractSimplicialComplex`, `PreAbstractSimplicialComplex`) left stale anchors anywhere in this repo. They did not; this is the only one. The many other `#TauCeti.`-prefixed anchors are correct, since those declarations are Tau Ceti's own notions and legitimately live in that namespace.