### PR TITLE
progress: ReductiveGroups report for 2026-09-12

### DIFF
--- a/TauCetiRoadmap/ReductiveGroups/PROGRESS.md
+++ b/TauCetiRoadmap/ReductiveGroups/PROGRESS.md
@@ -250,3 +250,48 @@ and its effect on the long and short simple root subgroups (TauCeti#5920); `B₂
 the matching endomorphism on the torus only. The special orthogonal groups lag: the
 standard comodule is faithful and simple in dimension at least three away from characteristic two,
 but reductivity is proved only in ranks zero and one.
+
+<!--tauceti-progress:v1 {"from_sha":"e7f4d8372f5a7ad39a75e61b43864f16d1bb57a0","prs":[5382,6045,6048,6070,6104,6112,6119,6132,6134,6136,6141,6150,6157,6160,6169,6186,6187,6192,6204,6225,6227,6283,6307,6317,6337,6341,6356,6364,6375,6385,6408,6420,6424,6443],"roadmap":"ReductiveGroups","to_sha":"890ee2c15e6cc392ab851708562a109a4b010a89"}-->
+## ReductiveGroups: 2026-09-09 to 2026-09-12 (`e7f4d83` to `890ee2c`)
+
+Every standard special orthogonal group is now
+[reductive](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.html#TauCeti.SpecialOrthogonal.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra)
+over every field of characteristic different from two, in every dimension, completing the classical
+families. Two halves meet. In dimension at least three, reductivity
+[reduces to geometric connectedness](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.html#TauCeti.SpecialOrthogonal.reductiveCommHopfAlgProperty_iff_geometricallyConnected_of_three_le),
+smoothness and triviality of the geometric unipotent radical being automatic (TauCeti#6119); and
+`SOₙ` is
+[geometrically connected](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Connected.html#TauCeti.SpecialOrthogonal.geometricallyConnectedCommHopfAlgProperty_coordinateHopfAlgebra)
+in every dimension, by Cartan-Dieudonné, that
+[products of two reflections generate it](https://taucetiproject.github.io/TauCeti/docs/TauCeti/LinearAlgebra/QuadraticForm/CartanDieudonne/SpecialOrthogonal.html#TauCeti.QuadraticMap.closure_reflection_mul_eq_specialOrthogonalGroup),
+together with a
+[one-parameter family over the Laurent polynomials](https://taucetiproject.github.io/TauCeti/docs/TauCeti/LinearAlgebra/Matrix/SpecialOrthogonalGroup/Reflection.html#TauCeti.exists_laurentPath_reflectionMatrix_mul)
+joining each such product to the identity (TauCeti#6186). Dimension two went separately: `SO₂` is a
+[rank-one torus](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Torus.html#TauCeti.SpecialOrthogonal.torusCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra_two),
+split as soon as the base has a square root of `-1`.
+
+The symplectic diagonal torus became a
+[maximal torus over every field](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.html#TauCeti.Symplectic.isMaximalTorus_diagonalTorusDefiningIdeal),
+built as a closed subgroup scheme with split-torus quotient, then
+[descended from an algebraic closure](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Torus/Maximal.html#TauCeti.HopfIdeal.isMaximalTorus_of_baseChange).
+The unipotent radical gained recognition criteria rather than a new construction: it is
+[trivial for a reductive group](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Reductive/Basic.html#TauCeti.reductiveCommHopfAlgProperty.unipotentRadicalDefiningIdeal_eq_augmentation),
+triviality descends along field extensions, and a connected normal smooth unipotent kernel of a
+quotient onto a reductive group
+[is the radical](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Unipotent/Radical/Reductive/Quotient.html#TauCeti.FiniteTypeCommHopfAlgCat.unipotentRadicalDefiningIdeal_eq_kernelHopfIdeal_of_reductive).
+Two inputs to root data also landed: the
+[character lattice of a smooth geometrically connected group is torsion free](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/CharacterLattice/Torsion.html#TauCeti.CommHopfAlgCat.isMulTorsionFree_geometricCharacterGroup_of_smooth),
+and the Galois invariants of a split group algebra
+[carry a Hopf algebra structure](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/GroupAlgebra/Galois/Hopf.html#TauCeti.GaloisDescent.groupAlgebraInvariantsHopfAlgebra)
+whose scalar extension recovers the split one, the first step towards non-split tori.
+
+In the Chevalley lane the pinned Geck carrier acquired
+[Weyl representatives](https://taucetiproject.github.io/TauCeti/docs/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Weyl.html#TauCeti.DynkinType.geckSimpleWeylPoint)
+`xᵢ(1) x₋ᵢ(-1) xᵢ(1)`, which normalize the weight torus and
+[act on it by the reflection word they spell](https://taucetiproject.github.io/TauCeti/docs/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/Weyl.html#TauCeti.DynkinType.geckWeylWordPoint_conj_geckWeightTorusPoints);
+the graph automorphism and the
+[twisted Frobenius](https://taucetiproject.github.io/TauCeti/docs/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/TwistedFrobenius.html#TauCeti.DynkinType.geckTwistedFrobenius_geckRootSubgroupMatrix)
+renumber root subgroups by the diagram symmetry and raise the parameter to its `p ^ k`-th power. The
+[Frobenius-fixed points of the type-B spin carrier](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Lie/Orthogonal/TypeB/SpinCarrier/FixedPoints.html#TauCeti.TypeBSpinCarrier.pointsMulEquivFixedSubgroupFrobenius)
+are its points over the fixed subring, and finite. No uniform construction from a root datum, and no
+isomorphism theorem for pinned groups.

--- a/TauCetiRoadmap/ReductiveGroups/STATUS.md
+++ b/TauCetiRoadmap/ReductiveGroups/STATUS.md
@@ -1,17 +1,17 @@
-<!--tauceti-status:v1 {"roadmap":"ReductiveGroups","to_sha":"e7f4d8372f5a7ad39a75e61b43864f16d1bb57a0","ts":"2026-09-09T14:34:24+10:00"}-->
+<!--tauceti-status:v1 {"roadmap":"ReductiveGroups","to_sha":"890ee2c15e6cc392ab851708562a109a4b010a89","ts":"2026-09-12T19:06:17Z"}-->
 # Status: ReductiveGroups
 
-This file documents the status of the ReductiveGroups roadmap up until `e7f4d83` (2026-09-09T14:34:24+10:00). There may have been subsequent updates.
+This file documents the status of the ReductiveGroups roadmap up until `890ee2c` (2026-09-12T19:06:17Z). There may have been subsequent updates.
 
 It is generated, and its prose is not security-validated; see
 https://github.com/TauCetiProject/TauCetiProgress for what that means.
 
 ## Where this roadmap stands
 
-**At a glance.** Layers 0-4 are done, and Layer 7 has just acquired its first general theorems:
-maximal tori and Borel subgroups exist. What is missing there is uniqueness, since no conjugacy
-statement is available, and with it the root datum of a general reductive group. Layer 8, the
-classification, has not begun.
+**At a glance.** Layers 0-2 and 4 are done, and the four classical families are now all known to be
+reductive. Layer 7 has existence of maximal tori and Borel subgroups but no conjugacy, which keeps
+the root datum of a general reductive group out of reach; Layer 8 has not begun, and Layer 9 has
+carriers type by type rather than one construction.
 
 ### Named results
 
@@ -22,16 +22,16 @@ classification, has not begun.
   subgroup of some general linear group ([`exists_isClosedImmersion_generalLinear`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Embedding.html#TauCeti.AffineGroupSchemeCat.exists_isClosedImmersion_generalLinear)).
 - **Tannakian reconstruction** — a commutative Hopf algebra's points are exactly the tensor
   automorphisms of scalar extension on its finite-dimensional comodules ([`fgPointTensorIsoEquiv`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Representation/Tannaka/Equivalence.html#TauCeti.Tannaka.fgPointTensorIsoEquiv)).
+- **Reductivity of the classical groups** — `GLₙ`, `SLₙ` and `Sp₂ₘ` are reductive over every field,
+  and [`SOₙ` in every dimension](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/SpecialOrthogonal/Reductive.html#TauCeti.SpecialOrthogonal.reductiveCommHopfAlgProperty_finiteTypeCoordinateHopfAlgebra)
+  over every field of characteristic different from two. The orthogonal case runs through
+  Cartan-Dieudonné and a Laurent-polynomial path to the identity; characteristic two is excluded.
 - **Existence of maximal tori and Borel subgroups** — every finite-type affine group over a field
   contains a maximal torus ([`exists_isMaximalTorus`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Torus/Existence.html#TauCeti.HopfIdeal.exists_isMaximalTorus)),
-  its geometric fibre contains a Borel subgroup ([`exists_geometricBorel`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Borel/Existence.html#TauCeti.HopfIdeal.exists_geometricBorel)),
-  and over an algebraically closed field every torus lies inside a Borel. The solvable radical is
-  contained in every Borel, and a normal Borel is exactly the solvable radical.
-- **Lie-Kolchin** — if the derived subgroup of a reduced finite-type affine group over an
-  algebraically closed field is geometrically unipotent, every finite-dimensional representation
-  is upper triangular in a suitable basis, with characters on the diagonal ([`exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_derived`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Solvable/LieKolchin.html#TauCeti.Comodule.exists_basis_coefficientMatrix_isUpperTriangular_of_geometricallyUnipotent_derived)).
-  The hypothesis is unipotence of the derived subgroup, not connectedness and solvability, and
-  nothing yet links the two.
+  its geometric fibre contains a Borel ([`exists_geometricBorel`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Borel/Existence.html#TauCeti.HopfIdeal.exists_geometricBorel)),
+  and the solvable radical is contained in every Borel. The diagonal tori of `GLₙ` and
+  [`Sp₂ₘ`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Symplectic/DiagonalTorus/Maximal.html#TauCeti.Symplectic.isMaximalTorus_diagonalTorusDefiningIdeal)
+  are maximal over every field. Nothing says two maximal tori, or two Borels, are conjugate.
 
 ### Notable definitions and infrastructure
 
@@ -41,44 +41,44 @@ classification, has not begun.
   coordinate ring.
 - **The Borel predicate.** [`IsBorel`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/Borel/Basic.html#TauCeti.HopfIdeal.IsBorel)
   is stated on Hopf ideals over an arbitrary field by base change to an algebraic closure, so
-  concrete groups can be tested against it: the upper-triangular subgroups of `GL₂` and `SL₂` are
-  Borel over every field.
-- **Group-like weight spaces of comodules.** [`weightSpace`](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/Coalgebra/Comodule/Weight/Space.html#GroupLike.weightSpace)
-  presents a weight space as the joint eigenspace of the coaction components, with independence and
-  finiteness on Noetherian comodules: the machine underneath the triangularization results.
+  concrete groups can be tested against it.
+- **The pinned Geck carrier as a group functor.** Its points are now
+  [functorial in the value ring](https://taucetiproject.github.io/TauCeti/docs/TauCeti/LinearAlgebra/RootSystem/SimplyConnectedRootDatum/GeckLattice/PointsFunctor.html#TauCeti.DynkinType.geckPointsMap)
+  and carry Weyl representatives, a graph automorphism and a twisted Frobenius, what the finite
+  groups of Lie type are to be built from.
 
 ### Roadmap coverage
 
-Layers 0-2 and 4 are done. Layer 3 has Hopf ideals, kernels, identity components and fppf
-quotients, with a representability result only for the component quotient. Layer 5 has Lie-Kolchin as
-above, geometric unipotence, and a criterion making the unipotent radical trivial given a faithful
-completely reducible representation, but not the general construction-and-maximality theorem.
-Layer 6 has the radicals, the reduced centre, central isogenies, simply connected semisimple groups
-as a property, and reductivity for `GLₙ`, `SLₙ`, `Sp₂ₘ` and direct products; the special orthogonal
-groups are reductive only in ranks zero and one, and the characteristic-zero equivalence with linear
-reductivity and simply connected covers are open. Layer 7 has existence of maximal tori and Borels,
-dynamic parabolics, and root data only for `GLₙ`; conjugacy, the Weyl group of a general pair, and
-Bruhat decomposition beyond `GL₂` and `SL₂` are absent. Layer 8 is untouched. Layer 9 has explicit
-integral carriers for several types with root subgroups, weight tori, Weyl representatives and
-Frobenius endomorphisms whose fixed points are the points over the fixed subring, and the
-exceptional isogeny of `Sp₄` in characteristic two, but no uniform pinned Chevalley-Demazure
-construction and no isomorphism theorem.
+Layers 0-2 and 4 are complete. Layer 3 has Hopf ideals, kernels, identity components and fppf
+quotients, representable only for the component quotient. Layer 5 has geometric unipotence,
+Lie-Kolchin under a hypothesis on the derived subgroup rather than solvability, and recognition
+criteria identifying a given connected normal smooth unipotent kernel as the unipotent radical, but
+not a general maximality theorem. Layer 6 has the radicals, the centre with base-change and
+finiteness criteria, central isogenies, simple connectivity as a property, and the classical groups
+above; the characteristic-zero equivalence with linear reductivity and simply connected covers are
+open. Layer 7 has existence as above, dynamic parabolics and Levis, with the `GLₙ` weight Levis shown
+smooth, geometrically connected and of
+[trivial unipotent radical](https://taucetiproject.github.io/TauCeti/docs/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Weight/Levi/UnipotentRadical.html#TauCeti.GeneralLinear.unipotentRadicalDefiningIdeal_weightLeviFiniteTypeCoordinateHopfAlgebra),
+and root data only for `GLₙ`. Layer 8 is untouched. Layer 9 has integral carriers for several types
+with root subgroups, weight tori, Weyl representatives, Frobenius and twisted-Frobenius
+endomorphisms whose fixed points are the points over the fixed subring, G₂ short-pair commutator
+relations, and the exceptional isogeny of `Sp₄` in characteristic two, but no uniform construction
+and no isomorphism theorem.
 
 ## The frontier
 
 - **Conjugacy of Borel subgroups and maximal tori.** Existence is settled; nothing yet says any two
-  are conjugate over an algebraically closed field. This is the immediate blocker for defining the
-  root datum of a group rather than of `GLₙ`.
-- **The unipotent radical.** The general construction of the maximal connected normal smooth
-  unipotent closed subgroup, with its maximality, is still missing; what exists are
-  characterizations and computations in examples.
+  are conjugate over an algebraically closed field. This is the immediate blocker for the root datum
+  of a group rather than of `GLₙ`.
 - **Root data and Weyl groups of a general reductive group.** Extracting roots from a maximal torus
-  and identifying the normalizer quotient as a Weyl group needs conjugacy first, then the split case
-  before any Galois or relative theory.
-- **Reductivity of the special orthogonal groups.** The standard comodule is faithful, and simple
-  in dimension at least three away from characteristic two, which is the input; the conclusion is
-  proved only for `SO₀` and `SO₁`.
-- **A uniform pinned Chevalley-Demazure construction.** The carriers exist type by type, with
-  root-subgroup and torus data and, for `B₂`, `F₄` and `G₂`, a special isogeny only at torus level.
-  A single construction from a root datum, and the isomorphism theorem for pinned groups, remain to
-  be built.
+  and identifying the normalizer quotient as a Weyl group needs conjugacy first. Torsion-freeness of
+  the character lattice is an input, not the theorem.
+- **The unipotent radical.** What exists are computations in examples and criteria recognising a
+  candidate kernel as the radical; the general maximality statement for the maximal connected normal
+  smooth unipotent closed subgroup is still missing.
+- **Non-split tori and forms.** Galois descent now produces a Hopf algebra from the invariants of a
+  split group algebra, and recovers the split one after scalar extension. The absolute root datum
+  with its Galois action, and relative root systems, have not been attempted.
+- **A uniform pinned Chevalley-Demazure construction.** Carriers exist type by type with root
+  subgroups and torus data, and `B₂`, `F₄` and `G₂` have a special isogeny only at torus level. A
+  single construction from a root datum, and the isomorphism theorem for pinned groups, remain.


### PR DESCRIPTION
<!--tauceti-progress-pr:v1 {"from_sha":"e7f4d8372f5a7ad39a75e61b43864f16d1bb57a0","prs":[5382,6045,6048,6070,6104,6112,6119,6132,6134,6136,6141,6150,6157,6160,6169,6186,6187,6192,6204,6225,6227,6283,6307,6317,6337,6341,6356,6364,6375,6385,6408,6420,6424,6443],"roadmap":"ReductiveGroups","to_sha":"890ee2c15e6cc392ab851708562a109a4b010a89","version":"880e8b9737973bfbd8f1f214f4ac2ded67f5b856"}-->
This PR records progress on the ReductiveGroups roadmap for the window `e7f4d83..890ee2c` of TauCeti `main`, covering 34 merged pull requests.

`STATUS.md` is rewritten as a snapshot at `890ee2c`; `PROGRESS.md` gains one appended section for the window. Both files are machine-owned and their prose is not security-validated.

Pull requests in the window: #5382, #6045, #6048, #6070, #6104, #6112, #6119, #6132, #6134, #6136, #6141, #6150, #6157, #6160, #6169, #6186, #6187, #6192, #6204, #6225, #6227, #6283, #6307, #6317, #6337, #6341, #6356, #6364, #6375, #6385, #6408, #6420, #6424, #6443

Generated by [TauCetiProgress](https://github.com/TauCetiProject/TauCetiProgress) at `880e8b9737973bfbd8f1f214f4ac2ded67f5b856`.

🤖 Prepared with Claude Code
