### PR TITLE
ci: re-arm auto-merge after a push

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,7 +15,14 @@ on:
   pull_request_target:
     # `edited` reconsiders a stacked PR when its base is changed to `main`. The job condition below
     # ignores title/body edits. GitHub disables existing auto-merge when a PR's base changes.
-    types: [opened, reopened, ready_for_review, edited]
+    #
+    # `synchronize` re-arms auto-merge after a push. GitHub also drops auto-merge when a pull
+    # request becomes conflicted with `main`, silently and with no event of its own, and resolving
+    # that conflict is a push rather than a reopen. Without this trigger a pull request loses
+    # auto-merge the first time it ever conflicts and never regains it, so the longest-open ones
+    # accumulate approvals and sit unmerged. `gh pr merge --auto` is idempotent, so re-running it
+    # on every push costs nothing.
+    types: [opened, reopened, ready_for_review, edited, synchronize]
     branches: [main]
 
 permissions:


### PR DESCRIPTION
This PR adds `synchronize` to the auto-merge workflow's triggers, so that a push re-arms GitHub-native auto-merge. GitHub drops auto-merge when a pull request becomes conflicted with `main`, silently and with no event of its own, and resolving that conflict is a push rather than a reopen. The workflow listened only for `opened`, `reopened`, `ready_for_review` and base-change edits, so a pull request lost auto-merge the first time it ever conflicted and never regained it.

The cost fell on the oldest contributions, which are the ones most likely to have conflicted. Ten non-draft pull requests are in that state today, all from outside contributors, and an approving review on any of them merges nothing. The job's guards are unchanged: drafts are skipped, the base is re-read and must be `main`, and the step fails closed if the ruleset stops requiring a code-owner review and the `build` check. `gh pr merge --auto` is idempotent, so re-running it on every push costs nothing.

🤖 Prepared with Claude Code
