### PR TITLE
Fix singular-chain example synthesis timeout

### DIFF
--- a/TauCetiRoadmap/AlgebraicTopology/Suggested.lean
+++ b/TauCetiRoadmap/AlgebraicTopology/Suggested.lean
@@ -32,6 +32,7 @@ private abbrev SingularHomology (R : Type u) [CommRing R] (M : ModuleCat.{u} R)
 example {X : TopCat} (A : Set X) : TopPair :=
   TopPair.ofSubset A
 
+set_option synthInstance.maxHeartbeats 40000 in
 /-- Ordinary singular chains remain the absolute chain functor used by the relative theory. -/
 noncomputable example (R : Type*) [CommRing R] :
     ModuleCat R ⥤ TopCat ⥤ ChainComplex (ModuleCat R) ℕ :=


### PR DESCRIPTION
## Change

Raise `synthInstance.maxHeartbeats` from 20,000 to 40,000 for the ordinary singular-chain functor example in `AlgebraicTopology/Suggested.lean`, using a declaration-local `set_option … in`.

At the current main's pins, the example times out synthesizing coproducts for `ModuleCat R`. The extra budget lets the existing term elaborate. No signature, proof term, docstring, dependency pin, or file-wide option changes.

## Validation

- The full patched file passes `lake env lean`, with the existing roadmap `sorry` warnings. Checked from a warm worktree whose `lean-toolchain` and `lake-manifest.json` are byte-identical to this branch's.
- `git diff --check` passes; one line added to one file.
- The same timeout is visible in [CI run 34623058256](https://github.com/TauCetiProject/TauCetiRoadmap/actions/runs/34623058256/job/103341436047). This PR is independent of #66; it contains no regularity-roadmap changes.

Full-project CI will run on this PR; the local check above is file-level only.

the most recent revision prepared by Codex with Astra xhigh and with advice from Astra Pro.
