### PR TITLE
roadmap(UniversalCovers): split recognition of K(G, 1) spaces out of item 13

### DIFF
--- a/TauCetiRoadmap/UniversalCovers/README.md
+++ b/TauCetiRoadmap/UniversalCovers/README.md
@@ -142,7 +142,13 @@ higher-homotopy-group API:
 12. `π₁(S¹) ≅ ℤ`, built from `AddCircle.isCoveringMap_coe` (`ℝ → S¹`) and deck
     transformations. (Mathlib has the covering map but, as far as the pin shows, not the
     `π₁ ≅ ℤ` statement, so this is an application target, not a reconciliation.)
-13. `π_n(Tᵏ)`, `π₁(RPⁿ)`, `K(G, 1)` spaces.
+13. `π_n(Tᵏ)` and `π₁(RPⁿ)`.
+14. **Recognition of `K(G, 1)` spaces.** A path-connected space whose universal cover is
+    weakly contractible is aspherical, and is a `K(G, 1)` for `G ≅ π₁`; asphericity transfers
+    along a covering map to the total space; asphericity and the `K(G, 1)` property are stable
+    under products, indexed products and homeomorphism. Circles and tori are the examples.
+    Constructing a `K(G, 1)` for an arbitrary group is outside this roadmap; it rests on
+    simplicial realization theory.
 
 ## Ordering
 


### PR DESCRIPTION
This PR splits item 13 of Stage 4, which ran `π_n(Tᵏ)`, `π₁(RPⁿ)` and a bare mention of `K(G, 1)` spaces together, into the applications it names.

Recognition of `K(G, 1)` spaces becomes item 14: a path-connected space whose universal cover is weakly contractible is aspherical and is a `K(G, 1)` for its fundamental group; asphericity transfers along a covering map to the total space; and asphericity and the `K(G, 1)` property are stable under products, indexed products and homeomorphism. Circles and tori are the examples. Everything it rests on is already in Stages 2 and 3.

Constructing a `K(G, 1)` for an arbitrary group is stated as outside the roadmap. It rests on the geometric realization of an abstract simplicial complex carrying the weak topology, with maps induced by simplicial maps, restriction to finitely many vertices, and the factorization of a map from a compact space through such a restriction. That is simplicial topology in its own right, and does not belong behind a covering-space roadmap.

🤖 Prepared with Claude Code
