### PR TITLE
fix: pin universes in algebraic topology singular-chain example

### DIFF
--- a/TauCetiRoadmap/AlgebraicTopology/Suggested.lean
+++ b/TauCetiRoadmap/AlgebraicTopology/Suggested.lean
@@ -33,9 +33,9 @@ example {X : TopCat} (A : Set X) : TopPair :=
   TopPair.ofSubset A
 
 /-- Ordinary singular chains remain the absolute chain functor used by the relative theory. -/
-noncomputable example (R : Type*) [CommRing R] :
-    ModuleCat R ⥤ TopCat ⥤ ChainComplex (ModuleCat R) ℕ :=
-  AlgebraicTopology.singularChainComplexFunctor (ModuleCat R)
+noncomputable example (R : Type u) [CommRing R] :
+    ModuleCat.{u} R ⥤ TopCat.{u} ⥤ ChainComplex (ModuleCat.{u} R) ℕ :=
+  AlgebraicTopology.singularChainComplexFunctor (ModuleCat.{u} R)
 
 /-- Cellular chains are built from Mathlib's actual cells, not from a record of cell counts. -/
 example {X : Type*} [TopologicalSpace X] (C : Set X) [CWComplex C] (n : ℕ) : Type _ :=


### PR DESCRIPTION
Replace the temporary declaration-local 40,000-heartbeat workaround merged in #374 with explicit universe annotations for the ordinary singular-chain example from #283.

Pin the coefficient ring, `ModuleCat`, and `TopCat` to the existing universe `u`, matching the `SingularChains` and `SingularHomology` helpers immediately above the example. Remove `set_option synthInstance.maxHeartbeats 40000 in`, so the example elaborates with the default 20,000 budget. The diff against current `main` changes three example lines and removes that one option; the roadmap content and named interfaces are unchanged.

Reported in [the comment on #283](https://github.com/TauCetiProject/TauCetiRoadmap/pull/283#issuecomment-5637935858), and also [on Zulip](https://leanprover.zulipchat.com/#narrow/channel/610393-Tau-Ceti/topic/Getting.20started.3A.20roadmaps/near/623612595). The GitHub report includes this universe-pinning fix.

Validation after incorporating main at `1ebd499a89df1f3634d3b7d93dc30e93bb8c7468`, using Lean `v4.34.0-rc2`, the committed manifest, and the existing Mathlib cache:

- `lake env lean TauCetiRoadmap/AlgebraicTopology/Suggested.lean`: passed at the default budget with the same 47 existing warnings.
- `lake build TauCetiRoadmap/AlgebraicTopology/Suggested.lean`: passed.
- `git diff --check`: passed; no heartbeat override remains in the file.
- The resulting source tree is identical to the earlier #376 head `611b0e09`, whose [full GitHub build passed](https://github.com/TauCetiProject/TauCetiRoadmap/actions/runs/34673796444). The new commit incorporates #374 in its history and explicitly removes the workaround from the PR diff. A fresh PR build will validate this updated head.
- Earlier local full-project validation was incomplete; the fresh checks above are file/module-level.

AI assistance: prepared with Codex (GPT-6).